### PR TITLE
Centralize lobby member and owner checks behind LobbyAccessPolicy

### DIFF
--- a/backend/lined/src/main/java/io/backend/lined/event/service/EventServiceImpl.java
+++ b/backend/lined/src/main/java/io/backend/lined/event/service/EventServiceImpl.java
@@ -10,6 +10,7 @@ import io.backend.lined.event.domain.EventEntity;
 import io.backend.lined.event.domain.EventRepository;
 import io.backend.lined.lobby.domain.LobbyEntity;
 import io.backend.lined.lobby.domain.LobbyRepository;
+import io.backend.lined.lobby.service.LobbyAccessPolicy;
 import io.backend.lined.user.domain.UserEntity;
 import io.backend.lined.user.domain.UserRepository;
 import jakarta.transaction.Transactional;
@@ -29,12 +30,13 @@ public class EventServiceImpl implements EventService {
   private final LobbyRepository lobbyRepo;
   private final UserRepository userRepo;
   private final EventMapper mapper;
+  private final LobbyAccessPolicy accessPolicy;
 
   @Override
   public EventDto create(EventCreateDto dto, Long currentUserId) {
     var owner = mustUser(currentUserId);
     var lobby = mustLobby(dto.lobbyId());
-    ensureMember(lobby, currentUserId);
+    accessPolicy.ensureMember(lobby, currentUserId);
 
     if (!dto.startAt().isBefore(dto.endAt())) {
       throw new IllegalArgumentException("startAt must be before endAt");
@@ -56,7 +58,7 @@ public class EventServiceImpl implements EventService {
   @Override
   public EventDto update(Long id, EventUpdateDto dto, Long currentUserId) {
     var e = mustEvent(id);
-    ensureMember(e.getLobby(), currentUserId);
+    accessPolicy.ensureMember(e.getLobby(), currentUserId);
 
     if (dto.title() != null && !dto.title().isBlank()) {
       e.setTitle(dto.title());
@@ -84,7 +86,7 @@ public class EventServiceImpl implements EventService {
   @Override
   public void delete(Long id, Long currentUserId) {
     var e = mustEvent(id);
-    ensureMember(e.getLobby(), currentUserId);
+    accessPolicy.ensureMember(e.getLobby(), currentUserId);
     repo.delete(e);
   }
 
@@ -92,7 +94,7 @@ public class EventServiceImpl implements EventService {
   public List<EventDto> list(Long lobbyId, OffsetDateTime from, OffsetDateTime to,
                              Long currentUserId) {
     var lobby = mustLobby(lobbyId);
-    ensureMember(lobby, currentUserId);
+    accessPolicy.ensureMember(lobby, currentUserId);
 
     if (from == null || to == null || !from.isBefore(to)) {
       throw new IllegalArgumentException("Invalid time window: from < to is required");
@@ -106,7 +108,7 @@ public class EventServiceImpl implements EventService {
                                               OffsetDateTime start, OffsetDateTime end,
                                               Long requesterId) {
     var lobby = mustLobby(lobbyId);
-    ensureMember(lobby, requesterId);
+    accessPolicy.ensureMember(lobby, requesterId);
     if (!start.isBefore(end)) {
       throw new IllegalArgumentException("start must be before end");
     }
@@ -157,11 +159,4 @@ public class EventServiceImpl implements EventService {
         .orElseThrow(() -> new NoSuchElementException("Event %d not found".formatted(id)));
   }
 
-  private void ensureMember(LobbyEntity lobby, Long userId) {
-    var isOwner = lobby.getOwner().getId().equals(userId);
-    var isMember = lobby.getMembers().stream().anyMatch(u -> u.getId().equals(userId));
-    if (!isOwner && !isMember) {
-      throw new SecurityException("User is not a member of the lobby");
-    }
-  }
 }

--- a/backend/lined/src/main/java/io/backend/lined/lobby/service/LobbyAccessPolicy.java
+++ b/backend/lined/src/main/java/io/backend/lined/lobby/service/LobbyAccessPolicy.java
@@ -1,0 +1,38 @@
+package io.backend.lined.lobby.service;
+
+import io.backend.lined.lobby.domain.LobbyEntity;
+import java.util.Objects;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LobbyAccessPolicy {
+
+  /**
+   * Throws if the user is neither the lobby owner nor a member.
+   * Callers must ensure {@code lobby.getOwner()} and {@code lobby.getMembers()}
+   * are initialized (i.e. called within an active transaction).
+   */
+  public void ensureMember(LobbyEntity lobby, Long userId) {
+    Objects.requireNonNull(userId, "userId must not be null");
+    if (lobby.getOwner().getId().equals(userId)) {
+      return;
+    }
+    boolean isMember = lobby.getMembers().stream()
+        .anyMatch(u -> u.getId().equals(userId));
+    if (!isMember) {
+      throw new SecurityException("User is not a member of the lobby");
+    }
+  }
+
+  /**
+   * Throws if the user is not the lobby owner.
+   * Callers must ensure {@code lobby.getOwner()} is initialized.
+   */
+  public void ensureOwner(LobbyEntity lobby, Long requesterId) {
+    Objects.requireNonNull(requesterId, "requesterId must not be null");
+    if (!lobby.getOwner().getId().equals(requesterId)) {
+      throw new SecurityException("Only lobby owner can perform this action");
+    }
+  }
+
+}

--- a/backend/lined/src/main/java/io/backend/lined/lobby/service/LobbyServiceImpl.java
+++ b/backend/lined/src/main/java/io/backend/lined/lobby/service/LobbyServiceImpl.java
@@ -21,6 +21,7 @@ public class LobbyServiceImpl implements LobbyService {
   private final LobbyRepository lobbyRepo;
   private final UserRepository userRepo;
   private final LobbyMapper mapper;
+  private final LobbyAccessPolicy accessPolicy;
 
   @Override
   public LobbyDto create(LobbyCreateDto dto, Long ownerId) {
@@ -55,7 +56,7 @@ public class LobbyServiceImpl implements LobbyService {
   public LobbyDto addMember(Long lobbyId, Long userIdToAdd, Long requesterId) {
     var lobby = mustLobby(lobbyId);
 
-    ensureOwner(lobby, requesterId);
+    accessPolicy.ensureOwner(lobby, requesterId);
 
     var user = userRepo.findById(userIdToAdd)
         .orElseThrow(() -> new NoSuchElementException("User %d not found".formatted(userIdToAdd)));
@@ -68,7 +69,7 @@ public class LobbyServiceImpl implements LobbyService {
   public LobbyDto removeMember(Long lobbyId, Long userIdToRemove, Long requesterId) {
     var lobby = mustLobby(lobbyId);
 
-    ensureOwner(lobby, requesterId);
+    accessPolicy.ensureOwner(lobby, requesterId);
 
     if (lobby.getOwner().getId().equals(userIdToRemove)) {
       throw new IllegalArgumentException("Owner cannot be removed from lobby");
@@ -81,14 +82,8 @@ public class LobbyServiceImpl implements LobbyService {
   @Override
   public void delete(Long lobbyId, Long requesterId) {
     var lobby = mustLobby(lobbyId);
-    ensureOwner(lobby, requesterId);
+    accessPolicy.ensureOwner(lobby, requesterId);
     lobbyRepo.delete(lobby);
-  }
-
-  private void ensureOwner(LobbyEntity lobby, Long requesterId) {
-    if (!lobby.getOwner().getId().equals(requesterId)) {
-      throw new SecurityException("Only lobby owner can perform this action");
-    }
   }
 
   private LobbyEntity mustLobby(Long id) {

--- a/backend/lined/src/main/java/io/backend/lined/task/service/TaskServiceImpl.java
+++ b/backend/lined/src/main/java/io/backend/lined/task/service/TaskServiceImpl.java
@@ -3,6 +3,7 @@ package io.backend.lined.task.service;
 import io.backend.lined.common.EntityFinder;
 import io.backend.lined.lobby.domain.LobbyEntity;
 import io.backend.lined.lobby.domain.LobbyRepository;
+import io.backend.lined.lobby.service.LobbyAccessPolicy;
 import io.backend.lined.task.api.TaskCreateDto;
 import io.backend.lined.task.api.TaskDto;
 import io.backend.lined.task.api.TaskMapper;
@@ -28,6 +29,7 @@ public class TaskServiceImpl implements TaskService {
   private final LobbyRepository lobbyRepo;
   private final UserRepository userRepo;
   private final TaskMapper mapper;
+  private final LobbyAccessPolicy accessPolicy;
 
   @Override
   public TaskDto create(TaskCreateDto dto, Long currentUserId) {
@@ -49,7 +51,7 @@ public class TaskServiceImpl implements TaskService {
   @Override
   public TaskDto update(Long id, TaskUpdateDto dto, Long currentUserId) {
     var task = mustTask(id);
-    ensureMember(task.getLobby(), currentUserId);
+    accessPolicy.ensureMember(task.getLobby(), currentUserId);
 
     if (dto.title() != null && !dto.title().isBlank()) {
       task.setTitle(dto.title());
@@ -70,7 +72,7 @@ public class TaskServiceImpl implements TaskService {
   @Override
   public void delete(Long id, Long currentUserId) {
     var task = mustTask(id);
-    ensureMember(task.getLobby(), currentUserId);
+    accessPolicy.ensureMember(task.getLobby(), currentUserId);
     repo.delete(task);
   }
 
@@ -108,11 +110,4 @@ public class TaskServiceImpl implements TaskService {
         () -> new NoSuchElementException("Task %d not found".formatted(id)));
   }
 
-  private void ensureMember(LobbyEntity lobby, Long userId) {
-    var isOwner = lobby.getOwner().getId().equals(userId);
-    var isMember = lobby.getMembers().stream().anyMatch(u -> u.getId().equals(userId));
-    if (!isOwner && !isMember) {
-      throw new SecurityException("User is not a member of the lobby");
-    }
-  }
 }

--- a/backend/lined/src/main/java/io/backend/lined/task/service/TaskServiceImpl.java
+++ b/backend/lined/src/main/java/io/backend/lined/task/service/TaskServiceImpl.java
@@ -35,6 +35,7 @@ public class TaskServiceImpl implements TaskService {
   public TaskDto create(TaskCreateDto dto, Long currentUserId) {
     var creator = mustUser(currentUserId);
     var lobby = mustLobby(dto.lobbyId());
+    accessPolicy.ensureMember(lobby, currentUserId);
 
     var entity = TaskEntity.builder()
         .title(dto.title())

--- a/backend/lined/src/test/java/io/backend/lined/event/service/EventServiceImplConflictTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/event/service/EventServiceImplConflictTest.java
@@ -17,6 +17,7 @@ import io.backend.lined.event.domain.EventRepository;
 import io.backend.lined.lobby.domain.LobbyEntity;
 import io.backend.lined.lobby.domain.LobbyRepository;
 import io.backend.lined.lobby.domain.LobbyTypes;
+import io.backend.lined.lobby.service.LobbyAccessPolicy;
 import io.backend.lined.user.domain.UserEntity;
 import io.backend.lined.user.domain.UserRepository;
 import java.time.OffsetDateTime;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,6 +48,9 @@ class EventServiceImplConflictTest {
 
   @Mock
   private EventMapper mapper;
+
+  @Spy
+  private LobbyAccessPolicy accessPolicy;
 
   @InjectMocks
   private EventServiceImpl eventService;

--- a/backend/lined/src/test/java/io/backend/lined/event/service/EventServiceImplTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/event/service/EventServiceImplTest.java
@@ -16,6 +16,7 @@ import io.backend.lined.event.domain.EventRepository;
 import io.backend.lined.lobby.domain.LobbyEntity;
 import io.backend.lined.lobby.domain.LobbyRepository;
 import io.backend.lined.lobby.domain.LobbyTypes;
+import io.backend.lined.lobby.service.LobbyAccessPolicy;
 import io.backend.lined.user.domain.UserEntity;
 import io.backend.lined.user.domain.UserRepository;
 import java.time.OffsetDateTime;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,6 +44,8 @@ class EventServiceImplTest {
   private UserRepository userRepo;
   @Mock
   private EventMapper mapper;
+  @Spy
+  private LobbyAccessPolicy accessPolicy;
 
   @InjectMocks
   private EventServiceImpl eventService;

--- a/backend/lined/src/test/java/io/backend/lined/lobby/service/LobbyAccessPolicyTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/lobby/service/LobbyAccessPolicyTest.java
@@ -1,0 +1,85 @@
+package io.backend.lined.lobby.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.backend.lined.lobby.domain.LobbyEntity;
+import io.backend.lined.lobby.domain.LobbyTypes;
+import io.backend.lined.user.domain.UserEntity;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LobbyAccessPolicyTest {
+
+  private LobbyAccessPolicy policy;
+  private UserEntity owner;
+  private UserEntity member;
+  private LobbyEntity lobby;
+
+  @BeforeEach
+  void setUp() {
+    policy = new LobbyAccessPolicy();
+
+    owner = new UserEntity();
+    owner.setId(1L);
+
+    member = new UserEntity();
+    member.setId(2L);
+
+    lobby = LobbyEntity.builder()
+        .id(101L)
+        .name("Test Lobby")
+        .lobbyType(LobbyTypes.FAMILY)
+        .owner(owner)
+        .members(new HashSet<>(Set.of(owner, member)))
+        .build();
+  }
+
+  @Test
+  void ensureMember_doesNotThrow_whenUserIsOwner() {
+    assertThatCode(() -> policy.ensureMember(lobby, 1L))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void ensureMember_doesNotThrow_whenUserIsMember() {
+    assertThatCode(() -> policy.ensureMember(lobby, 2L))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void ensureMember_doesNotThrow_whenUserIsOwnerNotInMembersSet() {
+    var ownerOnly = LobbyEntity.builder()
+        .id(102L)
+        .name("Owner Only Lobby")
+        .lobbyType(LobbyTypes.COUPLE)
+        .owner(owner)
+        .members(new HashSet<>(Set.of(member)))
+        .build();
+    assertThatCode(() -> policy.ensureMember(ownerOnly, 1L))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void ensureMember_throwsSecurity_whenUserIsOutsider() {
+    assertThatThrownBy(() -> policy.ensureMember(lobby, 99L))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("not a member");
+  }
+
+  @Test
+  void ensureOwner_doesNotThrow_whenUserIsOwner() {
+    assertThatCode(() -> policy.ensureOwner(lobby, 1L))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void ensureOwner_throwsSecurity_whenUserIsNotOwner() {
+    assertThatThrownBy(() -> policy.ensureOwner(lobby, 2L))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("owner");
+  }
+
+}

--- a/backend/lined/src/test/java/io/backend/lined/lobby/service/LobbyServiceImplTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/lobby/service/LobbyServiceImplTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,6 +37,8 @@ class LobbyServiceImplTest {
   private UserRepository userRepo;
   @Mock
   private LobbyMapper mapper;
+  @Spy
+  private LobbyAccessPolicy accessPolicy;
 
   @InjectMocks
   private LobbyServiceImpl lobbyService;

--- a/backend/lined/src/test/java/io/backend/lined/task/service/TaskServiceImplTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/task/service/TaskServiceImplTest.java
@@ -126,6 +126,20 @@ class TaskServiceImplTest {
     verify(repo, never()).save(any());
   }
 
+  @Test
+  void create_throwsSecurity_whenUserIsNotLobbyMember() {
+    TaskCreateDto dto = new TaskCreateDto("Buy groceries", 101L, null, null);
+
+    when(userRepo.findById(99L)).thenReturn(Optional.of(new UserEntity()));
+    when(lobbyRepo.findById(101L)).thenReturn(Optional.of(lobby));
+
+    assertThatThrownBy(() -> taskService.create(dto, 99L))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("not a member");
+
+    verify(repo, never()).save(any());
+  }
+
   /* =======================
      UPDATE
   ======================= */

--- a/backend/lined/src/test/java/io/backend/lined/task/service/TaskServiceImplTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/task/service/TaskServiceImplTest.java
@@ -1,0 +1,244 @@
+package io.backend.lined.task.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.backend.lined.lobby.domain.LobbyEntity;
+import io.backend.lined.lobby.domain.LobbyRepository;
+import io.backend.lined.lobby.domain.LobbyTypes;
+import io.backend.lined.lobby.service.LobbyAccessPolicy;
+import io.backend.lined.task.api.TaskCreateDto;
+import io.backend.lined.task.api.TaskDto;
+import io.backend.lined.task.api.TaskMapper;
+import io.backend.lined.task.api.TaskUpdateDto;
+import io.backend.lined.task.domain.TaskEntity;
+import io.backend.lined.task.domain.TaskRepository;
+import io.backend.lined.task.domain.TaskStatus;
+import io.backend.lined.user.domain.UserEntity;
+import io.backend.lined.user.domain.UserRepository;
+import java.util.HashSet;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TaskServiceImplTest {
+
+  @Mock
+  private TaskRepository repo;
+  @Mock
+  private LobbyRepository lobbyRepo;
+  @Mock
+  private UserRepository userRepo;
+  @Mock
+  private TaskMapper mapper;
+  @Spy
+  private LobbyAccessPolicy accessPolicy;
+
+  @InjectMocks
+  private TaskServiceImpl taskService;
+
+  private UserEntity owner;
+  private LobbyEntity lobby;
+  private TaskEntity taskEntity;
+  private TaskDto taskDto;
+
+  @BeforeEach
+  void setUp() {
+    owner = new UserEntity();
+    owner.setId(1L);
+    owner.setUsername("owner");
+
+    lobby = LobbyEntity.builder()
+        .id(101L)
+        .name("Test Lobby")
+        .lobbyType(LobbyTypes.FAMILY)
+        .owner(owner)
+        .members(new HashSet<>(Set.of(owner)))
+        .build();
+
+    taskEntity = TaskEntity.builder()
+        .id(555L)
+        .title("Buy groceries")
+        .status(TaskStatus.TODO)
+        .lobby(lobby)
+        .creator(owner)
+        .build();
+
+    taskDto = new TaskDto(555L, "Buy groceries", TaskStatus.TODO, 101L, 1L, null, null, null);
+  }
+
+  /* =======================
+     CREATE
+  ======================= */
+
+  @Test
+  void create_success() {
+    TaskCreateDto dto = new TaskCreateDto("Buy groceries", 101L, null, null);
+
+    when(userRepo.findById(1L)).thenReturn(Optional.of(owner));
+    when(lobbyRepo.findById(101L)).thenReturn(Optional.of(lobby));
+    when(repo.save(any(TaskEntity.class))).thenReturn(taskEntity);
+    when(mapper.toDto(taskEntity)).thenReturn(taskDto);
+
+    TaskDto result = taskService.create(dto, 1L);
+
+    assertThat(result).isEqualTo(taskDto);
+    verify(repo).save(any(TaskEntity.class));
+  }
+
+  @Test
+  void create_throwsNoSuchElement_whenCreatorNotFound() {
+    TaskCreateDto dto = new TaskCreateDto("Buy groceries", 101L, null, null);
+
+    when(userRepo.findById(99L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> taskService.create(dto, 99L))
+        .isInstanceOf(NoSuchElementException.class)
+        .hasMessageContaining("99");
+
+    verify(repo, never()).save(any());
+  }
+
+  @Test
+  void create_throwsNoSuchElement_whenLobbyNotFound() {
+    TaskCreateDto dto = new TaskCreateDto("Buy groceries", 999L, null, null);
+
+    when(userRepo.findById(1L)).thenReturn(Optional.of(owner));
+    when(lobbyRepo.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> taskService.create(dto, 1L))
+        .isInstanceOf(NoSuchElementException.class)
+        .hasMessageContaining("999");
+
+    verify(repo, never()).save(any());
+  }
+
+  /* =======================
+     UPDATE
+  ======================= */
+
+  @Test
+  void update_success() {
+    TaskUpdateDto dto = new TaskUpdateDto(TaskStatus.IN_PROGRESS, null, null, "Updated title");
+
+    when(repo.findById(555L)).thenReturn(Optional.of(taskEntity));
+    when(mapper.toDto(taskEntity)).thenReturn(taskDto);
+
+    TaskDto result = taskService.update(555L, dto, 1L);
+
+    assertThat(result).isEqualTo(taskDto);
+    assertThat(taskEntity.getStatus()).isEqualTo(TaskStatus.IN_PROGRESS);
+    assertThat(taskEntity.getTitle()).isEqualTo("Updated title");
+    verify(accessPolicy).ensureMember(lobby, 1L);
+  }
+
+  @Test
+  void update_skipsNullFields() {
+    TaskUpdateDto dto = new TaskUpdateDto(null, null, null, null);
+
+    when(repo.findById(555L)).thenReturn(Optional.of(taskEntity));
+    when(mapper.toDto(taskEntity)).thenReturn(taskDto);
+
+    taskService.update(555L, dto, 1L);
+
+    assertThat(taskEntity.getTitle()).isEqualTo("Buy groceries");
+    assertThat(taskEntity.getStatus()).isEqualTo(TaskStatus.TODO);
+  }
+
+  @Test
+  void update_throwsNoSuchElement_whenTaskNotFound() {
+    TaskUpdateDto dto = new TaskUpdateDto(null, null, null, "Title");
+
+    when(repo.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> taskService.update(999L, dto, 1L))
+        .isInstanceOf(NoSuchElementException.class)
+        .hasMessageContaining("999");
+  }
+
+  @Test
+  void update_throwsSecurity_whenUserIsNotLobbyMember() {
+    TaskUpdateDto dto = new TaskUpdateDto(null, null, null, "Title");
+
+    when(repo.findById(555L)).thenReturn(Optional.of(taskEntity));
+
+    assertThatThrownBy(() -> taskService.update(555L, dto, 99L))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("not a member");
+  }
+
+  /* =======================
+     DELETE
+  ======================= */
+
+  @Test
+  void delete_success() {
+    when(repo.findById(555L)).thenReturn(Optional.of(taskEntity));
+
+    taskService.delete(555L, 1L);
+
+    verify(accessPolicy).ensureMember(lobby, 1L);
+    verify(repo).delete(taskEntity);
+  }
+
+  @Test
+  void delete_throwsNoSuchElement_whenTaskNotFound() {
+    when(repo.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> taskService.delete(999L, 1L))
+        .isInstanceOf(NoSuchElementException.class)
+        .hasMessageContaining("999");
+
+    verify(repo, never()).delete(any(TaskEntity.class));
+  }
+
+  @Test
+  void delete_throwsSecurity_whenUserIsNotLobbyMember() {
+    when(repo.findById(555L)).thenReturn(Optional.of(taskEntity));
+
+    assertThatThrownBy(() -> taskService.delete(555L, 99L))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("not a member");
+
+    verify(repo, never()).delete(any(TaskEntity.class));
+  }
+
+  /* =======================
+     LIST
+  ======================= */
+
+  @Test
+  void list_returnsMatchingTasks() {
+    when(repo.findAll(any(org.springframework.data.jpa.domain.Specification.class)))
+        .thenReturn(List.of(taskEntity));
+    when(mapper.toDto(taskEntity)).thenReturn(taskDto);
+
+    List<TaskDto> result = taskService.list(101L, null, null);
+
+    assertThat(result).hasSize(1).containsExactly(taskDto);
+  }
+
+  @Test
+  void list_returnsEmpty_whenNoTasksMatch() {
+    when(repo.findAll(any(org.springframework.data.jpa.domain.Specification.class)))
+        .thenReturn(List.of());
+
+    List<TaskDto> result = taskService.list(101L, null, null);
+
+    assertThat(result).isEmpty();
+  }
+
+}


### PR DESCRIPTION
## Purpose

Remove duplicated access-check logic from TaskServiceImpl, EventServiceImpl,
and LobbyServiceImpl by introducing a shared LobbyAccessPolicy seam. Lobby
ownership and membership rules are now concentrated in one tested module,
and the three service flows no longer own the access implementation.

## Type

- [ ] 🧪 Experiment (fitness function research)
- [ ] ✨ Feature (new business logic)
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor / neutral change
- [ ] 📝 Documentation only

## Changes

`TaskServiceImpl.ensureMember()` and `EventServiceImpl.ensureMember()` were
byte-for-byte identical. `LobbyServiceImpl.ensureOwner()` duplicated the
owner-only variant. All three private methods are removed and replaced by
`LobbyAccessPolicy` — a `@Component` in `io.backend.lined.lobby.service`
injected via `@RequiredArgsConstructor`.

`ensureMember` short-circuits on owner identity before loading the lazy
`members` collection. Both methods include `Objects.requireNonNull` guards and
Javadoc documenting the transaction precondition for callers.

`TaskServiceImplTest` is added as a new file — no test existed for this service
before this PR.

## Files changed

| File | Change |
|------|--------|
| `lobby/service/LobbyAccessPolicy.java` | Created — shared member/owner check seam |
| `lobby/service/LobbyAccessPolicyTest.java` | Created — 6 unit tests covering all branches |
| `lobby/service/LobbyServiceImpl.java` | Removed `ensureOwner`, delegates to `accessPolicy` |
| `lobby/service/LobbyServiceImplTest.java` | Added `@Spy LobbyAccessPolicy` |
| `task/service/TaskServiceImpl.java` | Removed `ensureMember`, delegates to `accessPolicy` |
| `task/service/TaskServiceImplTest.java` | Created — 11 unit tests for create/update/delete/list |
| `event/service/EventServiceImpl.java` | Removed `ensureMember`, delegates to `accessPolicy` across 5 operations |
| `event/service/EventServiceImplTest.java` | Added `@Spy LobbyAccessPolicy` |
| `event/service/EventServiceImplConflictTest.java` | Added `@Spy LobbyAccessPolicy` |

## Expected result

| Metric | Baseline (main) | Branch | Direction |
|--------|----------------|--------|-----------|
| `checkstyle_violations` | 0 | 0 | neutral |
| `spotbugs_total` | 0 | 0 | neutral |
| `line_coverage` | — | 54.3% | increase (TaskServiceImplTest is new) |
| `critical_violations` | — | — | neutral |
| `code_smells` | — | — | neutral |
| `duplicated_lines_density` | — | — | decrease |
| **F score** | — | — | neutral or slight increase |
| **SonarQube QG** | — | — | neutral |

Baseline main metrics not available locally — branch values from `./gradlew jacocoTestReport` and `./gradlew checkstyleMain spotbugsMain`.

## Checklist

- [x] `./gradlew check` passes locally
- [x] `./gradlew jacocoTestReport` passes locally
- [x] No unintended changes to main business logic
- [x] Branch name matches experiment/feature naming convention