### PR TITLE
Add verified auth login endpoint

### DIFF
--- a/backend/lined/docs/api.md
+++ b/backend/lined/docs/api.md
@@ -7,11 +7,17 @@ Base URL: **http://localhost:8080**
 
 ## 🔑 Authentication
 
-All protected endpoints require **JWT Bearer Token** in the `Authorization` header.
+`POST /api/auth/login` verifies a user's password and returns a short-lived
+Bearer-style token plus the authenticated user identity.
 
 ```http
 Authorization: Bearer <access_token>
 ```
+
+The rest of the backend still accepts the MVP `X-User-Id: <Long>` caller
+identity header on endpoints that require a user id. Treat that header path as
+deprecated transitional auth while request filtering is moved to the login
+token.
 
 ---
 
@@ -187,13 +193,15 @@ Returns the currently authenticated user's profile.
 
 `POST /api/auth/login`
 
-Authenticate and get JWT access token.
+Verify a password for an existing user and return a token plus the user identity
+needed by the current web auth store. The identifier can be an email address or
+username.
 
 **Request**
 
 ```json
 {
-  "email": "alex@example.com",
+  "identifier": "alex@example.com",
   "password": "P@ssw0rd!"
 }
 ```
@@ -202,74 +210,28 @@ Authenticate and get JWT access token.
 
 ```json
 {
-  "accessToken": "eyJhbGciOiJIUzI1NiIsInR...",
-  "refreshToken": "eyJhbGciOiJIUzI1NiIsInR...",
+  "accessToken": "djE6NDI6MTc2MDAwMDAwMA.qfV...",
   "tokenType": "Bearer",
-  "expiresIn": 3600
+  "expiresIn": 3600,
+  "userId": 42,
+  "username": "alex",
+  "email": "alex@example.com",
+  "roles": [
+    "ROLE_USER"
+  ]
 }
 ```
+
+**Response 401**
+
+Returned when the identifier does not exist or the password does not match.
 
 ---
 
-### Refresh Token
+### Legacy / Planned Auth Endpoints
 
-`POST /api/auth/refresh`
-
-Get a new access token using a refresh token.
-
-**Request**
-
-```json
-{
-  "refreshToken": "eyJhbGciOiJIUzI1NiIsInR..."
-}
-```
-
-**Response 200**
-
-```json
-{
-  "accessToken": "newAccessToken123",
-  "tokenType": "Bearer",
-  "expiresIn": 3600
-}
-```
-
----
-
-### Register
-
-`POST /api/auth/register`
-
-Alternative registration endpoint for public users.
-
-**Request**
-
-```json
-{
-  "username": "newUser",
-  "email": "new.user@example.com",
-  "password": "Qwerty@123"
-}
-```
-
-**Response 201**
-
-```json
-{
-  "message": "User registered successfully"
-}
-```
-
----
-
-### Logout
-
-`POST /api/auth/logout`
-
-Invalidate refresh token (logout).
-
-**Response 204**
+`POST /api/auth/refresh`, `POST /api/auth/register`, and `POST /api/auth/logout`
+are not implemented yet. Registration currently uses `POST /api/users`.
 
 ---
 
@@ -472,7 +434,7 @@ Simple health and uptime information.
 | Status | Meaning               | Example                                                             |
 |:-------|:----------------------|:--------------------------------------------------------------------|
 | 400    | Bad Request           | `{ "code": "VALIDATION_ERROR", "message": "Invalid email" }`        |
-| 401    | Unauthorized          | `{ "code": "UNAUTHORIZED", "message": "Missing or invalid token" }` |
+| 401    | Unauthorized          | `{ "title": "Unauthorized", "detail": "Invalid email, username, or password" }` |
 | 403    | Forbidden             | `{ "code": "FORBIDDEN", "message": "Access denied" }`               |
 | 404    | Not Found             | `{ "code": "NOT_FOUND", "message": "User not found" }`              |
 | 409    | Conflict              | `{ "code": "EMAIL_EXISTS", "message": "Email already registered" }` |

--- a/backend/lined/docs/architecture.md
+++ b/backend/lined/docs/architecture.md
@@ -62,10 +62,13 @@ Controller -> Service -> Repository -> Entity
 
 ## API and Identity Model
 
-The backend currently uses an MVP identity model where endpoints that need the
-caller receive `X-User-Id: <Long>`. Treat this as temporary non-production auth.
-Do not replace it inside experiment-infrastructure PRs unless the task is
-explicitly about authentication.
+The backend is moving away from its MVP identity model. `POST /api/auth/login`
+now verifies a user's stored password and returns a short-lived Bearer-style
+token plus the authenticated user identity. Most existing endpoints still
+receive the caller through `X-User-Id: <Long>`; treat that header path as
+deprecated transitional auth until request filtering consumes the login token.
+Do not replace the remaining identity model inside experiment-infrastructure
+PRs unless the task is explicitly about authentication.
 
 Swagger UI is available at `/swagger-ui.html` when the app is running.
 
@@ -100,9 +103,9 @@ Candidate architecture/deployment alternatives:
 
 ## Known Inconsistencies and Risks
 
-- Legacy API documentation refers to JWT auth, while the current backend agent
-  guidance describes `X-User-Id` MVP auth. Treat `docs/api.md` as a document to
-  verify and update when endpoint work begins.
+- Request authentication is transitional: login verifies passwords and returns a
+  token, while existing protected flows still read `X-User-Id` until request
+  filtering is implemented.
 - Some service code still throws raw Java exceptions such as
   `NoSuchElementException`, `IllegalArgumentException`, or `SecurityException`.
   Prefer the application exception hierarchy for new work.

--- a/backend/lined/src/main/java/io/backend/lined/auth/api/AuthController.java
+++ b/backend/lined/src/main/java/io/backend/lined/auth/api/AuthController.java
@@ -1,0 +1,22 @@
+package io.backend.lined.auth.api;
+
+import io.backend.lined.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+  private final AuthService authService;
+
+  @PostMapping("/login")
+  public AuthLoginResponseDto login(@Valid @RequestBody AuthLoginDto dto) {
+    return authService.login(dto);
+  }
+}

--- a/backend/lined/src/main/java/io/backend/lined/auth/api/AuthLoginDto.java
+++ b/backend/lined/src/main/java/io/backend/lined/auth/api/AuthLoginDto.java
@@ -1,0 +1,29 @@
+package io.backend.lined.auth.api;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AuthLoginDto(
+    @Size(max = 255) String identifier,
+    @Size(max = 255) String email,
+    @Size(max = 64) String username,
+    @NotBlank @Size(max = 255) String password
+) {
+
+  public String resolvedIdentifier() {
+    if (hasText(identifier)) {
+      return identifier.trim();
+    }
+    if (hasText(email)) {
+      return email.trim();
+    }
+    if (hasText(username)) {
+      return username.trim();
+    }
+    return null;
+  }
+
+  private boolean hasText(String value) {
+    return value != null && !value.isBlank();
+  }
+}

--- a/backend/lined/src/main/java/io/backend/lined/auth/api/AuthLoginResponseDto.java
+++ b/backend/lined/src/main/java/io/backend/lined/auth/api/AuthLoginResponseDto.java
@@ -1,0 +1,14 @@
+package io.backend.lined.auth.api;
+
+import java.util.Set;
+
+public record AuthLoginResponseDto(
+    String accessToken,
+    String tokenType,
+    long expiresIn,
+    long userId,
+    String username,
+    String email,
+    Set<String> roles
+) {
+}

--- a/backend/lined/src/main/java/io/backend/lined/auth/service/AuthService.java
+++ b/backend/lined/src/main/java/io/backend/lined/auth/service/AuthService.java
@@ -1,0 +1,9 @@
+package io.backend.lined.auth.service;
+
+import io.backend.lined.auth.api.AuthLoginDto;
+import io.backend.lined.auth.api.AuthLoginResponseDto;
+
+public interface AuthService {
+
+  AuthLoginResponseDto login(AuthLoginDto dto);
+}

--- a/backend/lined/src/main/java/io/backend/lined/auth/service/AuthServiceImpl.java
+++ b/backend/lined/src/main/java/io/backend/lined/auth/service/AuthServiceImpl.java
@@ -1,0 +1,57 @@
+package io.backend.lined.auth.service;
+
+import io.backend.lined.auth.api.AuthLoginDto;
+import io.backend.lined.auth.api.AuthLoginResponseDto;
+import io.backend.lined.common.exception.BadRequestException;
+import io.backend.lined.common.exception.UnauthorizedException;
+import io.backend.lined.user.api.UserDto;
+import io.backend.lined.user.api.UserMapper;
+import io.backend.lined.user.domain.UserEntity;
+import io.backend.lined.user.domain.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthServiceImpl implements AuthService {
+
+  private static final String INVALID_CREDENTIALS_MESSAGE =
+      "Invalid email, username, or password";
+
+  private final UserRepository userRepository;
+  private final UserMapper userMapper;
+  private final PasswordEncoder passwordEncoder;
+  private final AuthTokenService tokenService;
+
+  @Override
+  public AuthLoginResponseDto login(AuthLoginDto dto) {
+    String identifier = dto.resolvedIdentifier();
+    if (identifier == null) {
+      throw new BadRequestException("Email, username, or identifier is required");
+    }
+
+    UserEntity user = findUser(identifier);
+    if (!passwordEncoder.matches(dto.password(), user.getPassword())) {
+      throw new UnauthorizedException(INVALID_CREDENTIALS_MESSAGE);
+    }
+
+    UserDto userDto = userMapper.toDto(user);
+    return new AuthLoginResponseDto(
+        tokenService.issueFor(user),
+        tokenService.tokenType(),
+        tokenService.ttlSeconds(),
+        userDto.id(),
+        userDto.username(),
+        userDto.email(),
+        userDto.roles());
+  }
+
+  private UserEntity findUser(String identifier) {
+    return userRepository.findByEmailIgnoreCase(identifier)
+        .or(() -> userRepository.findByUsernameIgnoreCase(identifier))
+        .orElseThrow(() -> new UnauthorizedException(INVALID_CREDENTIALS_MESSAGE));
+  }
+}

--- a/backend/lined/src/main/java/io/backend/lined/auth/service/AuthTokenService.java
+++ b/backend/lined/src/main/java/io/backend/lined/auth/service/AuthTokenService.java
@@ -1,0 +1,58 @@
+package io.backend.lined.auth.service;
+
+import io.backend.lined.user.domain.UserEntity;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthTokenService {
+
+  private static final String TOKEN_TYPE = "Bearer";
+  private static final String ALGORITHM = "HmacSHA256";
+  private static final String VERSION = "v1";
+
+  private final String secret;
+  private final long ttlSeconds;
+
+  public AuthTokenService(
+      @Value("${lined.auth.token-secret:local-development-only-change-me}") String secret,
+      @Value("${lined.auth.token-ttl-seconds:3600}") long ttlSeconds) {
+    this.secret = secret;
+    this.ttlSeconds = ttlSeconds;
+  }
+
+  public String issueFor(UserEntity user) {
+    long expiresAt = Instant.now().plusSeconds(ttlSeconds).getEpochSecond();
+    String payload = "%s:%d:%d".formatted(VERSION, user.getId(), expiresAt);
+    return encode(payload) + "." + sign(payload);
+  }
+
+  public String tokenType() {
+    return TOKEN_TYPE;
+  }
+
+  public long ttlSeconds() {
+    return ttlSeconds;
+  }
+
+  private String sign(String payload) {
+    try {
+      Mac mac = Mac.getInstance(ALGORITHM);
+      mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), ALGORITHM));
+      byte[] signature = mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+      return Base64.getUrlEncoder().withoutPadding().encodeToString(signature);
+    } catch (java.security.GeneralSecurityException ex) {
+      throw new IllegalStateException("Unable to issue auth token", ex);
+    }
+  }
+
+  private String encode(String payload) {
+    return Base64.getUrlEncoder().withoutPadding()
+        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/backend/lined/src/main/java/io/backend/lined/common/exception/UnauthorizedException.java
+++ b/backend/lined/src/main/java/io/backend/lined/common/exception/UnauthorizedException.java
@@ -1,0 +1,10 @@
+package io.backend.lined.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends BaseAppException {
+
+  public UnauthorizedException(String message) {
+    super(HttpStatus.UNAUTHORIZED, "common.unauthorized", message);
+  }
+}

--- a/backend/lined/src/main/java/io/backend/lined/config/GlobalExceptionHandler.java
+++ b/backend/lined/src/main/java/io/backend/lined/config/GlobalExceptionHandler.java
@@ -22,6 +22,7 @@ public class GlobalExceptionHandler {
       case CONFLICT -> "Conflict";
       case BAD_REQUEST -> "Bad request";
       case FORBIDDEN -> "Forbidden";
+      case UNAUTHORIZED -> "Unauthorized";
       default -> ex.getStatus().getReasonPhrase();
     });
     pd.setType(URI.create("https://errors.lined.app/" + ex.getCode()));

--- a/backend/lined/src/main/java/io/backend/lined/config/OpenApiConfig.java
+++ b/backend/lined/src/main/java/io/backend/lined/config/OpenApiConfig.java
@@ -25,6 +25,14 @@ public class OpenApiConfig {
   }
 
   @Bean
+  public GroupedOpenApi authApi() {
+    return GroupedOpenApi.builder()
+        .group("auth")
+        .pathsToMatch("/api/auth/**")
+        .build();
+  }
+
+  @Bean
   public GroupedOpenApi usersApi() {
     return GroupedOpenApi.builder()
         .group("users")

--- a/backend/lined/src/test/java/io/backend/lined/auth/api/AuthControllerTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/auth/api/AuthControllerTest.java
@@ -1,0 +1,40 @@
+package io.backend.lined.auth.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.backend.lined.auth.service.AuthService;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+  @Mock
+  private AuthService authService;
+
+  private AuthController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller = new AuthController(authService);
+  }
+
+  @Test
+  void login_delegatesToAuthService() {
+    var request = new AuthLoginDto("alice@example.com", null, null, "password");
+    var response = new AuthLoginResponseDto(
+        "token", "Bearer", 3600L, 1L, "alice", "alice@example.com", Set.of("ROLE_USER"));
+    when(authService.login(request)).thenReturn(response);
+
+    AuthLoginResponseDto result = controller.login(request);
+
+    assertThat(result).isEqualTo(response);
+    verify(authService).login(request);
+  }
+}

--- a/backend/lined/src/test/java/io/backend/lined/auth/service/AuthServiceImplTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/auth/service/AuthServiceImplTest.java
@@ -1,0 +1,132 @@
+package io.backend.lined.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.backend.lined.auth.api.AuthLoginDto;
+import io.backend.lined.common.exception.BadRequestException;
+import io.backend.lined.common.exception.UnauthorizedException;
+import io.backend.lined.user.api.UserDto;
+import io.backend.lined.user.api.UserMapper;
+import io.backend.lined.user.domain.UserEntity;
+import io.backend.lined.user.domain.UserRepository;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceImplTest {
+
+  private static final long USER_ID = 1L;
+  private static final String USERNAME = "alice";
+  private static final String EMAIL = "alice@example.com";
+  private static final String PASSWORD = "password";
+  private static final String ENCODED_PASSWORD = "encoded";
+  private static final String TOKEN = "token";
+
+  @Mock
+  private UserRepository userRepository;
+  @Mock
+  private UserMapper userMapper;
+  @Mock
+  private PasswordEncoder passwordEncoder;
+  @Mock
+  private AuthTokenService tokenService;
+
+  private AuthServiceImpl authService;
+  private UserEntity user;
+  private UserDto userDto;
+
+  @BeforeEach
+  void setUp() {
+    authService = new AuthServiceImpl(userRepository, userMapper, passwordEncoder, tokenService);
+    user = new UserEntity();
+    user.setId(USER_ID);
+    user.setUsername(USERNAME);
+    user.setEmail(EMAIL);
+    user.setPassword(ENCODED_PASSWORD);
+    userDto = new UserDto(USER_ID, USERNAME, EMAIL, null, Set.of("ROLE_USER"), null, null);
+  }
+
+  @Test
+  void login_successWithEmail_returnsVerifiedIdentity() {
+    var request = new AuthLoginDto(EMAIL, null, null, PASSWORD);
+    when(userRepository.findByEmailIgnoreCase(EMAIL)).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches(PASSWORD, ENCODED_PASSWORD)).thenReturn(true);
+    when(userMapper.toDto(user)).thenReturn(userDto);
+    when(tokenService.issueFor(user)).thenReturn(TOKEN);
+    when(tokenService.tokenType()).thenReturn("Bearer");
+    when(tokenService.ttlSeconds()).thenReturn(3600L);
+
+    var response = authService.login(request);
+
+    assertThat(response.accessToken()).isEqualTo(TOKEN);
+    assertThat(response.userId()).isEqualTo(USER_ID);
+    assertThat(response.username()).isEqualTo(USERNAME);
+    assertThat(response.email()).isEqualTo(EMAIL);
+    assertThat(response.roles()).containsExactly("ROLE_USER");
+  }
+
+  @Test
+  void login_successWithUsername_whenEmailLookupMisses() {
+    var request = new AuthLoginDto(USERNAME, null, null, PASSWORD);
+    when(userRepository.findByEmailIgnoreCase(USERNAME)).thenReturn(Optional.empty());
+    when(userRepository.findByUsernameIgnoreCase(USERNAME)).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches(PASSWORD, ENCODED_PASSWORD)).thenReturn(true);
+    when(userMapper.toDto(user)).thenReturn(userDto);
+    when(tokenService.issueFor(user)).thenReturn(TOKEN);
+    when(tokenService.tokenType()).thenReturn("Bearer");
+    when(tokenService.ttlSeconds()).thenReturn(3600L);
+
+    var response = authService.login(request);
+
+    assertThat(response.userId()).isEqualTo(USER_ID);
+    verify(userRepository).findByUsernameIgnoreCase(USERNAME);
+  }
+
+  @Test
+  void login_throwsUnauthorized_whenUserMissing() {
+    var request = new AuthLoginDto("missing@example.com", null, null, PASSWORD);
+    when(userRepository.findByEmailIgnoreCase("missing@example.com")).thenReturn(Optional.empty());
+    when(userRepository.findByUsernameIgnoreCase("missing@example.com"))
+        .thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> authService.login(request))
+        .isInstanceOf(UnauthorizedException.class)
+        .hasMessageContaining("Invalid email, username, or password");
+
+    verify(passwordEncoder, never()).matches(PASSWORD, ENCODED_PASSWORD);
+  }
+
+  @Test
+  void login_throwsUnauthorized_whenPasswordDoesNotMatch() {
+    var request = new AuthLoginDto(EMAIL, null, null, PASSWORD);
+    when(userRepository.findByEmailIgnoreCase(EMAIL)).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches(PASSWORD, ENCODED_PASSWORD)).thenReturn(false);
+
+    assertThatThrownBy(() -> authService.login(request))
+        .isInstanceOf(UnauthorizedException.class)
+        .hasMessageContaining("Invalid email, username, or password");
+
+    verify(tokenService, never()).issueFor(user);
+  }
+
+  @Test
+  void login_throwsBadRequest_whenIdentifierMissing() {
+    var request = new AuthLoginDto(" ", null, null, PASSWORD);
+
+    assertThatThrownBy(() -> authService.login(request))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("identifier is required");
+
+    verify(userRepository, never()).findByEmailIgnoreCase(" ");
+  }
+}

--- a/backend/lined/src/test/java/io/backend/lined/auth/service/AuthTokenServiceTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/auth/service/AuthTokenServiceTest.java
@@ -1,0 +1,23 @@
+package io.backend.lined.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.backend.lined.user.domain.UserEntity;
+import org.junit.jupiter.api.Test;
+
+class AuthTokenServiceTest {
+
+  @Test
+  void issueFor_returnsSignedBearerCompatibleToken() {
+    var service = new AuthTokenService("test-secret", 3600L);
+    var user = new UserEntity();
+    user.setId(42L);
+
+    String token = service.issueFor(user);
+
+    assertThat(token).contains(".");
+    assertThat(token.split("\\.")).hasSize(2);
+    assertThat(service.tokenType()).isEqualTo("Bearer");
+    assertThat(service.ttlSeconds()).isEqualTo(3600L);
+  }
+}

--- a/backend/lined/src/test/java/io/backend/lined/config/GlobalExceptionHandlerTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/config/GlobalExceptionHandlerTest.java
@@ -8,9 +8,12 @@ import io.backend.lined.common.exception.BadRequestException;
 import io.backend.lined.common.exception.ConflictException;
 import io.backend.lined.common.exception.ForbiddenException;
 import io.backend.lined.common.exception.NotFoundException;
+import io.backend.lined.common.exception.UnauthorizedException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,6 +81,17 @@ class GlobalExceptionHandlerTest {
   }
 
   @Test
+  void handleBase_unauthorized_returns401WithCorrectTitle() {
+    var ex = new UnauthorizedException("Invalid email, username, or password");
+
+    ResponseEntity<ProblemDetail> response = handler.handleBase(ex);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getTitle()).isEqualTo("Unauthorized");
+  }
+
+  @Test
   void handleValidation_returns400WithErrorsProperty() {
     MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
     BindingResult bindingResult = mock(BindingResult.class);
@@ -88,11 +102,12 @@ class GlobalExceptionHandlerTest {
     ResponseEntity<ProblemDetail> response = handler.handleValidation(ex);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-    assertThat(response.getBody()).isNotNull();
-    assertThat(response.getBody().getTitle()).isEqualTo("Validation error");
-    assertThat(response.getBody().getProperties()).containsKey("errors");
+    ProblemDetail body = Objects.requireNonNull(response.getBody());
+    assertThat(body.getTitle()).isEqualTo("Validation error");
+    Map<String, Object> properties = Objects.requireNonNull(body.getProperties());
+    assertThat(properties).containsKey("errors");
     @SuppressWarnings("unchecked")
-    List<String> errors = (List<String>) response.getBody().getProperties().get("errors");
+    List<String> errors = (List<String>) properties.get("errors");
     assertThat(errors).anyMatch(e -> e.contains("email"));
   }
 


### PR DESCRIPTION
## Purpose

Add a real backend login endpoint for the web auth flow so sign-in verifies the stored password instead of resolving identity through user search.

## Type

- [ ] Experiment (fitness function research)
- [ ] Feature (new business logic)
- [x] Bug fix
- [ ] Refactor / neutral change
- [ ] Documentation only

## Changes

Root cause: the web auth task had to sign users in by `GET /api/users/search` and trust the returned id because the backend exposed registration with a stored password but no endpoint to verify that password.

This PR adds `POST /api/auth/login`, accepts an email/username identifier plus password, verifies the stored BCrypt password, and returns a verified user identity with a short-lived Bearer-style token. Existing protected backend flows still use the transitional `X-User-Id` header until request filtering is wired to consume login tokens.

## Files changed

| File | Change |
|------|--------|
| `backend/lined/src/main/java/io/backend/lined/auth/**` | Adds auth controller, login DTOs, login service, and token issuer. |
| `backend/lined/src/main/java/io/backend/lined/common/exception/UnauthorizedException.java` | Adds an application-level 401 exception for invalid credentials. |
| `backend/lined/src/main/java/io/backend/lined/config/GlobalExceptionHandler.java` | Maps unauthorized errors to a 401 ProblemDetail title. |
| `backend/lined/src/main/java/io/backend/lined/config/OpenApiConfig.java` | Registers the `/api/auth/**` OpenAPI group. |
| `backend/lined/src/test/java/io/backend/lined/auth/**` | Adds focused controller, service, and token tests for login behavior. |
| `backend/lined/src/test/java/io/backend/lined/config/GlobalExceptionHandlerTest.java` | Covers 401 handling and cleans a SpotBugs nullability finding. |
| `backend/lined/docs/api.md` | Documents login request/response and removes stale unimplemented auth endpoint examples. |
| `backend/lined/docs/architecture.md` | Documents login plus the deprecated transitional `X-User-Id` path. |

## Expected result

| Metric | Baseline (main) | Branch | Direction |
|--------|----------------|--------|-----------|
| checkstyle_violations | not measured | 0 local failures | neutral |
| spotbugs_total | not measured | 0 local failures | neutral |
| line_coverage | not measured | report generated | neutral |
| critical_violations | not measured | not measured | unknown |
| code_smells | not measured | not measured | unknown |
| duplicated_lines_density | not measured | not measured | unknown |
| **F score** | not measured | not measured | unknown |
| **SonarQube QG** | not measured | not measured | unknown |

## How to use and test

Call login:

```bash
curl -X POST http://localhost:8080/api/auth/login \
  -H 'Content-Type: application/json' \
  -d '{"identifier":"alex@example.com","password":"P@ssw0rd!"}'
```

Expected success response includes `accessToken`, `tokenType`, `expiresIn`, `userId`, `username`, `email`, and `roles`. Unknown users and wrong passwords return `401 Unauthorized`.

Local validation:

```bash
./gradlew check
./gradlew jacocoTestReport
git diff --check
```

## Checklist

- [x] ./gradlew check passes locally
- [x] ./gradlew jacocoTestReport passes locally
- [x] No unintended changes to main business logic
- [x] Branch name matches bug scope
