### PR TITLE
Add lobby update and ownership transfer endpoint

### DIFF
--- a/backend/lined/docs/api.md
+++ b/backend/lined/docs/api.md
@@ -235,6 +235,47 @@ are not implemented yet. Registration currently uses `POST /api/users`.
 
 ---
 
+## 👥 Lobbies API
+
+### Update Lobby
+
+`PATCH /api/lobbies/{id}`
+
+The current lobby owner can partially update the name, type, and ownership.
+The `X-User-Id` header identifies the owner for the current MVP authentication
+path. An ownership-transfer target must already be a member of the lobby.
+
+**Request Body**
+
+```json
+{
+  "name": "Weekend Crew",
+  "lobbyType": "FRIENDS",
+  "ownerId": 77
+}
+```
+
+All fields are optional; omitted fields remain unchanged.
+
+**Response 200**
+
+```json
+{
+  "id": 101,
+  "name": "Weekend Crew",
+  "lobbyType": "FRIENDS",
+  "ownerId": 77,
+  "memberIds": [42, 77]
+}
+```
+
+**Errors**
+
+- `403 Forbidden` when the caller is not the current owner.
+- `409 Conflict` when `ownerId` is not an existing lobby member.
+
+---
+
 ## 🛡️ Roles API
 
 ### Get All Roles

--- a/backend/lined/src/main/java/io/backend/lined/lobby/api/LobbyController.java
+++ b/backend/lined/src/main/java/io/backend/lined/lobby/api/LobbyController.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -60,6 +61,26 @@ public class LobbyController {
   public LobbyDto get(
       @Parameter(description = "Lobby ID", example = "101") @PathVariable Long id) {
     return lobbyService.getById(id);
+  }
+
+  @Operation(
+      summary = "Update lobby",
+      description = "Partially update lobby name, type, or owner (owner only)."
+  )
+  @PatchMapping("/{id}")
+  public LobbyDto update(
+      @Parameter(description = "Lobby ID", example = "101") @PathVariable Long id,
+      @Parameter(description = "Current user id (temporary for MVP)", example = "42")
+      @RequestHeader("X-User-Id") Long currentUserId,
+      @io.swagger.v3.oas.annotations.parameters.RequestBody(
+          required = true,
+          description = "Fields to update; ownership may transfer only to an existing member",
+          content = @Content(schema = @Schema(implementation = LobbyUpdateDto.class),
+              examples = @ExampleObject(value = """
+                    { "name": "Weekend Crew", "lobbyType": "FRIENDS", "ownerId": 77 }
+                  """)))
+      @Valid @RequestBody LobbyUpdateDto dto) {
+    return lobbyService.update(id, dto, currentUserId);
   }
 
   @Operation(summary = "Add member", description = "Add user to lobby (owner only).")

--- a/backend/lined/src/main/java/io/backend/lined/lobby/api/LobbyUpdateDto.java
+++ b/backend/lined/src/main/java/io/backend/lined/lobby/api/LobbyUpdateDto.java
@@ -1,0 +1,21 @@
+package io.backend.lined.lobby.api;
+
+import io.backend.lined.lobby.domain.LobbyTypes;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+@Schema(name = "LobbyUpdateDto", description = "Partial lobby update payload")
+public record LobbyUpdateDto(
+    @Schema(description = "Lobby name", example = "Weekend Crew")
+    @Size(max = 64)
+    @Pattern(regexp = ".*\\S.*", message = "must not be blank") String name,
+
+    @Schema(description = "Lobby type", example = "FRIENDS", allowableValues = {
+        "COUPLE", "FAMILY", "FRIENDS", "WORK"}) LobbyTypes lobbyType,
+
+    @Schema(description = "New owner ID; must already be a lobby member", example = "77")
+    @Positive Long ownerId
+) {
+}

--- a/backend/lined/src/main/java/io/backend/lined/lobby/service/LobbyService.java
+++ b/backend/lined/src/main/java/io/backend/lined/lobby/service/LobbyService.java
@@ -2,6 +2,7 @@ package io.backend.lined.lobby.service;
 
 import io.backend.lined.lobby.api.LobbyCreateDto;
 import io.backend.lined.lobby.api.LobbyDto;
+import io.backend.lined.lobby.api.LobbyUpdateDto;
 import java.util.List;
 
 public interface LobbyService {
@@ -11,6 +12,8 @@ public interface LobbyService {
   LobbyDto getById(Long id);
 
   List<LobbyDto> myLobbies(Long userId);
+
+  LobbyDto update(Long lobbyId, LobbyUpdateDto dto, Long requesterId);
 
   LobbyDto addMember(Long lobbyId, Long userIdToAdd, Long requesterId);
 

--- a/backend/lined/src/main/java/io/backend/lined/lobby/service/LobbyServiceImpl.java
+++ b/backend/lined/src/main/java/io/backend/lined/lobby/service/LobbyServiceImpl.java
@@ -2,10 +2,12 @@ package io.backend.lined.lobby.service;
 
 import io.backend.lined.common.EntityFinder;
 import io.backend.lined.common.exception.BadRequestException;
+import io.backend.lined.common.exception.ConflictException;
 import io.backend.lined.common.exception.NotFoundException;
 import io.backend.lined.lobby.api.LobbyCreateDto;
 import io.backend.lined.lobby.api.LobbyDto;
 import io.backend.lined.lobby.api.LobbyMapper;
+import io.backend.lined.lobby.api.LobbyUpdateDto;
 import io.backend.lined.lobby.domain.LobbyEntity;
 import io.backend.lined.lobby.domain.LobbyRepository;
 import io.backend.lined.user.domain.UserRepository;
@@ -54,6 +56,23 @@ public class LobbyServiceImpl implements LobbyService {
   }
 
   @Override
+  public LobbyDto update(Long lobbyId, LobbyUpdateDto dto, Long requesterId) {
+    var lobby = mustLobby(lobbyId);
+    accessPolicy.ensureOwner(lobby, requesterId);
+
+    if (dto.name() != null) {
+      lobby.setName(dto.name());
+    }
+    if (dto.lobbyType() != null) {
+      lobby.setLobbyType(dto.lobbyType());
+    }
+    if (dto.ownerId() != null) {
+      transferOwnership(lobby, dto.ownerId());
+    }
+    return mapper.toDto(lobby);
+  }
+
+  @Override
   public LobbyDto addMember(Long lobbyId, Long userIdToAdd, Long requesterId) {
     var lobby = mustLobby(lobbyId);
 
@@ -91,6 +110,14 @@ public class LobbyServiceImpl implements LobbyService {
     return EntityFinder.findOrThrow(
         lobbyRepo.findById(id),
         () -> new NotFoundException("Lobby %d not found".formatted(id)));
+  }
+
+  private void transferOwnership(LobbyEntity lobby, Long newOwnerId) {
+    var newOwner = lobby.getMembers().stream()
+        .filter(member -> member.getId().equals(newOwnerId))
+        .findFirst()
+        .orElseThrow(() -> new ConflictException("New owner must be a lobby member"));
+    lobby.setOwner(newOwner);
   }
 
 }

--- a/backend/lined/src/test/java/io/backend/lined/lobby/api/LobbyControllerTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/lobby/api/LobbyControllerTest.java
@@ -10,6 +10,7 @@ import io.backend.lined.common.exception.ForbiddenException;
 import io.backend.lined.common.exception.NotFoundException;
 import io.backend.lined.lobby.domain.LobbyTypes;
 import io.backend.lined.lobby.service.LobbyService;
+import io.backend.lined.lobby.api.LobbyUpdateDto;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,6 +91,40 @@ class LobbyControllerTest {
     assertThatThrownBy(() -> controller.get(999L))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("999");
+  }
+
+  @Test
+  void update_delegatesToService() {
+    var dto = new LobbyUpdateDto("Weekend Crew", LobbyTypes.FRIENDS, 2L);
+    when(lobbyService.update(101L, dto, 1L)).thenReturn(sampleLobby);
+
+    LobbyDto result = controller.update(101L, 1L, dto);
+
+    assertThat(result).isEqualTo(sampleLobby);
+    verify(lobbyService).update(101L, dto, 1L);
+  }
+
+  @Test
+  void update_propagatesForbidden_whenRequesterIsNotOwner() {
+    var dto = new LobbyUpdateDto(null, null, null);
+    when(lobbyService.update(101L, dto, 99L))
+        .thenThrow(new ForbiddenException("Only owner can update lobby"));
+
+    assertThatThrownBy(() -> controller.update(101L, 99L, dto))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining("owner");
+  }
+
+  @Test
+  void update_propagatesConflict_whenNewOwnerIsNotMember() {
+    var dto = new LobbyUpdateDto(null, null, 2L);
+    when(lobbyService.update(101L, dto, 1L))
+        .thenThrow(new io.backend.lined.common.exception.ConflictException(
+            "New owner must be a lobby member"));
+
+    assertThatThrownBy(() -> controller.update(101L, 1L, dto))
+        .isInstanceOf(io.backend.lined.common.exception.ConflictException.class)
+        .hasMessageContaining("member");
   }
 
   @Test

--- a/backend/lined/src/test/java/io/backend/lined/lobby/service/LobbyServiceImplTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/lobby/service/LobbyServiceImplTest.java
@@ -8,11 +8,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.backend.lined.common.exception.BadRequestException;
+import io.backend.lined.common.exception.ConflictException;
 import io.backend.lined.common.exception.ForbiddenException;
 import io.backend.lined.common.exception.NotFoundException;
 import io.backend.lined.lobby.api.LobbyCreateDto;
 import io.backend.lined.lobby.api.LobbyDto;
 import io.backend.lined.lobby.api.LobbyMapper;
+import io.backend.lined.lobby.api.LobbyUpdateDto;
 import io.backend.lined.lobby.domain.LobbyEntity;
 import io.backend.lined.lobby.domain.LobbyRepository;
 import io.backend.lined.lobby.domain.LobbyTypes;
@@ -163,6 +165,88 @@ class LobbyServiceImplTest {
     List<LobbyDto> result = lobbyService.myLobbies(99L);
 
     assertThat(result).isEmpty();
+  }
+
+  /* =======================
+     UPDATE
+  ======================= */
+
+  @Test
+  void update_renamesLobby() {
+    LobbyUpdateDto dto = new LobbyUpdateDto("Weekend Crew", null, null);
+    when(lobbyRepo.findById(101L)).thenReturn(Optional.of(lobbyEntity));
+    when(mapper.toDto(lobbyEntity)).thenReturn(lobbyDto);
+
+    LobbyDto result = lobbyService.update(101L, dto, 1L);
+
+    assertThat(result).isEqualTo(lobbyDto);
+    assertThat(lobbyEntity.getName()).isEqualTo("Weekend Crew");
+  }
+
+  @Test
+  void update_changesLobbyType() {
+    LobbyUpdateDto dto = new LobbyUpdateDto(null, LobbyTypes.FRIENDS, null);
+    when(lobbyRepo.findById(101L)).thenReturn(Optional.of(lobbyEntity));
+    when(mapper.toDto(lobbyEntity)).thenReturn(lobbyDto);
+
+    lobbyService.update(101L, dto, 1L);
+
+    assertThat(lobbyEntity.getLobbyType()).isEqualTo(LobbyTypes.FRIENDS);
+  }
+
+  @Test
+  void update_changesAllSuppliedFields() {
+    lobbyEntity.getMembers().add(member);
+    LobbyUpdateDto dto = new LobbyUpdateDto("Weekend Crew", LobbyTypes.FRIENDS, 2L);
+    when(lobbyRepo.findById(101L)).thenReturn(Optional.of(lobbyEntity));
+    when(mapper.toDto(lobbyEntity)).thenReturn(lobbyDto);
+
+    lobbyService.update(101L, dto, 1L);
+
+    assertThat(lobbyEntity.getName()).isEqualTo("Weekend Crew");
+    assertThat(lobbyEntity.getLobbyType()).isEqualTo(LobbyTypes.FRIENDS);
+    assertThat(lobbyEntity.getOwner()).isEqualTo(member);
+    assertThat(lobbyEntity.getMembers()).containsExactlyInAnyOrder(owner, member);
+  }
+
+  @Test
+  void update_skipsNullFields() {
+    LobbyUpdateDto dto = new LobbyUpdateDto(null, null, null);
+    when(lobbyRepo.findById(101L)).thenReturn(Optional.of(lobbyEntity));
+    when(mapper.toDto(lobbyEntity)).thenReturn(lobbyDto);
+
+    lobbyService.update(101L, dto, 1L);
+
+    assertThat(lobbyEntity.getName()).isEqualTo("Our Family");
+    assertThat(lobbyEntity.getLobbyType()).isEqualTo(LobbyTypes.FAMILY);
+    assertThat(lobbyEntity.getOwner()).isEqualTo(owner);
+  }
+
+  @Test
+  void update_throwsNotFound_whenLobbyNotFound() {
+    when(lobbyRepo.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> lobbyService.update(999L, new LobbyUpdateDto(null, null, null), 1L))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("999");
+  }
+
+  @Test
+  void update_throwsForbidden_whenRequesterIsNotOwner() {
+    when(lobbyRepo.findById(101L)).thenReturn(Optional.of(lobbyEntity));
+
+    assertThatThrownBy(() -> lobbyService.update(101L, new LobbyUpdateDto(null, null, null), 99L))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining("owner");
+  }
+
+  @Test
+  void update_throwsConflict_whenNewOwnerIsNotMember() {
+    when(lobbyRepo.findById(101L)).thenReturn(Optional.of(lobbyEntity));
+
+    assertThatThrownBy(() -> lobbyService.update(101L, new LobbyUpdateDto(null, null, 2L), 1L))
+        .isInstanceOf(ConflictException.class)
+        .hasMessageContaining("member");
   }
 
   /* =======================


### PR DESCRIPTION
## Purpose

Add the owner-only lobby PATCH API required to rename a lobby, change its type, and transfer ownership to an existing member. This unblocks the editable Lobby Settings general card and the Members-page "Make owner" action.

## Type

- [ ] 🧪 Experiment (fitness function research)
- [x] ✨ Feature (new business logic)
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor / neutral change
- [ ] 📝 Documentation only

## Changes

- Added `PATCH /api/lobbies/{id}` with partial `name`, `lobbyType`, and `ownerId` updates.
- Enforced current-owner authorization and reject ownership transfers to non-members with HTTP 409.
- Added service and controller unit coverage plus API-reference and Swagger request documentation.

## Files changed

| File | Change |
|------|--------|
| `src/main/java/io/backend/lined/lobby/api/LobbyUpdateDto.java` | Added the partial update request contract and validation. |
| `src/main/java/io/backend/lined/lobby/api/LobbyController.java` | Exposed the owner-only PATCH endpoint and Swagger example. |
| `src/main/java/io/backend/lined/lobby/service/LobbyServiceImpl.java` | Applied partial updates and member-only ownership transfers. |
| `src/test/java/io/backend/lined/lobby/` | Covered successful updates, partial updates, 403 authorization, 404 lookup, and 409 transfer conflicts. |
| `docs/api.md` | Documented the PATCH API and error behavior. |

## Expected result

Owners can rename and retype a lobby or transfer ownership to an existing member. Non-owners receive 403; a non-member transfer target receives 409.

| Metric | Baseline (main) | Branch | Direction |
|--------|----------------|--------|-----------|
| checkstyle_violations | not measured | 0 observed locally | neutral |
| spotbugs_total | not measured | 0 observed locally | neutral |
| line_coverage | not measured | not measured | unknown |
| critical_violations | not measured | not measured | unknown |
| code_smells | not measured | not measured | unknown |
| duplicated_lines_density | not measured | not measured | unknown |
| **F score** | not measured | not measured | unknown |
| **SonarQube QG** | not measured | not measured | unknown |

## Checklist

- [x] ./gradlew check passes locally
- [x] ./gradlew jacocoTestReport passes locally
- [x] No unintended changes to main business logic
- [x] Branch name matches experiment/feature naming convention