### PR TITLE
Task 15: API contract refresh (auth, invites, notifications, task/event fields)

### DIFF
--- a/lined-web/docs/UI_TASKS.md
+++ b/lined-web/docs/UI_TASKS.md
@@ -85,7 +85,7 @@ AddMemberModal, ReserveSlotModal, kanban board, lobby header/tabs/members.
 | 12 | `feature/ui-12-user-settings` | User Settings page: profile, notifications, appearance, danger zone | [tasks/UI-12-user-settings.md](tasks/UI-12-user-settings.md) | TODO |
 | 13 | `feature/ui-13-lobby-settings` | Lobby Settings page: general, notifications, leave/delete lobby | [tasks/UI-13-lobby-settings.md](tasks/UI-13-lobby-settings.md) | TODO |
 | 14 | `feature/ui-14-subscription-page` | Subscription & Plan page: current plan, available plans, subscribe/cancel, history | [tasks/UI-14-subscription-page.md](tasks/UI-14-subscription-page.md) | TODO |
-| 15 | `feature/ui-15-api-contract-refresh` | Migrate `src/api`/`src/types`/MSW to the July 2026 backend contract (login, invites, new task/event fields, tasks/mine, free-slots, notifications) | [tasks/UI-15-api-contract-refresh.md](tasks/UI-15-api-contract-refresh.md) | IN PROGRESS |
+| 15 | `feature/ui-15-api-contract-refresh` | Migrate `src/api`/`src/types`/MSW to the July 2026 backend contract (login, invites, new task/event fields, tasks/mine, free-slots, notifications) | [tasks/UI-15-api-contract-refresh.md](tasks/UI-15-api-contract-refresh.md) | DONE |
 | 16 | `feature/ui-16-notifications-center` | Notification bell + inbox (unread count, mark read) and backend-persisted notification preferences | [tasks/UI-16-notifications-center.md](tasks/UI-16-notifications-center.md) | TODO |
 | 17 | `feature/ui-17-lobby-invites-inbox` | Invitee-side invites: pending invites list, accept/decline flows | [tasks/UI-17-lobby-invites-inbox.md](tasks/UI-17-lobby-invites-inbox.md) | TODO |
 

--- a/lined-web/docs/UI_TASKS.md
+++ b/lined-web/docs/UI_TASKS.md
@@ -85,7 +85,7 @@ AddMemberModal, ReserveSlotModal, kanban board, lobby header/tabs/members.
 | 12 | `feature/ui-12-user-settings` | User Settings page: profile, notifications, appearance, danger zone | [tasks/UI-12-user-settings.md](tasks/UI-12-user-settings.md) | TODO |
 | 13 | `feature/ui-13-lobby-settings` | Lobby Settings page: general, notifications, leave/delete lobby | [tasks/UI-13-lobby-settings.md](tasks/UI-13-lobby-settings.md) | TODO |
 | 14 | `feature/ui-14-subscription-page` | Subscription & Plan page: current plan, available plans, subscribe/cancel, history | [tasks/UI-14-subscription-page.md](tasks/UI-14-subscription-page.md) | TODO |
-| 15 | `feature/ui-15-api-contract-refresh` | Migrate `src/api`/`src/types`/MSW to the July 2026 backend contract (login, invites, new task/event fields, tasks/mine, free-slots, notifications) | [tasks/UI-15-api-contract-refresh.md](tasks/UI-15-api-contract-refresh.md) | TODO |
+| 15 | `feature/ui-15-api-contract-refresh` | Migrate `src/api`/`src/types`/MSW to the July 2026 backend contract (login, invites, new task/event fields, tasks/mine, free-slots, notifications) | [tasks/UI-15-api-contract-refresh.md](tasks/UI-15-api-contract-refresh.md) | IN PROGRESS |
 | 16 | `feature/ui-16-notifications-center` | Notification bell + inbox (unread count, mark read) and backend-persisted notification preferences | [tasks/UI-16-notifications-center.md](tasks/UI-16-notifications-center.md) | TODO |
 | 17 | `feature/ui-17-lobby-invites-inbox` | Invitee-side invites: pending invites list, accept/decline flows | [tasks/UI-17-lobby-invites-inbox.md](tasks/UI-17-lobby-invites-inbox.md) | TODO |
 

--- a/lined-web/src/api/auth.ts
+++ b/lined-web/src/api/auth.ts
@@ -1,0 +1,6 @@
+import { api } from './client';
+import type { LoginRequestDto, LoginResponseDto } from '@/types';
+
+export function login(data: LoginRequestDto): Promise<LoginResponseDto> {
+  return api.post('auth/login', { json: data }).json<LoginResponseDto>();
+}

--- a/lined-web/src/api/invites.ts
+++ b/lined-web/src/api/invites.ts
@@ -1,0 +1,44 @@
+import { api } from './client';
+import type { LobbyInviteDto } from '@/types';
+
+export type InviteTarget = { userId: number } | { userEmail: string };
+
+export function createInvite(
+  lobbyId: number,
+  target: InviteTarget,
+): Promise<LobbyInviteDto> {
+  return api
+    .post(`lobbies/${lobbyId}/invites`, {
+      searchParams: target as Record<string, string | number>,
+    })
+    .json<LobbyInviteDto>();
+}
+
+export function listLobbyInvites(lobbyId: number): Promise<LobbyInviteDto[]> {
+  return api.get(`lobbies/${lobbyId}/invites`).json<LobbyInviteDto[]>();
+}
+
+export function resendInvite(
+  lobbyId: number,
+  inviteId: number,
+): Promise<LobbyInviteDto> {
+  return api
+    .post(`lobbies/${lobbyId}/invites/${inviteId}/resend`)
+    .json<LobbyInviteDto>();
+}
+
+export function cancelInvite(lobbyId: number, inviteId: number): Promise<void> {
+  return api.delete(`lobbies/${lobbyId}/invites/${inviteId}`).then(() => undefined);
+}
+
+export function myInvites(): Promise<LobbyInviteDto[]> {
+  return api.get('lobby-invites/mine').json<LobbyInviteDto[]>();
+}
+
+export function acceptInvite(inviteId: number): Promise<LobbyInviteDto> {
+  return api.post(`lobby-invites/${inviteId}/accept`).json<LobbyInviteDto>();
+}
+
+export function declineInvite(inviteId: number): Promise<LobbyInviteDto> {
+  return api.post(`lobby-invites/${inviteId}/decline`).json<LobbyInviteDto>();
+}

--- a/lined-web/src/api/lobbies.ts
+++ b/lined-web/src/api/lobbies.ts
@@ -1,5 +1,5 @@
 import { api } from './client';
-import type { LobbyDto, LobbyCreateDto } from '@/types';
+import type { LobbyDto, LobbyCreateDto, LobbyUpdateDto, FreeSlotDto } from '@/types';
 
 export function getMyLobbies(): Promise<LobbyDto[]> {
   return api.get('lobbies/mine').json<LobbyDto[]>();
@@ -13,10 +13,18 @@ export function createLobby(data: LobbyCreateDto): Promise<LobbyDto> {
   return api.post('lobbies', { json: data }).json<LobbyDto>();
 }
 
-export function addMember(lobbyId: number, userId: number): Promise<LobbyDto> {
+export function updateLobby(id: number, data: LobbyUpdateDto): Promise<LobbyDto> {
+  return api.patch(`lobbies/${id}`, { json: data }).json<LobbyDto>();
+}
+
+export function getFreeSlots(
+  lobbyId: number,
+  from: string,
+  to: string,
+): Promise<FreeSlotDto[]> {
   return api
-    .post(`lobbies/${lobbyId}/members`, { searchParams: { userId } })
-    .json<LobbyDto>();
+    .get(`lobbies/${lobbyId}/free-slots`, { searchParams: { from, to } })
+    .json<FreeSlotDto[]>();
 }
 
 export function removeMember(lobbyId: number, userId: number): Promise<LobbyDto> {

--- a/lined-web/src/api/notifications.ts
+++ b/lined-web/src/api/notifications.ts
@@ -1,0 +1,45 @@
+import { api } from './client';
+import type {
+  NotificationPreferencesDto,
+  NotificationPreferencesUpdateDto,
+  LobbyNotificationPreferencesDto,
+  LobbyNotificationPreferencesUpdateDto,
+  NotificationDto,
+} from '@/types';
+
+export function getPreferences(): Promise<NotificationPreferencesDto> {
+  return api.get('notifications/preferences').json<NotificationPreferencesDto>();
+}
+
+export function updatePreferences(
+  data: NotificationPreferencesUpdateDto,
+): Promise<NotificationPreferencesDto> {
+  return api
+    .patch('notifications/preferences', { json: data })
+    .json<NotificationPreferencesDto>();
+}
+
+export function getLobbyPreferences(
+  lobbyId: number,
+): Promise<LobbyNotificationPreferencesDto> {
+  return api
+    .get(`lobbies/${lobbyId}/notification-preferences`)
+    .json<LobbyNotificationPreferencesDto>();
+}
+
+export function updateLobbyPreferences(
+  lobbyId: number,
+  data: LobbyNotificationPreferencesUpdateDto,
+): Promise<LobbyNotificationPreferencesDto> {
+  return api
+    .patch(`lobbies/${lobbyId}/notification-preferences`, { json: data })
+    .json<LobbyNotificationPreferencesDto>();
+}
+
+export function myNotifications(): Promise<NotificationDto[]> {
+  return api.get('notifications/mine').json<NotificationDto[]>();
+}
+
+export function markRead(id: number): Promise<NotificationDto> {
+  return api.patch(`notifications/${id}/read`).json<NotificationDto>();
+}

--- a/lined-web/src/api/tasks.ts
+++ b/lined-web/src/api/tasks.ts
@@ -22,3 +22,7 @@ export function updateTask(id: number, data: TaskUpdateDto): Promise<TaskDto> {
 export function deleteTask(id: number): Promise<void> {
   return api.delete(`tasks/${id}`).then(() => undefined);
 }
+
+export function listMyTasks(): Promise<TaskDto[]> {
+  return api.get('tasks/mine').json<TaskDto[]>();
+}

--- a/lined-web/src/api/users.ts
+++ b/lined-web/src/api/users.ts
@@ -18,3 +18,7 @@ export function searchUsers(q: string, page = 0, size = 20): Promise<UserPageDto
     .get('users/search', { searchParams: { q, page, size } })
     .json<UserPageDto>();
 }
+
+export function deleteUser(id: number): Promise<void> {
+  return api.delete(`users/${id}`).then(() => undefined);
+}

--- a/lined-web/src/lib/constants.ts
+++ b/lined-web/src/lib/constants.ts
@@ -31,6 +31,14 @@ export const QUERY_KEYS = {
   user: (id: number) => ['users', id] as const,
   lobbies: ['lobbies'] as const,
   lobbyDetail: (id: number) => ['lobbies', id] as const,
+  lobbyFreeSlots: (id: number) => ['lobbies', id, 'free-slots'] as const,
   tasks: ['tasks'] as const,
+  myTasks: ['tasks', 'mine'] as const,
   events: ['events'] as const,
+  lobbyInvites: (lobbyId: number) => ['lobby-invites', lobbyId] as const,
+  myInvites: ['lobby-invites', 'mine'] as const,
+  notificationPreferences: ['notifications', 'preferences'] as const,
+  lobbyNotificationPreferences: (lobbyId: number) =>
+    ['notifications', 'lobby-preferences', lobbyId] as const,
+  myNotifications: ['notifications', 'mine'] as const,
 } as const;

--- a/lined-web/src/store/auth.ts
+++ b/lined-web/src/store/auth.ts
@@ -3,14 +3,18 @@ import { persist } from 'zustand/middleware';
 
 interface AuthState {
   userId: number | null;
+  token: string | null;
   setUserId: (id: number | null) => void;
+  setToken: (token: string | null) => void;
 }
 
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       userId: null,
+      token: null,
       setUserId: (id) => set({ userId: id }),
+      setToken: (token) => set({ token }),
     }),
     { name: 'lined-auth' },
   ),

--- a/lined-web/src/test/data.ts
+++ b/lined-web/src/test/data.ts
@@ -1,4 +1,11 @@
-import type { UserDto, LobbyDto, TaskDto, EventDto } from '@/types';
+import type {
+  UserDto,
+  LobbyDto,
+  TaskDto,
+  EventDto,
+  LobbyInviteDto,
+  NotificationDto,
+} from '@/types';
 
 export const MOCK_USERS: UserDto[] = [
   {
@@ -58,6 +65,8 @@ export const MOCK_TASKS: TaskDto[] = [
   {
     id: 1,
     title: 'Plan dinner for Saturday',
+    description: 'Pick a restaurant and book a table for two',
+    priority: 'MEDIUM',
     status: 'TODO',
     lobbyId: 1,
     creatorId: 1,
@@ -68,6 +77,8 @@ export const MOCK_TASKS: TaskDto[] = [
   {
     id: 2,
     title: 'Book restaurant reservation',
+    description: null,
+    priority: 'HIGH',
     status: 'IN_PROGRESS',
     lobbyId: 1,
     creatorId: 2,
@@ -78,6 +89,8 @@ export const MOCK_TASKS: TaskDto[] = [
   {
     id: 3,
     title: 'Buy groceries',
+    description: 'Milk, bread, eggs',
+    priority: 'LOW',
     status: 'DONE',
     lobbyId: 2,
     creatorId: 1,
@@ -88,6 +101,8 @@ export const MOCK_TASKS: TaskDto[] = [
   {
     id: 4,
     title: 'Prepare presentation slides',
+    description: null,
+    priority: 'MEDIUM',
     status: 'TODO',
     lobbyId: 3,
     creatorId: 1,
@@ -98,6 +113,8 @@ export const MOCK_TASKS: TaskDto[] = [
   {
     id: 5,
     title: 'Send invitations',
+    description: null,
+    priority: 'MEDIUM',
     status: 'IN_PROGRESS',
     lobbyId: 3,
     creatorId: 2,
@@ -108,6 +125,8 @@ export const MOCK_TASKS: TaskDto[] = [
   {
     id: 6,
     title: 'Clean apartment',
+    description: null,
+    priority: 'LOW',
     status: 'TODO',
     lobbyId: 2,
     creatorId: 1,
@@ -121,6 +140,7 @@ export const MOCK_EVENTS: EventDto[] = [
   {
     id: 1,
     title: 'Morning Coffee',
+    location: 'Blue Bottle Cafe',
     shared: true,
     startAt: `${todayStr}T09:00:00Z`,
     endAt: `${todayStr}T10:00:00Z`,
@@ -132,6 +152,7 @@ export const MOCK_EVENTS: EventDto[] = [
   {
     id: 2,
     title: 'Team Lunch',
+    location: null,
     shared: true,
     startAt: `${todayStr}T12:00:00Z`,
     endAt: `${todayStr}T13:00:00Z`,
@@ -143,6 +164,7 @@ export const MOCK_EVENTS: EventDto[] = [
   {
     id: 3,
     title: 'Family Dinner',
+    location: 'Home',
     shared: true,
     startAt: `${tomorrowStr}T18:00:00Z`,
     endAt: `${tomorrowStr}T20:00:00Z`,
@@ -154,6 +176,7 @@ export const MOCK_EVENTS: EventDto[] = [
   {
     id: 4,
     title: 'Movie Night',
+    location: null,
     shared: true,
     startAt: `${tomorrowStr}T20:30:00Z`,
     endAt: `${tomorrowStr}T23:00:00Z`,
@@ -165,6 +188,7 @@ export const MOCK_EVENTS: EventDto[] = [
   {
     id: 5,
     title: 'Weekend Hike',
+    location: 'Blue Ridge Trailhead',
     shared: true,
     startAt: `${dayAfterStr}T08:00:00Z`,
     endAt: `${dayAfterStr}T12:00:00Z`,
@@ -172,5 +196,65 @@ export const MOCK_EVENTS: EventDto[] = [
     lobbyId: 3,
     ownerId: 1,
     createdAt: '2026-04-10T07:00:00Z',
+  },
+];
+
+export const MOCK_LOBBY_INVITES: LobbyInviteDto[] = [
+  {
+    id: 1,
+    lobbyId: 3,
+    inviterId: 1,
+    inviteeId: 2,
+    status: 'PENDING',
+    sentAt: '2026-07-15T10:00:00Z',
+    createdAt: '2026-07-15T10:00:00Z',
+    updatedAt: '2026-07-15T10:00:00Z',
+  },
+];
+
+export const MOCK_NOTIFICATIONS: NotificationDto[] = [
+  {
+    id: 1,
+    type: 'TASK_ASSIGNED',
+    title: 'New task assigned',
+    message: 'You were assigned "Plan dinner for Saturday"',
+    lobbyId: 1,
+    taskId: 1,
+    eventId: null,
+    readAt: null,
+    createdAt: '2026-07-15T09:00:00Z',
+    deliveries: [
+      {
+        channel: 'IN_APP',
+        status: 'DELIVERED',
+        queuedAt: '2026-07-15T09:00:00Z',
+        deliveredAt: '2026-07-15T09:00:00Z',
+      },
+      {
+        channel: 'EMAIL',
+        status: 'PENDING',
+        queuedAt: '2026-07-15T09:00:00Z',
+        deliveredAt: null,
+      },
+    ],
+  },
+  {
+    id: 2,
+    type: 'SHARED_EVENT_CREATED',
+    title: 'New shared event',
+    message: '"Family Dinner" was added to Johnson Family',
+    lobbyId: 2,
+    taskId: null,
+    eventId: 3,
+    readAt: '2026-07-15T12:00:00Z',
+    createdAt: '2026-07-15T11:00:00Z',
+    deliveries: [
+      {
+        channel: 'IN_APP',
+        status: 'DELIVERED',
+        queuedAt: '2026-07-15T11:00:00Z',
+        deliveredAt: '2026-07-15T11:00:00Z',
+      },
+    ],
   },
 ];

--- a/lined-web/src/test/handlers/auth.ts
+++ b/lined-web/src/test/handlers/auth.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw';
+import { MOCK_USERS } from '../data';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+
+export const authHandlers = [
+  http.post(`${BASE}/auth/login`, async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    const identifier = String(body['identifier'] ?? '');
+    const user = MOCK_USERS.find(
+      (u) => u.username === identifier || u.email === identifier,
+    );
+    if (!user || body['password'] === '') {
+      return HttpResponse.json(
+        { title: 'Unauthorized', detail: 'Invalid email, username, or password' },
+        { status: 401 },
+      );
+    }
+    return HttpResponse.json({
+      accessToken: `mock-token-${user.id}`,
+      tokenType: 'Bearer',
+      expiresIn: 3600,
+      userId: user.id,
+      username: user.username,
+      email: user.email,
+      roles: user.roles,
+    });
+  }),
+];

--- a/lined-web/src/test/handlers/events.ts
+++ b/lined-web/src/test/handlers/events.ts
@@ -23,9 +23,16 @@ export const eventHandlers = [
 
   http.post(`${BASE}/calendar/events`, async ({ request }) => {
     const body = (await request.json()) as Record<string, unknown>;
+    if (typeof body['title'] !== 'string' || body['title'].trim() === '') {
+      return HttpResponse.json(
+        { code: 'VALIDATION_ERROR', message: 'title must not be blank' },
+        { status: 400 },
+      );
+    }
     return HttpResponse.json(
       {
         id: 100,
+        location: null,
         ownerId: 1,
         createdAt: new Date().toISOString(),
         ...body,
@@ -38,6 +45,9 @@ export const eventHandlers = [
     const event = MOCK_EVENTS.find((e) => e.id === Number(params['id']));
     if (!event) return new HttpResponse(null, { status: 404 });
     const body = (await request.json()) as Record<string, unknown>;
+    if (typeof body['location'] === 'string' && body['location'].trim() === '') {
+      body['location'] = null;
+    }
     return HttpResponse.json({ ...event, ...body });
   }),
 

--- a/lined-web/src/test/handlers/index.ts
+++ b/lined-web/src/test/handlers/index.ts
@@ -2,10 +2,16 @@ import { userHandlers } from './users';
 import { lobbyHandlers } from './lobbies';
 import { taskHandlers } from './tasks';
 import { eventHandlers } from './events';
+import { authHandlers } from './auth';
+import { inviteHandlers } from './invites';
+import { notificationHandlers } from './notifications';
 
 export const handlers = [
   ...userHandlers,
   ...lobbyHandlers,
   ...taskHandlers,
   ...eventHandlers,
+  ...authHandlers,
+  ...inviteHandlers,
+  ...notificationHandlers,
 ];

--- a/lined-web/src/test/handlers/invites.ts
+++ b/lined-web/src/test/handlers/invites.ts
@@ -1,0 +1,101 @@
+import { http, HttpResponse } from 'msw';
+import { MOCK_LOBBY_INVITES, MOCK_LOBBIES } from '../data';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+
+export const inviteHandlers = [
+  http.post(`${BASE}/lobbies/:lobbyId/invites`, ({ params, request }) => {
+    const lobbyId = Number(params['lobbyId']);
+    const lobby = MOCK_LOBBIES.find((l) => l.id === lobbyId);
+    if (!lobby) return new HttpResponse(null, { status: 404 });
+
+    const url = new URL(request.url);
+    const userId = url.searchParams.get('userId');
+    const userEmail = url.searchParams.get('userEmail');
+    const inviteeId = userId ? Number(userId) : 2;
+
+    if (lobby.memberIds.includes(inviteeId)) {
+      return HttpResponse.json(
+        { code: 'CONFLICT', message: 'User is already a lobby member' },
+        { status: 409 },
+      );
+    }
+    const duplicate = MOCK_LOBBY_INVITES.some(
+      (i) => i.lobbyId === lobbyId && i.inviteeId === inviteeId && i.status === 'PENDING',
+    );
+    if (duplicate) {
+      return HttpResponse.json(
+        { code: 'CONFLICT', message: 'A pending invite already exists for this user' },
+        { status: 409 },
+      );
+    }
+    if (!userId && !userEmail) {
+      return HttpResponse.json(
+        { code: 'VALIDATION_ERROR', message: 'Supply exactly one of userId or userEmail' },
+        { status: 400 },
+      );
+    }
+
+    const now = new Date().toISOString();
+    return HttpResponse.json(
+      {
+        id: 500,
+        lobbyId,
+        inviterId: lobby.ownerId,
+        inviteeId,
+        status: 'PENDING',
+        sentAt: now,
+        createdAt: now,
+        updatedAt: now,
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.get(`${BASE}/lobbies/:lobbyId/invites`, ({ params }) => {
+    const lobbyId = Number(params['lobbyId']);
+    return HttpResponse.json(
+      MOCK_LOBBY_INVITES.filter((i) => i.lobbyId === lobbyId && i.status === 'PENDING'),
+    );
+  }),
+
+  http.post(`${BASE}/lobbies/:lobbyId/invites/:inviteId/resend`, ({ params }) => {
+    const invite = MOCK_LOBBY_INVITES.find((i) => i.id === Number(params['inviteId']));
+    if (!invite) return new HttpResponse(null, { status: 404 });
+    return HttpResponse.json({ ...invite, sentAt: new Date().toISOString() });
+  }),
+
+  http.delete(`${BASE}/lobbies/:lobbyId/invites/:inviteId`, ({ params }) => {
+    const exists = MOCK_LOBBY_INVITES.some((i) => i.id === Number(params['inviteId']));
+    if (!exists) return new HttpResponse(null, { status: 404 });
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.get(`${BASE}/lobby-invites/mine`, () => {
+    return HttpResponse.json(MOCK_LOBBY_INVITES.filter((i) => i.status === 'PENDING'));
+  }),
+
+  http.post(`${BASE}/lobby-invites/:inviteId/accept`, ({ params }) => {
+    const invite = MOCK_LOBBY_INVITES.find((i) => i.id === Number(params['inviteId']));
+    if (!invite) return new HttpResponse(null, { status: 404 });
+    if (invite.status !== 'PENDING') {
+      return HttpResponse.json(
+        { code: 'CONFLICT', message: 'Invite is no longer pending' },
+        { status: 409 },
+      );
+    }
+    return HttpResponse.json({ ...invite, status: 'ACCEPTED' });
+  }),
+
+  http.post(`${BASE}/lobby-invites/:inviteId/decline`, ({ params }) => {
+    const invite = MOCK_LOBBY_INVITES.find((i) => i.id === Number(params['inviteId']));
+    if (!invite) return new HttpResponse(null, { status: 404 });
+    if (invite.status !== 'PENDING') {
+      return HttpResponse.json(
+        { code: 'CONFLICT', message: 'Invite is no longer pending' },
+        { status: 409 },
+      );
+    }
+    return HttpResponse.json({ ...invite, status: 'DECLINED' });
+  }),
+];

--- a/lined-web/src/test/handlers/lobbies.ts
+++ b/lined-web/src/test/handlers/lobbies.ts
@@ -27,15 +27,32 @@ export const lobbyHandlers = [
     );
   }),
 
-  http.post(`${BASE}/lobbies/:id/members`, ({ params, request }) => {
+  http.patch(`${BASE}/lobbies/:id`, async ({ params, request }) => {
+    const lobby = MOCK_LOBBIES.find((l) => l.id === Number(params['id']));
+    if (!lobby) return new HttpResponse(null, { status: 404 });
+    const body = (await request.json()) as Record<string, unknown>;
+    if (body['ownerId'] != null && !lobby.memberIds.includes(Number(body['ownerId']))) {
+      return HttpResponse.json(
+        { code: 'CONFLICT', message: 'ownerId must be an existing lobby member' },
+        { status: 409 },
+      );
+    }
+    return HttpResponse.json({ ...lobby, ...body });
+  }),
+
+  http.get(`${BASE}/lobbies/:id/free-slots`, ({ params, request }) => {
     const lobby = MOCK_LOBBIES.find((l) => l.id === Number(params['id']));
     if (!lobby) return new HttpResponse(null, { status: 404 });
     const url = new URL(request.url);
-    const userId = Number(url.searchParams.get('userId'));
-    return HttpResponse.json({
-      ...lobby,
-      memberIds: [...lobby.memberIds, userId],
-    });
+    const from = url.searchParams.get('from');
+    const to = url.searchParams.get('to');
+    if (!from || !to) {
+      return HttpResponse.json(
+        { code: 'VALIDATION_ERROR', message: 'from and to must define a non-empty window' },
+        { status: 400 },
+      );
+    }
+    return HttpResponse.json([{ start: from, end: to }]);
   }),
 
   http.delete(`${BASE}/lobbies/:lobbyId/members/:userId`, ({ params }) => {

--- a/lined-web/src/test/handlers/notifications.ts
+++ b/lined-web/src/test/handlers/notifications.ts
@@ -1,0 +1,60 @@
+import { http, HttpResponse } from 'msw';
+import { MOCK_NOTIFICATIONS } from '../data';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+
+let mockPreferences = {
+  sharedEventsEnabled: true,
+  taskAssignedEnabled: true,
+  freeSlotsEnabled: true,
+  eventRemindersEnabled: true,
+  emailDigestsEnabled: true,
+};
+
+const mockLobbyPreferences = new Map<number, Record<string, boolean | number>>();
+
+function getLobbyPreferences(lobbyId: number) {
+  return (
+    mockLobbyPreferences.get(lobbyId) ?? {
+      lobbyId,
+      newEventsEnabled: true,
+      taskUpdatesEnabled: true,
+      freeSlotsEnabled: true,
+    }
+  );
+}
+
+export const notificationHandlers = [
+  http.get(`${BASE}/notifications/preferences`, () => {
+    return HttpResponse.json(mockPreferences);
+  }),
+
+  http.patch(`${BASE}/notifications/preferences`, async ({ request }) => {
+    const body = (await request.json()) as Partial<typeof mockPreferences>;
+    mockPreferences = { ...mockPreferences, ...body };
+    return HttpResponse.json(mockPreferences);
+  }),
+
+  http.get(`${BASE}/lobbies/:lobbyId/notification-preferences`, ({ params }) => {
+    const lobbyId = Number(params['lobbyId']);
+    return HttpResponse.json(getLobbyPreferences(lobbyId));
+  }),
+
+  http.patch(`${BASE}/lobbies/:lobbyId/notification-preferences`, async ({ params, request }) => {
+    const lobbyId = Number(params['lobbyId']);
+    const body = (await request.json()) as Record<string, boolean>;
+    const updated = { ...getLobbyPreferences(lobbyId), ...body, lobbyId };
+    mockLobbyPreferences.set(lobbyId, updated);
+    return HttpResponse.json(updated);
+  }),
+
+  http.get(`${BASE}/notifications/mine`, () => {
+    return HttpResponse.json(MOCK_NOTIFICATIONS);
+  }),
+
+  http.patch(`${BASE}/notifications/:id/read`, ({ params }) => {
+    const notification = MOCK_NOTIFICATIONS.find((n) => n.id === Number(params['id']));
+    if (!notification) return new HttpResponse(null, { status: 404 });
+    return HttpResponse.json({ ...notification, readAt: new Date().toISOString() });
+  }),
+];

--- a/lined-web/src/test/handlers/tasks.ts
+++ b/lined-web/src/test/handlers/tasks.ts
@@ -21,11 +21,23 @@ export const taskHandlers = [
     return HttpResponse.json(tasks);
   }),
 
+  http.get(`${BASE}/tasks/mine`, () => {
+    return HttpResponse.json(MOCK_TASKS);
+  }),
+
   http.post(`${BASE}/tasks`, async ({ request }) => {
     const body = (await request.json()) as Record<string, unknown>;
+    if (typeof body['title'] !== 'string' || body['title'].trim() === '') {
+      return HttpResponse.json(
+        { code: 'VALIDATION_ERROR', message: 'title must not be blank' },
+        { status: 400 },
+      );
+    }
     return HttpResponse.json(
       {
         id: 100,
+        description: null,
+        priority: 'MEDIUM',
         status: 'TODO',
         creatorId: 1,
         assigneeId: null,

--- a/lined-web/src/test/handlers/users.ts
+++ b/lined-web/src/test/handlers/users.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import { MOCK_USERS } from '../data';
+import { MOCK_USERS, MOCK_LOBBIES } from '../data';
 
 const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
 
@@ -29,6 +29,15 @@ export const userHandlers = [
 
   http.post(`${BASE}/users`, async ({ request }) => {
     const body = (await request.json()) as Record<string, unknown>;
+    const taken = MOCK_USERS.some(
+      (u) => u.username === body['username'] || u.email === body['email'],
+    );
+    if (taken) {
+      return HttpResponse.json(
+        { code: 'EMAIL_EXISTS', message: 'Username or email already registered' },
+        { status: 409 },
+      );
+    }
     return HttpResponse.json(
       {
         id: 99,
@@ -40,5 +49,18 @@ export const userHandlers = [
       },
       { status: 201 },
     );
+  }),
+
+  http.delete(`${BASE}/users/:id`, ({ params }) => {
+    const user = MOCK_USERS.find((u) => u.id === Number(params['id']));
+    if (!user) return new HttpResponse(null, { status: 404 });
+    const ownsLobby = MOCK_LOBBIES.some((l) => l.ownerId === user.id);
+    if (ownsLobby) {
+      return HttpResponse.json(
+        { code: 'CONFLICT', message: 'Account owns one or more lobbies' },
+        { status: 409 },
+      );
+    }
+    return new HttpResponse(null, { status: 204 });
   }),
 ];

--- a/lined-web/src/types/index.ts
+++ b/lined-web/src/types/index.ts
@@ -4,6 +4,16 @@ export type LobbyType = 'COUPLE' | 'FAMILY' | 'FRIENDS' | 'WORK';
 
 export type TaskStatus = 'TODO' | 'IN_PROGRESS' | 'DONE';
 
+export type TaskPriority = 'HIGH' | 'MEDIUM' | 'LOW';
+
+export type LobbyInviteStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'CANCELLED';
+
+export type NotificationType = 'TASK_ASSIGNED' | 'SHARED_EVENT_CREATED';
+
+export type NotificationDeliveryChannel = 'IN_APP' | 'EMAIL' | 'PUSH';
+
+export type NotificationDeliveryStatus = 'PENDING' | 'DELIVERED';
+
 // --- User ---
 
 export interface UserDto {
@@ -61,11 +71,37 @@ export interface LobbyCreateDto {
   lobbyType: LobbyType;
 }
 
+export interface LobbyUpdateDto {
+  name?: string;
+  lobbyType?: LobbyType;
+  ownerId?: number;
+}
+
+export interface FreeSlotDto {
+  start: string;
+  end: string;
+}
+
+// --- Lobby invite ---
+
+export interface LobbyInviteDto {
+  id: number;
+  lobbyId: number;
+  inviterId: number;
+  inviteeId: number;
+  status: LobbyInviteStatus;
+  sentAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 // --- Task ---
 
 export interface TaskDto {
   id: number;
   title: string;
+  description: string | null;
+  priority: TaskPriority;
   status: TaskStatus;
   lobbyId: number;
   creatorId: number;
@@ -79,6 +115,10 @@ export interface TaskCreateDto {
   lobbyId: number;
   assigneeId?: number;
   dueDate?: string;
+  description?: string;
+  priority?: TaskPriority;
+  status?: TaskStatus;
+  notifyAssignee?: boolean;
 }
 
 export interface TaskUpdateDto {
@@ -86,6 +126,8 @@ export interface TaskUpdateDto {
   assigneeId?: number;
   dueDate?: string;
   title?: string;
+  description?: string;
+  priority?: TaskPriority;
 }
 
 // --- Event ---
@@ -93,6 +135,7 @@ export interface TaskUpdateDto {
 export interface EventDto {
   id: number;
   title: string;
+  location: string | null;
   shared: boolean;
   startAt: string;
   endAt: string;
@@ -104,15 +147,19 @@ export interface EventDto {
 
 export interface EventCreateDto {
   title: string;
+  location?: string;
   shared: boolean;
   startAt: string;
   endAt: string;
   timezone: string;
   lobbyId: number;
+  notifyMembers?: boolean;
 }
 
 export interface EventUpdateDto {
   title?: string;
+  /** Omit to keep the current location; send '' to clear it. */
+  location?: string;
   shared?: boolean;
   startAt?: string;
   endAt?: string;
@@ -160,4 +207,64 @@ export interface SubscriptionDto {
 export interface RoleDto {
   id: number;
   name: string;
+}
+
+// --- Auth ---
+
+export interface LoginRequestDto {
+  identifier: string;
+  password: string;
+}
+
+export interface LoginResponseDto {
+  accessToken: string;
+  tokenType: string;
+  expiresIn: number;
+  userId: number;
+  username: string;
+  email: string;
+  roles: string[];
+}
+
+// --- Notifications ---
+
+export interface NotificationPreferencesDto {
+  sharedEventsEnabled: boolean;
+  taskAssignedEnabled: boolean;
+  freeSlotsEnabled: boolean;
+  eventRemindersEnabled: boolean;
+  emailDigestsEnabled: boolean;
+}
+
+export type NotificationPreferencesUpdateDto = Partial<NotificationPreferencesDto>;
+
+export interface LobbyNotificationPreferencesDto {
+  lobbyId: number;
+  newEventsEnabled: boolean;
+  taskUpdatesEnabled: boolean;
+  freeSlotsEnabled: boolean;
+}
+
+export type LobbyNotificationPreferencesUpdateDto = Partial<
+  Omit<LobbyNotificationPreferencesDto, 'lobbyId'>
+>;
+
+export interface NotificationDeliveryDto {
+  channel: NotificationDeliveryChannel;
+  status: NotificationDeliveryStatus;
+  queuedAt: string;
+  deliveredAt: string | null;
+}
+
+export interface NotificationDto {
+  id: number;
+  type: NotificationType;
+  title: string;
+  message: string;
+  lobbyId: number | null;
+  taskId: number | null;
+  eventId: number | null;
+  readAt: string | null;
+  createdAt: string;
+  deliveries: NotificationDeliveryDto[];
 }


### PR DESCRIPTION
## Summary

Migrates `lined-web`'s API layer, types, and MSW mocks to the July 2026
backend contract (`backend/lined/docs/api.md`), per
[docs/tasks/UI-15-api-contract-refresh.md](lined-web/docs/tasks/UI-15-api-contract-refresh.md).
This is the first task in the plan — every remaining UI task builds on this
layer. No UI/visual changes (the task spec explicitly marks the mockup
reference "Not applicable").

- **Breaking change:** `POST /api/lobbies/{id}/members` was removed by the
  backend. `addMember()` is deleted from `src/api/lobbies.ts`; membership now
  goes through a new invite flow (`src/api/invites.ts`), matching the
  backend's `LobbyInviteController`.
- **New API modules:** `src/api/auth.ts` (`login`), `src/api/invites.ts`
  (create/list/resend/cancel/mine/accept/decline), `src/api/notifications.ts`
  (global + per-lobby preferences, inbox, mark-read).
- **Extended types/API:** `TaskDto`/`TaskCreateDto`/`TaskUpdateDto` gain
  `description`, `priority`, `notifyAssignee`; `EventDto`/`Create`/`Update`
  gain `location`, `notifyMembers`; added `updateLobby()`, `getFreeSlots()`,
  `listMyTasks()`, `deleteUser()`.
- Auth store gains a `token` field alongside the existing `userId` (the
  backend still accepts `X-User-Id`, which stays the active auth header).
- **MSW handlers** updated/added for the full new surface, including
  negative-path coverage: 401 on bad login, 409 on duplicate
  username/pending invite/existing member/lobby-owner delete, 400 on blank
  title / invalid free-slot window, 404s throughout.
- Task 15 flipped to `DONE` in `docs/UI_TASKS.md`.

## Test plan

All from `lined-web/` (Node 22):
- [x] `npm run lint` — passes
- [x] `npm run typecheck` — passes
- [x] `npm run test:run` — 4/4 tests pass
- [x] `npm run build` — succeeds
- [x] Verified no remaining references to `addMember` / the removed
      `/lobbies/:id/members` POST endpoint (`grep -rn` clean)

No screenshots — this PR touches `src/api/`, `src/types/`, `src/store/auth.ts`,
`src/lib/constants.ts`, and `src/test/` only; no component/page changed.