### PR TITLE
feat(web): lobby detail header, tabs, and Tasks tab (UI-05)

### DIFF
--- a/lined-web/docs/UI_TASKS.md
+++ b/lined-web/docs/UI_TASKS.md
@@ -37,15 +37,16 @@ exist for every task, including `create-lobby` (task 4), `calendar-month`
 - **Global Calendar page (week view)** — `CalendarTopBar`, `WeekGrid` (with client-side free-slot bands), `EventDetailPanel`, `CreateEventModal`, delete event. Missing: month view, edit event, legend.
 - **"+ Create" dropdown & Create Lobby modal** — `CreateMenu`, `CreateLobbyModal`, `LobbyTypePicker`, `useCreateLobby`; New Task / Reserve Free Slot only flip store state until Tasks 8/11 land.
 - Zustand stores: `auth` (persisted userId), `calendar` (view state), `createMenu` (create-lobby + event/task/reserveSlot overlay state)
-- Hooks: `useMyLobbies`, `useLobby`, `useCreateLobby`, `useWeekEvents`, `useCreateEvent`, `useDeleteEvent`
+- Hooks: `useMyLobbies`, `useLobby`, `useCreateLobby`, `useWeekEvents`, `useCreateEvent`, `useDeleteEvent`, `useUsers`, `useLobbyTasks`, `useUpdateTask`
 - MSW handlers + smoke tests
+- **Lobby detail page** — `LobbyHeader`, `LobbyTabBar`, `LobbyTaskList`, `TaskRow`: type-accent header with resolved member avatars, `?tab=`-synced tab bar, and a live Tasks tab (filter pills with counts, due-date sort, checkbox status toggle). Calendar/Members tabs remain "coming soon" placeholders until Tasks 6/7.
 
 **Stubs only ("coming soon" placeholders):**
-SignInPage, SignUpPage, DashboardPage, LobbyPage, TasksPage,
+SignInPage, SignUpPage, DashboardPage, TasksPage,
 UserSettingsPage, LobbySettingsPage.
 
 **Not started:** AddTaskDrawer, AddMemberModal, ReserveSlotModal, kanban
-board, lobby header/tabs/members.
+board, lobby calendar/members tabs.
 
 ## Backend API summary
 
@@ -77,7 +78,7 @@ board, lobby header/tabs/members.
 | 2 | `feature/ui-02-sidebar-live-data` | Sidebar: real lobbies + real current user from API, "+ New" lobby entry point | [tasks/UI-02-sidebar-live-data.md](tasks/UI-02-sidebar-live-data.md) | DONE |
 | 3 | `feature/ui-03-dashboard` | Dashboard page: lobby cards, upcoming events, my tasks, free-slot banner | [tasks/UI-03-dashboard.md](tasks/UI-03-dashboard.md) | DONE |
 | 4 | `feature/ui-04-create-menu-lobby-modal` | "+ Create" dropdown menu and Create Lobby modal (type picker) | [tasks/UI-04-create-menu-lobby-modal.md](tasks/UI-04-create-menu-lobby-modal.md) | DONE |
-| 5 | `feature/ui-05-lobby-tasks-tab` | Lobby detail page: header, tab bar, Tasks tab (filter pills, task rows) | [tasks/UI-05-lobby-tasks-tab.md](tasks/UI-05-lobby-tasks-tab.md) | TODO |
+| 5 | `feature/ui-05-lobby-tasks-tab` | Lobby detail page: header, tab bar, Tasks tab (filter pills, task rows) | [tasks/UI-05-lobby-tasks-tab.md](tasks/UI-05-lobby-tasks-tab.md) | DONE |
 | 6 | `feature/ui-06-lobby-members` | Lobby Members tab + Add Member modal (user search, invite, remove) | [tasks/UI-06-lobby-members.md](tasks/UI-06-lobby-members.md) | TODO |
 | 7 | `feature/ui-07-lobby-calendar` | Lobby Calendar tab (week grid scoped to lobby, free-slot bands) | [tasks/UI-07-lobby-calendar.md](tasks/UI-07-lobby-calendar.md) | TODO |
 | 8 | `feature/ui-08-add-task-drawer` | Add Task drawer (title, assignee picker, due date, status) | [tasks/UI-08-add-task-drawer.md](tasks/UI-08-add-task-drawer.md) | TODO |

--- a/lined-web/src/components/LobbyTypePicker.tsx
+++ b/lined-web/src/components/LobbyTypePicker.tsx
@@ -1,17 +1,10 @@
 import type { LobbyType } from '@/types';
-import { LOBBY_TYPE_LABELS } from '@/lib/constants';
+import { LOBBY_TYPE_ICONS, LOBBY_TYPE_LABELS } from '@/lib/constants';
 
 interface LobbyTypePickerProps {
   value: LobbyType;
   onChange: (type: LobbyType) => void;
 }
-
-const LOBBY_TYPE_ICONS: Record<LobbyType, string> = {
-  COUPLE: '💑',
-  FAMILY: '👨‍👩‍👧‍👦',
-  FRIENDS: '🎉',
-  WORK: '💼',
-};
 
 const LOBBY_TYPES: LobbyType[] = ['COUPLE', 'FAMILY', 'FRIENDS', 'WORK'];
 

--- a/lined-web/src/components/lobby/LobbyHeader.tsx
+++ b/lined-web/src/components/lobby/LobbyHeader.tsx
@@ -1,0 +1,79 @@
+import { Link } from 'react-router-dom';
+import type { LobbyDto } from '@/types';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import {
+  LOBBY_TYPE_BADGE_CLASSES,
+  LOBBY_TYPE_BORDER_CLASSES,
+  LOBBY_TYPE_ICONS,
+  LOBBY_TYPE_LABELS,
+} from '@/lib/constants';
+import { useUsers } from '@/hooks/useUsers';
+
+const MAX_AVATARS_SHOWN = 4;
+
+interface LobbyHeaderProps {
+  lobby: LobbyDto;
+}
+
+export const LobbyHeader = ({ lobby }: LobbyHeaderProps) => {
+  const memberQueries = useUsers(lobby.memberIds);
+  const shown = memberQueries.slice(0, MAX_AVATARS_SHOWN);
+
+  return (
+    <div className={`border-t-4 bg-white ${LOBBY_TYPE_BORDER_CLASSES[lobby.lobbyType]}`}>
+      <div className="flex items-center justify-between gap-4 p-6">
+        <div className="flex items-center gap-4">
+          <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-xl bg-gray-100 text-2xl">
+            {LOBBY_TYPE_ICONS[lobby.lobbyType]}
+          </div>
+          <div>
+            <h1 className="text-lg font-semibold text-text-primary">{lobby.name}</h1>
+            <div className="mt-1 flex items-center gap-2">
+              <div className="flex -space-x-2" data-testid="lobby-member-avatars">
+                {shown.map((query, i) => (
+                  <Avatar key={lobby.memberIds[i]} size="sm" className="ring-2 ring-white">
+                    {query.isLoading && (
+                      <AvatarFallback className="animate-pulse bg-gray-200" />
+                    )}
+                    {!query.isLoading && query.data && (
+                      <AvatarFallback className="bg-brand-green text-xs font-semibold text-white">
+                        {query.data.username.charAt(0).toUpperCase()}
+                      </AvatarFallback>
+                    )}
+                    {!query.isLoading && !query.data && (
+                      <AvatarFallback className="bg-gray-300 text-xs font-semibold text-white">
+                        ?
+                      </AvatarFallback>
+                    )}
+                  </Avatar>
+                ))}
+              </div>
+              <span className="text-xs text-text-secondary">
+                {lobby.memberIds.length} member{lobby.memberIds.length === 1 ? '' : 's'}
+              </span>
+              <span
+                className={`w-fit rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${LOBBY_TYPE_BADGE_CLASSES[lobby.lobbyType]}`}
+              >
+                {LOBBY_TYPE_LABELS[lobby.lobbyType]}
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-shrink-0 items-center gap-2">
+          <button
+            type="button"
+            className="rounded-lg border border-border px-3 py-2 text-sm font-medium text-text-primary hover:bg-gray-50"
+          >
+            + Add member
+          </button>
+          <Link
+            to={`/lobbies/${lobby.id}/settings`}
+            className="rounded-lg border border-border px-3 py-2 text-sm font-medium text-text-primary hover:bg-gray-50"
+          >
+            ⚙ Settings
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/lined-web/src/components/lobby/LobbyTabBar.tsx
+++ b/lined-web/src/components/lobby/LobbyTabBar.tsx
@@ -1,0 +1,42 @@
+import type { LobbyType } from '@/types';
+import { LOBBY_TYPE_BORDER_CLASSES } from '@/lib/constants';
+
+export type LobbyTab = 'calendar' | 'tasks' | 'members';
+
+const TABS: { id: LobbyTab; label: string; emoji: string }[] = [
+  { id: 'calendar', label: 'Calendar', emoji: '📅' },
+  { id: 'tasks', label: 'Tasks', emoji: '✅' },
+  { id: 'members', label: 'Members', emoji: '👥' },
+];
+
+interface LobbyTabBarProps {
+  lobbyType: LobbyType;
+  activeTab: LobbyTab;
+  onTabChange: (tab: LobbyTab) => void;
+}
+
+export const LobbyTabBar = ({ lobbyType, activeTab, onTabChange }: LobbyTabBarProps) => {
+  return (
+    <div role="tablist" className="flex gap-6 border-b border-border bg-white px-6">
+      {TABS.map((tab) => {
+        const isActive = tab.id === activeTab;
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onTabChange(tab.id)}
+            className={`border-b-2 px-1 py-3 text-sm font-medium transition-colors ${
+              isActive
+                ? `${LOBBY_TYPE_BORDER_CLASSES[lobbyType]} text-text-primary`
+                : 'border-transparent text-text-secondary hover:text-text-primary'
+            }`}
+          >
+            {tab.emoji} {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/lined-web/src/components/lobby/LobbyTaskList.tsx
+++ b/lined-web/src/components/lobby/LobbyTaskList.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+import type { TaskDto, TaskStatus } from '@/types';
+import { useLobbyTasks, useUpdateTask } from '@/hooks/useTasks';
+import { useUsers } from '@/hooks/useUsers';
+import { useCreateMenuStore } from '@/store/createMenu';
+import { TASK_STATUS_LABELS } from '@/lib/constants';
+import { TaskRow } from './TaskRow';
+
+type FilterId = 'ALL' | TaskStatus;
+
+const FILTERS: { id: FilterId; label: string }[] = [
+  { id: 'ALL', label: 'All' },
+  { id: 'TODO', label: TASK_STATUS_LABELS.TODO },
+  { id: 'IN_PROGRESS', label: TASK_STATUS_LABELS.IN_PROGRESS },
+  { id: 'DONE', label: TASK_STATUS_LABELS.DONE },
+];
+
+const sortByDueDate = (tasks: TaskDto[]): TaskDto[] =>
+  [...tasks].sort((a, b) => {
+    if ((a.status === 'DONE') !== (b.status === 'DONE')) {
+      return a.status === 'DONE' ? 1 : -1;
+    }
+    if (a.dueDate == null && b.dueDate == null) return 0;
+    if (a.dueDate == null) return 1;
+    if (b.dueDate == null) return -1;
+    return a.dueDate.localeCompare(b.dueDate);
+  });
+
+interface LobbyTaskListProps {
+  lobbyId: number;
+}
+
+export const LobbyTaskList = ({ lobbyId }: LobbyTaskListProps) => {
+  const { data: tasks, isLoading, isError } = useLobbyTasks(lobbyId);
+  const updateTask = useUpdateTask(lobbyId);
+  const openOverlay = useCreateMenuStore((s) => s.openOverlay);
+  const [filter, setFilter] = useState<FilterId>('ALL');
+  const [updatingTaskId, setUpdatingTaskId] = useState<number | null>(null);
+  const [rowErrors, setRowErrors] = useState<Record<number, string>>({});
+
+  const assigneeIds = Array.from(
+    new Set((tasks ?? []).map((t) => t.assigneeId).filter((id): id is number => id != null)),
+  );
+  const assigneeQueries = useUsers(assigneeIds);
+  const assigneesById = new Map(assigneeIds.map((id, i) => [id, assigneeQueries[i]?.data]));
+
+  const counts: Record<FilterId, number> = {
+    ALL: tasks?.length ?? 0,
+    TODO: tasks?.filter((t) => t.status === 'TODO').length ?? 0,
+    IN_PROGRESS: tasks?.filter((t) => t.status === 'IN_PROGRESS').length ?? 0,
+    DONE: tasks?.filter((t) => t.status === 'DONE').length ?? 0,
+  };
+
+  const filtered = (tasks ?? []).filter((t) => filter === 'ALL' || t.status === filter);
+  const sorted = sortByDueDate(filtered);
+
+  const handleToggle = (task: TaskDto) => {
+    const nextStatus: TaskStatus = task.status === 'DONE' ? 'TODO' : 'DONE';
+    setUpdatingTaskId(task.id);
+    setRowErrors((prev) => {
+      if (!(task.id in prev)) return prev;
+      const next = { ...prev };
+      delete next[task.id];
+      return next;
+    });
+    updateTask.mutate(
+      { id: task.id, data: { status: nextStatus } },
+      {
+        onSettled: () => setUpdatingTaskId(null),
+        onError: () =>
+          setRowErrors((prev) => ({ ...prev, [task.id]: "Couldn't update — try again" })),
+      },
+    );
+  };
+
+  return (
+    <div className="p-6">
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        {FILTERS.map((f) => (
+          <button
+            key={f.id}
+            type="button"
+            onClick={() => setFilter(f.id)}
+            aria-pressed={filter === f.id}
+            className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+              filter === f.id
+                ? 'bg-brand-green text-white'
+                : 'bg-white text-text-secondary hover:bg-gray-50'
+            }`}
+          >
+            {f.label} ({counts[f.id]})
+          </button>
+        ))}
+        <span className="ml-auto text-xs text-text-secondary">Sort: Due date</span>
+      </div>
+
+      {isLoading && (
+        <div className="flex flex-col gap-2" data-testid="lobby-tasks-loading">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="h-16 animate-pulse rounded-lg bg-white" />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && isError && (
+        <p className="text-sm text-text-secondary">Couldn&apos;t load tasks. Try again later.</p>
+      )}
+
+      {!isLoading && !isError && tasks != null && tasks.length === 0 && (
+        <p className="text-sm text-text-secondary">No tasks yet.</p>
+      )}
+
+      {!isLoading && !isError && tasks != null && tasks.length > 0 && sorted.length === 0 && (
+        <p className="text-sm text-text-secondary">No tasks match this filter.</p>
+      )}
+
+      {!isLoading && !isError && sorted.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {sorted.map((task) => (
+            <TaskRow
+              key={task.id}
+              task={task}
+              assignee={task.assigneeId != null ? assigneesById.get(task.assigneeId) : undefined}
+              onToggle={handleToggle}
+              isUpdating={updatingTaskId === task.id}
+              updateError={rowErrors[task.id]}
+            />
+          ))}
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={() => openOverlay('task')}
+        className="mt-4 w-full rounded-lg border-2 border-dashed border-border py-2.5 text-sm font-medium text-text-secondary hover:border-brand-green hover:text-brand-green"
+      >
+        + Add task
+      </button>
+    </div>
+  );
+};

--- a/lined-web/src/components/lobby/LobbyTaskList.tsx
+++ b/lined-web/src/components/lobby/LobbyTaskList.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { TaskDto, TaskStatus } from '@/types';
+import type { TaskDto, TaskStatus, UserDto } from '@/types';
 import { useLobbyTasks, useUpdateTask } from '@/hooks/useTasks';
 import { useUsers } from '@/hooks/useUsers';
 import { useCreateMenuStore } from '@/store/createMenu';
@@ -25,6 +25,67 @@ const sortByDueDate = (tasks: TaskDto[]): TaskDto[] =>
     if (b.dueDate == null) return -1;
     return a.dueDate.localeCompare(b.dueDate);
   });
+
+interface TaskListContentProps {
+  isLoading: boolean;
+  isError: boolean;
+  tasks: TaskDto[] | undefined;
+  sorted: TaskDto[];
+  assigneesById: Map<number, UserDto | undefined>;
+  updatingTaskId: number | null;
+  rowErrors: Record<number, string>;
+  onToggle: (task: TaskDto) => void;
+}
+
+const TaskListContent = ({
+  isLoading,
+  isError,
+  tasks,
+  sorted,
+  assigneesById,
+  updatingTaskId,
+  rowErrors,
+  onToggle,
+}: TaskListContentProps) => {
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-2" data-testid="lobby-tasks-loading">
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="h-16 animate-pulse rounded-lg bg-white" />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="text-sm text-text-secondary">Couldn&apos;t load tasks. Try again later.</p>
+    );
+  }
+
+  if (tasks != null && tasks.length === 0) {
+    return <p className="text-sm text-text-secondary">No tasks yet.</p>;
+  }
+
+  if (sorted.length === 0) {
+    return <p className="text-sm text-text-secondary">No tasks match this filter.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {sorted.map((task) => (
+        <TaskRow
+          key={task.id}
+          task={task}
+          assignee={task.assigneeId != null ? assigneesById.get(task.assigneeId) : undefined}
+          onToggle={onToggle}
+          isUpdating={updatingTaskId === task.id}
+          updateError={rowErrors[task.id]}
+        />
+      ))}
+    </div>
+  );
+};
 
 interface LobbyTaskListProps {
   lobbyId: number;
@@ -94,40 +155,16 @@ export const LobbyTaskList = ({ lobbyId }: LobbyTaskListProps) => {
         <span className="ml-auto text-xs text-text-secondary">Sort: Due date</span>
       </div>
 
-      {isLoading && (
-        <div className="flex flex-col gap-2" data-testid="lobby-tasks-loading">
-          {[0, 1, 2].map((i) => (
-            <div key={i} className="h-16 animate-pulse rounded-lg bg-white" />
-          ))}
-        </div>
-      )}
-
-      {!isLoading && isError && (
-        <p className="text-sm text-text-secondary">Couldn&apos;t load tasks. Try again later.</p>
-      )}
-
-      {!isLoading && !isError && tasks != null && tasks.length === 0 && (
-        <p className="text-sm text-text-secondary">No tasks yet.</p>
-      )}
-
-      {!isLoading && !isError && tasks != null && tasks.length > 0 && sorted.length === 0 && (
-        <p className="text-sm text-text-secondary">No tasks match this filter.</p>
-      )}
-
-      {!isLoading && !isError && sorted.length > 0 && (
-        <div className="flex flex-col gap-2">
-          {sorted.map((task) => (
-            <TaskRow
-              key={task.id}
-              task={task}
-              assignee={task.assigneeId != null ? assigneesById.get(task.assigneeId) : undefined}
-              onToggle={handleToggle}
-              isUpdating={updatingTaskId === task.id}
-              updateError={rowErrors[task.id]}
-            />
-          ))}
-        </div>
-      )}
+      <TaskListContent
+        isLoading={isLoading}
+        isError={isError}
+        tasks={tasks}
+        sorted={sorted}
+        assigneesById={assigneesById}
+        updatingTaskId={updatingTaskId}
+        rowErrors={rowErrors}
+        onToggle={handleToggle}
+      />
 
       <button
         type="button"

--- a/lined-web/src/components/lobby/TaskRow.tsx
+++ b/lined-web/src/components/lobby/TaskRow.tsx
@@ -11,6 +11,20 @@ interface TaskRowProps {
   updateError?: string;
 }
 
+const AssigneeAvatarFallback = ({ assignee }: { assignee: UserDto | undefined }) => {
+  if (!assignee) {
+    return (
+      <AvatarFallback className="bg-gray-300 text-xs font-semibold text-white">?</AvatarFallback>
+    );
+  }
+
+  return (
+    <AvatarFallback className="bg-brand-green text-xs font-semibold text-white">
+      {assignee.username.charAt(0).toUpperCase()}
+    </AvatarFallback>
+  );
+};
+
 export const TaskRow = ({ task, assignee, onToggle, isUpdating, updateError }: TaskRowProps) => {
   const isDone = task.status === 'DONE';
   const due = formatTaskDueDate(task.dueDate, task.status);
@@ -52,15 +66,7 @@ export const TaskRow = ({ task, assignee, onToggle, isUpdating, updateError }: T
       <div className="flex flex-shrink-0 items-center gap-3">
         <StatusBadge status={task.status} />
         <Avatar size="sm">
-          {assignee ? (
-            <AvatarFallback className="bg-brand-green text-xs font-semibold text-white">
-              {assignee.username.charAt(0).toUpperCase()}
-            </AvatarFallback>
-          ) : (
-            <AvatarFallback className="bg-gray-300 text-xs font-semibold text-white">
-              ?
-            </AvatarFallback>
-          )}
+          <AssigneeAvatarFallback assignee={assignee} />
         </Avatar>
         <span
           className={`w-16 text-right text-xs ${

--- a/lined-web/src/components/lobby/TaskRow.tsx
+++ b/lined-web/src/components/lobby/TaskRow.tsx
@@ -1,0 +1,75 @@
+import type { TaskDto, UserDto } from '@/types';
+import { formatTaskDueDate } from '@/lib/calendarUtils';
+import { StatusBadge } from '@/components/dashboard/StatusBadge';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+
+interface TaskRowProps {
+  task: TaskDto;
+  assignee: UserDto | undefined;
+  onToggle: (task: TaskDto) => void;
+  isUpdating: boolean;
+  updateError?: string;
+}
+
+export const TaskRow = ({ task, assignee, onToggle, isUpdating, updateError }: TaskRowProps) => {
+  const isDone = task.status === 'DONE';
+  const due = formatTaskDueDate(task.dueDate, task.status);
+
+  return (
+    <div
+      className={`flex items-center gap-4 rounded-lg bg-white p-4 shadow-[var(--shadow-sm)] ${
+        isDone ? 'opacity-70' : ''
+      }`}
+    >
+      <button
+        type="button"
+        role="checkbox"
+        aria-checked={isDone}
+        aria-label={isDone ? `Mark "${task.title}" as to do` : `Mark "${task.title}" as done`}
+        disabled={isUpdating}
+        onClick={() => onToggle(task)}
+        className={`flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md border-2 text-xs text-white disabled:opacity-50 ${
+          isDone ? 'border-task-done bg-task-done' : 'border-border bg-white'
+        }`}
+      >
+        {isDone && '✓'}
+      </button>
+
+      <div className="min-w-0 flex-1">
+        <p
+          className={`text-sm font-medium ${
+            isDone ? 'text-text-muted line-through' : 'text-text-primary'
+          }`}
+        >
+          {task.title}
+        </p>
+        {task.description && (
+          <p className="mt-0.5 truncate text-xs text-text-secondary">{task.description}</p>
+        )}
+        {updateError && <p className="mt-0.5 text-xs text-red-500">{updateError}</p>}
+      </div>
+
+      <div className="flex flex-shrink-0 items-center gap-3">
+        <StatusBadge status={task.status} />
+        <Avatar size="sm">
+          {assignee ? (
+            <AvatarFallback className="bg-brand-green text-xs font-semibold text-white">
+              {assignee.username.charAt(0).toUpperCase()}
+            </AvatarFallback>
+          ) : (
+            <AvatarFallback className="bg-gray-300 text-xs font-semibold text-white">
+              ?
+            </AvatarFallback>
+          )}
+        </Avatar>
+        <span
+          className={`w-16 text-right text-xs ${
+            due.isUrgent ? 'font-semibold text-red-500' : isDone ? 'text-text-muted' : 'text-text-secondary'
+          }`}
+        >
+          {due.label}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/lined-web/src/components/lobby/__tests__/LobbyHeader.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/LobbyHeader.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders, screen } from '@/test/utils';
+import { server } from '@/test/server';
+import { MOCK_LOBBIES } from '@/test/data';
+import { LobbyHeader } from '../LobbyHeader';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+const lobby = MOCK_LOBBIES[0]!; // COUPLE, memberIds [1, 2]
+
+describe('LobbyHeader', () => {
+  it('renders the lobby name, type badge, and settings/add-member actions', async () => {
+    expect.assertions(4);
+    renderWithProviders(<LobbyHeader lobby={lobby} />);
+
+    expect(screen.getByText(lobby.name)).toBeInTheDocument();
+    expect(screen.getByText('Couple')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+ Add member' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '⚙ Settings' })).toHaveAttribute(
+      'href',
+      `/lobbies/${lobby.id}/settings`,
+    );
+  });
+
+  it('resolves and renders member avatars with the member count', async () => {
+    expect.assertions(2);
+    renderWithProviders(<LobbyHeader lobby={lobby} />);
+
+    expect(await screen.findByText('2 members')).toBeInTheDocument();
+    const avatars = screen.getByTestId('lobby-member-avatars');
+    expect(avatars.children).toHaveLength(2);
+  });
+
+  it('falls back to a placeholder avatar when a member profile fails to load', async () => {
+    expect.assertions(1);
+    server.use(
+      http.get(`${BASE}/users/:id`, ({ params }) => {
+        if (params['id'] === '2') return new HttpResponse(null, { status: 500 });
+        const user = { id: 1, username: 'alex_johnson', email: 'alex@lined.app' };
+        return HttpResponse.json(user);
+      }),
+    );
+    renderWithProviders(<LobbyHeader lobby={lobby} />);
+
+    const avatars = await screen.findByText('?');
+    expect(avatars).toBeInTheDocument();
+  });
+});

--- a/lined-web/src/components/lobby/__tests__/LobbyTabBar.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/LobbyTabBar.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
+import { LobbyTabBar } from '../LobbyTabBar';
+
+describe('LobbyTabBar', () => {
+  it('renders all three tabs with their emoji labels', () => {
+    expect.assertions(3);
+    renderWithProviders(
+      <LobbyTabBar lobbyType="COUPLE" activeTab="tasks" onTabChange={vi.fn()} />,
+    );
+
+    expect(screen.getByRole('tab', { name: '📅 Calendar' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '✅ Tasks' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '👥 Members' })).toBeInTheDocument();
+  });
+
+  it('marks the active tab as selected', () => {
+    expect.assertions(2);
+    renderWithProviders(
+      <LobbyTabBar lobbyType="COUPLE" activeTab="calendar" onTabChange={vi.fn()} />,
+    );
+
+    expect(screen.getByRole('tab', { name: '📅 Calendar' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByRole('tab', { name: '✅ Tasks' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+  });
+
+  it('calls onTabChange with the clicked tab id', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onTabChange = vi.fn();
+    renderWithProviders(
+      <LobbyTabBar lobbyType="COUPLE" activeTab="tasks" onTabChange={onTabChange} />,
+    );
+
+    await user.click(screen.getByRole('tab', { name: '👥 Members' }));
+
+    expect(onTabChange).toHaveBeenCalledWith('members');
+  });
+});

--- a/lined-web/src/components/lobby/__tests__/LobbyTaskList.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/LobbyTaskList.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders, screen, userEvent, waitFor } from '@/test/utils';
+import { server } from '@/test/server';
+import { useCreateMenuStore } from '@/store/createMenu';
+import { LobbyTaskList } from '../LobbyTaskList';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+
+describe('LobbyTaskList', () => {
+  it('shows a loading state while tasks are being fetched', () => {
+    expect.assertions(1);
+    renderWithProviders(<LobbyTaskList lobbyId={1} />);
+
+    expect(screen.getByTestId('lobby-tasks-loading')).toBeInTheDocument();
+  });
+
+  it('renders lobby tasks with correct filter-pill counts', async () => {
+    expect.assertions(4);
+    renderWithProviders(<LobbyTaskList lobbyId={1} />);
+
+    expect(await screen.findByText('Plan dinner for Saturday')).toBeInTheDocument();
+    expect(screen.getByText('Book restaurant reservation')).toBeInTheDocument();
+    expect(screen.getByText('All (2)')).toBeInTheDocument();
+    expect(screen.getByText('To Do (1)')).toBeInTheDocument();
+  });
+
+  it('filters the task rows when a filter pill is clicked', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyTaskList lobbyId={1} />);
+    await screen.findByText('Plan dinner for Saturday');
+
+    await user.click(screen.getByText('In Progress (1)'));
+
+    expect(screen.queryByText('Plan dinner for Saturday')).not.toBeInTheDocument();
+    expect(screen.getByText('Book restaurant reservation')).toBeInTheDocument();
+  });
+
+  it('shows an error message when the task list fails to load', async () => {
+    expect.assertions(1);
+    server.use(http.get(`${BASE}/tasks`, () => new HttpResponse(null, { status: 500 })));
+    renderWithProviders(<LobbyTaskList lobbyId={1} />);
+
+    expect(await screen.findByText("Couldn't load tasks. Try again later.")).toBeInTheDocument();
+  });
+
+  it('shows an empty state when the lobby has no tasks', async () => {
+    expect.assertions(1);
+    server.use(http.get(`${BASE}/tasks`, () => HttpResponse.json([])));
+    renderWithProviders(<LobbyTaskList lobbyId={1} />);
+
+    expect(await screen.findByText('No tasks yet.')).toBeInTheDocument();
+  });
+
+  it('checking a row PATCHes the status and moves it to Done styling', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyTaskList lobbyId={1} />);
+    await screen.findByText('Plan dinner for Saturday');
+
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Mark "Plan dinner for Saturday" as done' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Plan dinner for Saturday')).toHaveClass('line-through');
+    });
+    expect(
+      screen.getByRole('checkbox', { name: 'Mark "Plan dinner for Saturday" as to do' }),
+    ).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('shows an inline error and keeps the row unchanged when the PATCH fails', async () => {
+    expect.assertions(2);
+    server.use(http.patch(`${BASE}/tasks/:id`, () => new HttpResponse(null, { status: 500 })));
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyTaskList lobbyId={1} />);
+    await screen.findByText('Plan dinner for Saturday');
+
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Mark "Plan dinner for Saturday" as done' }),
+    );
+
+    expect(await screen.findByText("Couldn't update — try again")).toBeInTheDocument();
+    expect(screen.getByText('Plan dinner for Saturday')).not.toHaveClass('line-through');
+  });
+
+  it('opens the "task" create-menu overlay when "+ Add task" is clicked', async () => {
+    expect.assertions(1);
+    useCreateMenuStore.setState({ overlay: null });
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyTaskList lobbyId={1} />);
+    await screen.findByText('Plan dinner for Saturday');
+
+    await user.click(screen.getByText('+ Add task'));
+
+    expect(useCreateMenuStore.getState().overlay).toBe('task');
+  });
+});

--- a/lined-web/src/components/lobby/__tests__/TaskRow.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/TaskRow.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
+import type { TaskDto, UserDto } from '@/types';
+import { TaskRow } from '../TaskRow';
+
+const baseTask: TaskDto = {
+  id: 1,
+  title: 'Plan dinner for Saturday',
+  description: 'Pick a restaurant and book a table for two',
+  priority: 'MEDIUM',
+  status: 'TODO',
+  lobbyId: 1,
+  creatorId: 1,
+  assigneeId: 1,
+  dueDate: null,
+  createdAt: '2026-04-09T08:00:00Z',
+};
+
+const assignee: UserDto = {
+  id: 1,
+  username: 'alex_johnson',
+  email: 'alex@lined.app',
+  createdAt: '2025-01-15T10:00:00Z',
+  roles: ['ROLE_USER'],
+  activePlan: null,
+  activeUntil: null,
+};
+
+describe('TaskRow', () => {
+  it('renders title, description, status badge and assignee initial', () => {
+    expect.assertions(4);
+    renderWithProviders(
+      <TaskRow task={baseTask} assignee={assignee} onToggle={vi.fn()} isUpdating={false} />,
+    );
+
+    expect(screen.getByText(baseTask.title)).toBeInTheDocument();
+    expect(screen.getByText(baseTask.description!)).toBeInTheDocument();
+    expect(screen.getByText('To Do')).toBeInTheDocument();
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+
+  it('omits the description line when the task has none', () => {
+    expect.assertions(1);
+    renderWithProviders(
+      <TaskRow
+        task={{ ...baseTask, description: null }}
+        assignee={assignee}
+        onToggle={vi.fn()}
+        isUpdating={false}
+      />,
+    );
+
+    expect(screen.queryByText(baseTask.description!)).not.toBeInTheDocument();
+  });
+
+  it('renders a placeholder avatar when there is no assignee', () => {
+    expect.assertions(1);
+    renderWithProviders(
+      <TaskRow
+        task={{ ...baseTask, assigneeId: null }}
+        assignee={undefined}
+        onToggle={vi.fn()}
+        isUpdating={false}
+      />,
+    );
+
+    expect(screen.getByText('?')).toBeInTheDocument();
+  });
+
+  it('shows the due date in red when overdue', () => {
+    expect.assertions(1);
+    renderWithProviders(
+      <TaskRow
+        task={{ ...baseTask, dueDate: '2020-01-01' }}
+        assignee={assignee}
+        onToggle={vi.fn()}
+        isUpdating={false}
+      />,
+    );
+
+    expect(screen.getByText('Jan 1')).toHaveClass('text-red-500');
+  });
+
+  it('renders a done task struck through and dimmed, with a checked checkbox', () => {
+    expect.assertions(2);
+    renderWithProviders(
+      <TaskRow
+        task={{ ...baseTask, status: 'DONE' }}
+        assignee={assignee}
+        onToggle={vi.fn()}
+        isUpdating={false}
+      />,
+    );
+
+    expect(screen.getByText(baseTask.title)).toHaveClass('line-through');
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('calls onToggle when the checkbox is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    renderWithProviders(
+      <TaskRow task={baseTask} assignee={assignee} onToggle={onToggle} isUpdating={false} />,
+    );
+
+    await user.click(screen.getByRole('checkbox'));
+
+    expect(onToggle).toHaveBeenCalledWith(baseTask);
+  });
+
+  it('disables the checkbox while an update is in flight', () => {
+    expect.assertions(1);
+    renderWithProviders(
+      <TaskRow task={baseTask} assignee={assignee} onToggle={vi.fn()} isUpdating={true} />,
+    );
+
+    expect(screen.getByRole('checkbox')).toBeDisabled();
+  });
+
+  it('shows an inline error message when provided', () => {
+    expect.assertions(1);
+    renderWithProviders(
+      <TaskRow
+        task={baseTask}
+        assignee={assignee}
+        onToggle={vi.fn()}
+        isUpdating={false}
+        updateError="Couldn't update — try again"
+      />,
+    );
+
+    expect(screen.getByText("Couldn't update — try again")).toBeInTheDocument();
+  });
+});

--- a/lined-web/src/hooks/useTasks.ts
+++ b/lined-web/src/hooks/useTasks.ts
@@ -1,6 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
-import { listMyTasks } from '@/api/tasks';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { listMyTasks, listTasks, updateTask } from '@/api/tasks';
 import { QUERY_KEYS } from '@/lib/constants';
+import type { TaskUpdateDto } from '@/types';
 
 export function useMyTasks() {
   return useQuery({
@@ -8,3 +9,21 @@ export function useMyTasks() {
     queryFn: listMyTasks,
   });
 }
+
+export const useLobbyTasks = (lobbyId: number | undefined) =>
+  useQuery({
+    queryKey: QUERY_KEYS.lobbyTasks(lobbyId ?? 0),
+    queryFn: () => listTasks({ lobbyId }),
+    enabled: lobbyId != null,
+  });
+
+export const useUpdateTask = (lobbyId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: TaskUpdateDto }) => updateTask(id, data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lobbyTasks(lobbyId) });
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.myTasks });
+    },
+  });
+};

--- a/lined-web/src/hooks/useTasks.ts
+++ b/lined-web/src/hooks/useTasks.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { listMyTasks, listTasks, updateTask } from '@/api/tasks';
 import { QUERY_KEYS } from '@/lib/constants';
-import type { TaskUpdateDto } from '@/types';
+import type { TaskDto, TaskUpdateDto } from '@/types';
 
 export function useMyTasks() {
   return useQuery({
@@ -21,8 +21,10 @@ export const useUpdateTask = (lobbyId: number) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ id, data }: { id: number; data: TaskUpdateDto }) => updateTask(id, data),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lobbyTasks(lobbyId) });
+    onSuccess: (updatedTask) => {
+      queryClient.setQueryData<TaskDto[]>(QUERY_KEYS.lobbyTasks(lobbyId), (old) =>
+        old?.map((t) => (t.id === updatedTask.id ? updatedTask : t)),
+      );
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.myTasks });
     },
   });

--- a/lined-web/src/hooks/useUsers.ts
+++ b/lined-web/src/hooks/useUsers.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueries } from '@tanstack/react-query';
 import { getUser } from '@/api/users';
 import { QUERY_KEYS } from '@/lib/constants';
 
@@ -9,3 +9,11 @@ export function useUser(id: number | undefined) {
     enabled: id != null,
   });
 }
+
+export const useUsers = (ids: number[]) =>
+  useQueries({
+    queries: ids.map((id) => ({
+      queryKey: QUERY_KEYS.user(id),
+      queryFn: () => getUser(id),
+    })),
+  });

--- a/lined-web/src/lib/constants.ts
+++ b/lined-web/src/lib/constants.ts
@@ -21,6 +21,13 @@ export const LOBBY_TYPE_BADGE_CLASSES: Record<LobbyType, string> = {
   WORK: 'bg-lobby-work/10 text-lobby-work',
 };
 
+export const LOBBY_TYPE_ICONS: Record<LobbyType, string> = {
+  COUPLE: '💑',
+  FAMILY: '👨‍👩‍👧‍👦',
+  FRIENDS: '🎉',
+  WORK: '💼',
+};
+
 export const TASK_STATUS_LABELS: Record<TaskStatus, string> = {
   TODO: 'To Do',
   IN_PROGRESS: 'In Progress',
@@ -47,6 +54,7 @@ export const QUERY_KEYS = {
   lobbyFreeSlots: (id: number) => ['lobbies', id, 'free-slots'] as const,
   tasks: ['tasks'] as const,
   myTasks: ['tasks', 'mine'] as const,
+  lobbyTasks: (lobbyId: number) => ['tasks', 'lobby', lobbyId] as const,
   events: ['events'] as const,
   lobbyInvites: (lobbyId: number) => ['lobby-invites', lobbyId] as const,
   myInvites: ['lobby-invites', 'mine'] as const,

--- a/lined-web/src/lib/constants.ts
+++ b/lined-web/src/lib/constants.ts
@@ -21,6 +21,13 @@ export const LOBBY_TYPE_BADGE_CLASSES: Record<LobbyType, string> = {
   WORK: 'bg-lobby-work/10 text-lobby-work',
 };
 
+export const LOBBY_TYPE_BORDER_CLASSES: Record<LobbyType, string> = {
+  COUPLE: 'border-lobby-couple',
+  FAMILY: 'border-lobby-family',
+  FRIENDS: 'border-lobby-friends',
+  WORK: 'border-lobby-work',
+};
+
 export const LOBBY_TYPE_ICONS: Record<LobbyType, string> = {
   COUPLE: '💑',
   FAMILY: '👨‍👩‍👧‍👦',

--- a/lined-web/src/pages/LobbyPage.tsx
+++ b/lined-web/src/pages/LobbyPage.tsx
@@ -1,21 +1,64 @@
 import { useParams, useSearchParams } from 'react-router-dom';
+import { useLobby } from '@/hooks/useLobbies';
+import { LobbyHeader } from '@/components/lobby/LobbyHeader';
+import { LobbyTabBar, type LobbyTab } from '@/components/lobby/LobbyTabBar';
+import { LobbyTaskList } from '@/components/lobby/LobbyTaskList';
+
+const VALID_TABS: LobbyTab[] = ['calendar', 'tasks', 'members'];
+
+const isLobbyTab = (value: string | null): value is LobbyTab =>
+  VALID_TABS.includes(value as LobbyTab);
 
 export function LobbyPage() {
   const { id } = useParams<{ id: string }>();
-  const [searchParams] = useSearchParams();
-  const tab = searchParams.get('tab') ?? 'tasks';
+  const lobbyId = id ? Number(id) : undefined;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tabParam = searchParams.get('tab');
+  const activeTab: LobbyTab = isLobbyTab(tabParam) ? tabParam : 'tasks';
+
+  const { data: lobby, isLoading, isError } = useLobby(lobbyId);
+
+  const handleTabChange = (tab: LobbyTab) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('tab', tab);
+      return next;
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="h-24 animate-pulse rounded-xl bg-white" data-testid="lobby-page-loading" />
+        <div className="mt-4 h-10 w-64 animate-pulse rounded-lg bg-white" />
+      </div>
+    );
+  }
+
+  if (isError || !lobby) {
+    return (
+      <div className="flex-1 overflow-y-auto p-6">
+        <p className="text-sm text-text-secondary">
+          Lobby not found. It may have been deleted, or you may not have access to it.
+        </p>
+      </div>
+    );
+  }
 
   return (
-    <div className="flex-1 overflow-y-auto p-6">
-      <h2 className="text-2xl font-semibold text-text-primary">
-        Lobby #{id}
-      </h2>
-      <p className="mt-2 text-text-secondary">
-        Active tab: <span className="font-medium">{tab}</span>
-      </p>
-      <p className="mt-1 text-text-muted">
-        Lobby detail view with Tasks / Calendar / Members tabs coming soon...
-      </p>
+    <div className="flex-1 overflow-y-auto">
+      <LobbyHeader lobby={lobby} />
+      <LobbyTabBar lobbyType={lobby.lobbyType} activeTab={activeTab} onTabChange={handleTabChange} />
+
+      {activeTab === 'tasks' && <LobbyTaskList lobbyId={lobby.id} />}
+
+      {activeTab === 'calendar' && (
+        <p className="p-6 text-sm text-text-secondary">Lobby calendar coming soon...</p>
+      )}
+
+      {activeTab === 'members' && (
+        <p className="p-6 text-sm text-text-secondary">Lobby members coming soon...</p>
+      )}
     </div>
   );
 }

--- a/lined-web/src/pages/__tests__/LobbyPage.test.tsx
+++ b/lined-web/src/pages/__tests__/LobbyPage.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { Routes, Route } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
+import { server } from '@/test/server';
+import { LobbyPage } from '../LobbyPage';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+
+function renderLobbyPage(initialEntry: string) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/lobbies/:id" element={<LobbyPage />} />
+    </Routes>,
+    { initialEntries: [initialEntry] },
+  );
+}
+
+describe('LobbyPage', () => {
+  it('renders the header, tab bar, and the tasks tab by default', async () => {
+    expect.assertions(3);
+    renderLobbyPage('/lobbies/1');
+
+    expect(await screen.findByText('Alex & Anastasiia')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '✅ Tasks' })).toHaveAttribute('aria-selected', 'true');
+    expect(await screen.findByText('Plan dinner for Saturday')).toBeInTheDocument();
+  });
+
+  it('shows a friendly message when the lobby cannot be found', async () => {
+    expect.assertions(1);
+    server.use(http.get(`${BASE}/lobbies/:id`, () => new HttpResponse(null, { status: 404 })));
+    renderLobbyPage('/lobbies/999');
+
+    expect(
+      await screen.findByText(
+        'Lobby not found. It may have been deleted, or you may not have access to it.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('shows placeholder copy for the calendar and members tabs', async () => {
+    expect.assertions(2);
+    renderLobbyPage('/lobbies/1?tab=calendar');
+
+    expect(await screen.findByText('Lobby calendar coming soon...')).toBeInTheDocument();
+    expect(screen.queryByText('Plan dinner for Saturday')).not.toBeInTheDocument();
+  });
+
+  it('switches to the tasks tab and updates the URL when clicked', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    renderLobbyPage('/lobbies/1?tab=members');
+    await screen.findByText('Lobby members coming soon...');
+
+    await user.click(screen.getByRole('tab', { name: '✅ Tasks' }));
+
+    expect(await screen.findByText('Plan dinner for Saturday')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '✅ Tasks' })).toHaveAttribute('aria-selected', 'true');
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the `LobbyPage` stub with the real lobby detail screen: `LobbyHeader` (type-accent bar, avatar tile, resolved member avatar stack, member count, type badge, "+ Add member"/"⚙ Settings" actions) and `LobbyTabBar` (Calendar/Tasks/Members, active tab underlined in the lobby-type color, synced to `?tab=`).
- Implements the Tasks tab end-to-end: `LobbyTaskList` (filter pills with live counts, "Sort: Due date", loading/empty/error states, dashed "+ Add task" button wired to the existing create-menu `task` overlay) and `TaskRow` (checkbox status toggle, description line, status badge, assignee avatar, due date in red when overdue/today, done rows dimmed + struck through).
- Adds `useUsers(ids)` (batches per-member profile fetches via `useQueries`, sharing cache entries with `useUser`) and `useLobbyTasks`/`useUpdateTask` hooks. `useUpdateTask` patches the lobby task-list query cache directly from the PATCH response instead of relying on an invalidate+refetch, since the MSW mock store doesn't persist writes across GET calls — this is also strictly better against the real backend (immediate update, no extra round-trip).
- Promotes `LOBBY_TYPE_ICONS` (emoji per lobby type) out of `LobbyTypePicker` into shared constants, and adds `LOBBY_TYPE_BORDER_CLASSES`/`QUERY_KEYS.lobbyTasks` for reuse.
- Checking a task row PATCHes its status (`DONE` ⇄ `TODO`/`IN_PROGRESS`); a failed PATCH shows an inline per-row error and leaves the row unchanged (no optimistic update, so nothing needs rolling back). A lobby fetch failure (404/500) shows a friendly "Lobby not found" message instead of crashing.
- Calendar and Members tabs remain "coming soon" placeholders — owned by Tasks 7 and 6 respectively, per the task file's stated scope.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:run` (124 tests passing, incl. new `LobbyHeader`, `LobbyTabBar`, `LobbyTaskList`, `TaskRow`, `LobbyPage` suites covering positive/negative/loading/error paths with `expect.assertions`)
- [x] `npm run build`
- [x] Manually verified in the browser (MSW enabled) at 1280×800 against mockup screen `#lobby`: header/avatars/badges/tab bar/filter pills/task rows match; toggling a checkbox moves a task to Done styling and updates counts; filter pills correctly narrow the list; switching to `?tab=calendar`/`?tab=members` shows the placeholder copy and back to Tasks restores the list; an unknown lobby id shows the friendly not-found message.
- [x] `docs/UI_TASKS.md` row 5 updated to `DONE`, "Current implementation status" summary refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)