### PR TITLE
feat(web): Lobby Members tab + Add Member modal (UI-06)

### DIFF
--- a/lined-web/docs/UI_TASKS.md
+++ b/lined-web/docs/UI_TASKS.md
@@ -37,16 +37,17 @@ exist for every task, including `create-lobby` (task 4), `calendar-month`
 - **Global Calendar page (week view)** — `CalendarTopBar`, `WeekGrid` (with client-side free-slot bands), `EventDetailPanel`, `CreateEventModal`, delete event. Missing: month view, edit event, legend.
 - **"+ Create" dropdown & Create Lobby modal** — `CreateMenu`, `CreateLobbyModal`, `LobbyTypePicker`, `useCreateLobby`; New Task / Reserve Free Slot only flip store state until Tasks 8/11 land.
 - Zustand stores: `auth` (persisted userId), `calendar` (view state), `createMenu` (create-lobby + event/task/reserveSlot overlay state)
-- Hooks: `useMyLobbies`, `useLobby`, `useCreateLobby`, `useWeekEvents`, `useCreateEvent`, `useDeleteEvent`, `useUsers`, `useLobbyTasks`, `useUpdateTask`
+- Hooks: `useMyLobbies`, `useLobby`, `useCreateLobby`, `useUpdateLobbyOwner`, `useRemoveMember`, `useWeekEvents`, `useCreateEvent`, `useDeleteEvent`, `useUsers`, `useUserSearch`, `useLobbyTasks`, `useUpdateTask`, `useLobbyInvites`, `useCreateInvite`, `useResendInvite`, `useCancelInvite`
 - MSW handlers + smoke tests
-- **Lobby detail page** — `LobbyHeader`, `LobbyTabBar`, `LobbyTaskList`, `TaskRow`: type-accent header with resolved member avatars, `?tab=`-synced tab bar, and a live Tasks tab (filter pills with counts, due-date sort, checkbox status toggle). Calendar/Members tabs remain "coming soon" placeholders until Tasks 6/7.
+- **Lobby detail page** — `LobbyHeader`, `LobbyTabBar`, `LobbyTaskList`, `TaskRow`: type-accent header with resolved member avatars, `?tab=`-synced tab bar, and a live Tasks tab (filter pills with counts, due-date sort, checkbox status toggle). Calendar tab remains a "coming soon" placeholder until Task 7.
+- **Lobby Members tab & Add Member modal** — `LobbyMemberList`, `MemberCard`, `PendingInviteRow`, `AddMemberModal`, shared `ConfirmDialog`: role badges, owner-only "Make owner"/"Remove" actions with confirm dialogs, owner-only Pending Invites section (resend/cancel), and debounced user search with already-member/invitable/invite-sent states.
 
 **Stubs only ("coming soon" placeholders):**
 SignInPage, SignUpPage, DashboardPage, TasksPage,
 UserSettingsPage, LobbySettingsPage.
 
-**Not started:** AddTaskDrawer, AddMemberModal, ReserveSlotModal, kanban
-board, lobby calendar/members tabs.
+**Not started:** AddTaskDrawer, ReserveSlotModal, kanban board, lobby
+calendar tab.
 
 ## Backend API summary
 
@@ -79,7 +80,7 @@ board, lobby calendar/members tabs.
 | 3 | `feature/ui-03-dashboard` | Dashboard page: lobby cards, upcoming events, my tasks, free-slot banner | [tasks/UI-03-dashboard.md](tasks/UI-03-dashboard.md) | DONE |
 | 4 | `feature/ui-04-create-menu-lobby-modal` | "+ Create" dropdown menu and Create Lobby modal (type picker) | [tasks/UI-04-create-menu-lobby-modal.md](tasks/UI-04-create-menu-lobby-modal.md) | DONE |
 | 5 | `feature/ui-05-lobby-tasks-tab` | Lobby detail page: header, tab bar, Tasks tab (filter pills, task rows) | [tasks/UI-05-lobby-tasks-tab.md](tasks/UI-05-lobby-tasks-tab.md) | DONE |
-| 6 | `feature/ui-06-lobby-members` | Lobby Members tab + Add Member modal (user search, invite, remove) | [tasks/UI-06-lobby-members.md](tasks/UI-06-lobby-members.md) | TODO |
+| 6 | `feature/ui-06-lobby-members` | Lobby Members tab + Add Member modal (user search, invite, remove) | [tasks/UI-06-lobby-members.md](tasks/UI-06-lobby-members.md) | DONE |
 | 7 | `feature/ui-07-lobby-calendar` | Lobby Calendar tab (week grid scoped to lobby, free-slot bands) | [tasks/UI-07-lobby-calendar.md](tasks/UI-07-lobby-calendar.md) | TODO |
 | 8 | `feature/ui-08-add-task-drawer` | Add Task drawer (title, assignee picker, due date, status) | [tasks/UI-08-add-task-drawer.md](tasks/UI-08-add-task-drawer.md) | TODO |
 | 9 | `feature/ui-09-tasks-kanban` | Global Tasks Board: 3-column kanban with filters and status transitions | [tasks/UI-09-tasks-kanban.md](tasks/UI-09-tasks-kanban.md) | TODO |

--- a/lined-web/src/components/ConfirmDialog.tsx
+++ b/lined-web/src/components/ConfirmDialog.tsx
@@ -1,0 +1,57 @@
+interface ConfirmDialogProps {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  danger?: boolean;
+  isPending?: boolean;
+  error?: string | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export const ConfirmDialog = ({
+  title,
+  message,
+  confirmLabel,
+  danger = false,
+  isPending = false,
+  error,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) => {
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/45"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="w-[400px] max-w-[90vw] rounded-2xl bg-white p-6 shadow-[var(--shadow-lg)]">
+        <h2 className="text-lg font-bold text-text-primary">{title}</h2>
+        <p className="mt-2 text-sm text-text-secondary">{message}</p>
+
+        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+
+        <div className="mt-6 flex items-center justify-end gap-2.5">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="h-10 rounded-lg border border-border bg-white px-4 text-sm text-text-secondary hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isPending}
+            className={`h-10 rounded-lg px-4 text-sm font-semibold text-white transition-colors disabled:opacity-60 ${
+              danger ? 'bg-red-600 hover:bg-red-700' : 'bg-brand-green hover:bg-brand-green-dark'
+            }`}
+          >
+            {isPending ? 'Please wait…' : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/lined-web/src/components/ConfirmDialog.tsx
+++ b/lined-web/src/components/ConfirmDialog.tsx
@@ -21,6 +21,7 @@ export const ConfirmDialog = ({
 }: ConfirmDialogProps) => {
   return (
     <div
+      data-testid="confirm-dialog-backdrop"
       className="absolute inset-0 z-50 flex items-center justify-center bg-black/45"
       onClick={(e) => {
         if (e.target === e.currentTarget) onCancel();

--- a/lined-web/src/components/__tests__/ConfirmDialog.test.tsx
+++ b/lined-web/src/components/__tests__/ConfirmDialog.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderWithProviders as render, screen, userEvent } from '@/test/utils';
+import { ROLES, TEST_IDS, CONFIRM_DIALOG_TEXT, MEMBER_CARD_TEXT } from '@/test/lobbyMemberContent';
 import { ConfirmDialog } from '../ConfirmDialog';
 
 describe('ConfirmDialog', () => {
@@ -9,7 +10,7 @@ describe('ConfirmDialog', () => {
       <ConfirmDialog
         title="Remove member"
         message="Remove @nastia_k from this lobby?"
-        confirmLabel="Remove"
+        confirmLabel={MEMBER_CARD_TEXT.removeButtonName}
         onConfirm={vi.fn()}
         onCancel={vi.fn()}
       />,
@@ -17,7 +18,7 @@ describe('ConfirmDialog', () => {
 
     expect(screen.getByText('Remove member')).toBeInTheDocument();
     expect(screen.getByText('Remove @nastia_k from this lobby?')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+    expect(screen.getByRole(ROLES.button, { name: MEMBER_CARD_TEXT.removeButtonName })).toBeInTheDocument();
   });
 
   it('calls onConfirm when the confirm button is clicked', async () => {
@@ -28,13 +29,13 @@ describe('ConfirmDialog', () => {
       <ConfirmDialog
         title="Make owner"
         message="Make this member the owner?"
-        confirmLabel="Make owner"
+        confirmLabel={MEMBER_CARD_TEXT.makeOwnerButtonName}
         onConfirm={onConfirm}
         onCancel={vi.fn()}
       />,
     );
 
-    await user.click(screen.getByRole('button', { name: 'Make owner' }));
+    await user.click(screen.getByRole(ROLES.button, { name: MEMBER_CARD_TEXT.makeOwnerButtonName }));
 
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
@@ -47,13 +48,13 @@ describe('ConfirmDialog', () => {
       <ConfirmDialog
         title="Remove member"
         message="Are you sure?"
-        confirmLabel="Remove"
+        confirmLabel={MEMBER_CARD_TEXT.removeButtonName}
         onConfirm={vi.fn()}
         onCancel={onCancel}
       />,
     );
 
-    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await user.click(screen.getByRole(ROLES.button, { name: CONFIRM_DIALOG_TEXT.cancelButtonName }));
 
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
@@ -64,15 +65,19 @@ describe('ConfirmDialog', () => {
       <ConfirmDialog
         title="Remove member"
         message="Are you sure?"
-        confirmLabel="Remove"
+        confirmLabel={MEMBER_CARD_TEXT.removeButtonName}
         isPending
         onConfirm={vi.fn()}
         onCancel={vi.fn()}
       />,
     );
 
-    expect(screen.getByRole('button', { name: 'Please wait…' })).toBeDisabled();
-    expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole(ROLES.button, { name: CONFIRM_DIALOG_TEXT.pleaseWaitLabel }),
+    ).toBeDisabled();
+    expect(
+      screen.queryByRole(ROLES.button, { name: MEMBER_CARD_TEXT.removeButtonName }),
+    ).not.toBeInTheDocument();
   });
 
   it('renders an inline error message when provided', () => {
@@ -81,7 +86,7 @@ describe('ConfirmDialog', () => {
       <ConfirmDialog
         title="Remove member"
         message="Are you sure?"
-        confirmLabel="Remove"
+        confirmLabel={MEMBER_CARD_TEXT.removeButtonName}
         error="Could not remove this member — please try again"
         onConfirm={vi.fn()}
         onCancel={vi.fn()}
@@ -101,13 +106,13 @@ describe('ConfirmDialog', () => {
       <ConfirmDialog
         title="Remove member"
         message="Are you sure?"
-        confirmLabel="Remove"
+        confirmLabel={MEMBER_CARD_TEXT.removeButtonName}
         onConfirm={vi.fn()}
         onCancel={onCancel}
       />,
     );
 
-    await user.click(screen.getByTestId('confirm-dialog-backdrop'));
+    await user.click(screen.getByTestId(TEST_IDS.confirmDialogBackdrop));
 
     expect(onCancel).toHaveBeenCalledTimes(1);
   });

--- a/lined-web/src/components/__tests__/ConfirmDialog.test.tsx
+++ b/lined-web/src/components/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders as render, screen, userEvent } from '@/test/utils';
+import { ConfirmDialog } from '../ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  it('renders the title, message, and confirm label', () => {
+    expect.assertions(3);
+    render(
+      <ConfirmDialog
+        title="Remove member"
+        message="Remove @nastia_k from this lobby?"
+        confirmLabel="Remove"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Remove member')).toBeInTheDocument();
+    expect(screen.getByText('Remove @nastia_k from this lobby?')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+  });
+
+  it('calls onConfirm when the confirm button is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        title="Make owner"
+        message="Make this member the owner?"
+        confirmLabel="Make owner"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Make owner' }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when Cancel is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDialog
+        title="Remove member"
+        message="Are you sure?"
+        confirmLabel="Remove"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the confirm button and shows a pending label while isPending is true', () => {
+    expect.assertions(2);
+    render(
+      <ConfirmDialog
+        title="Remove member"
+        message="Are you sure?"
+        confirmLabel="Remove"
+        isPending
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Please wait…' })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
+  });
+
+  it('renders an inline error message when provided', () => {
+    expect.assertions(1);
+    render(
+      <ConfirmDialog
+        title="Remove member"
+        message="Are you sure?"
+        confirmLabel="Remove"
+        error="Could not remove this member — please try again"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText('Could not remove this member — please try again'),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onCancel when the backdrop is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDialog
+        title="Remove member"
+        message="Are you sure?"
+        confirmLabel="Remove"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    await user.click(screen.getByTestId('confirm-dialog-backdrop'));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lined-web/src/components/lobby/AddMemberModal.tsx
+++ b/lined-web/src/components/lobby/AddMemberModal.tsx
@@ -1,0 +1,186 @@
+import { useState } from 'react';
+import { X, Search } from 'lucide-react';
+import { HTTPError } from 'ky';
+import type { LobbyDto, UserSearchResultDto } from '@/types';
+import { useUserSearch } from '@/hooks/useUsers';
+import { useCreateInvite } from '@/hooks/useInvites';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+
+interface SearchResultRowProps {
+  user: UserSearchResultDto;
+  isMember: boolean;
+  isInvited: boolean;
+  isSending: boolean;
+  error?: string;
+  onInvite: () => void;
+}
+
+const SearchResultRow = ({
+  user,
+  isMember,
+  isInvited,
+  isSending,
+  error,
+  onInvite,
+}: SearchResultRowProps) => {
+  return (
+    <div
+      className={`flex items-center gap-3 rounded-lg p-2.5 ${isMember ? 'bg-brand-green-light' : ''}`}
+    >
+      <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-brand-green text-sm font-bold text-white">
+        {user.username.charAt(0).toUpperCase()}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-text-primary">{user.username}</p>
+        <p className="text-xs text-text-secondary">
+          @{user.username}
+          {isMember && ' · already in lobby'}
+        </p>
+        {error && <p className="mt-0.5 text-xs text-red-600">{error}</p>}
+      </div>
+      {isMember && <span className="text-lg text-task-done">✓</span>}
+      {!isMember && (
+        <button
+          type="button"
+          onClick={onInvite}
+          disabled={isInvited || isSending}
+          className="h-8 flex-shrink-0 rounded-lg bg-brand-green px-3.5 text-xs font-semibold text-white hover:bg-brand-green-dark disabled:opacity-60"
+        >
+          {isSending ? 'Inviting…' : isInvited ? 'Invite sent' : 'Invite'}
+        </button>
+      )}
+    </div>
+  );
+};
+
+interface AddMemberModalProps {
+  lobby: LobbyDto;
+  onClose: () => void;
+}
+
+export const AddMemberModal = ({ lobby, onClose }: AddMemberModalProps) => {
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebouncedValue(query.trim(), 300);
+  const { data: results, isLoading, isError } = useUserSearch(debouncedQuery);
+  const createInvite = useCreateInvite(lobby.id);
+
+  const [invitedIds, setInvitedIds] = useState<Set<number>>(new Set());
+  const [sendingId, setSendingId] = useState<number | null>(null);
+  const [rowErrors, setRowErrors] = useState<Record<number, string>>({});
+
+  const handleInvite = (userId: number) => {
+    setSendingId(userId);
+    setRowErrors((prev) => {
+      if (!(userId in prev)) return prev;
+      const next = { ...prev };
+      delete next[userId];
+      return next;
+    });
+
+    createInvite.mutate(
+      { userId },
+      {
+        onSuccess: () => {
+          setInvitedIds((prev) => new Set(prev).add(userId));
+        },
+        onError: (error) => {
+          const message =
+            error instanceof HTTPError && error.response.status === 409
+              ? 'Already a member or already invited'
+              : "Couldn't send invite — try again";
+          setRowErrors((prev) => ({ ...prev, [userId]: message }));
+        },
+        onSettled: () => setSendingId(null),
+      },
+    );
+  };
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/45"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="max-h-[85vh] w-[460px] max-w-[90vw] overflow-hidden rounded-2xl bg-white shadow-[var(--shadow-lg)]">
+        <div className="flex items-center justify-between px-6 pt-5">
+          <h2 className="text-lg font-bold text-text-primary">Add Member</h2>
+          <button onClick={onClose} aria-label="Close" className="text-text-muted hover:text-text-secondary">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="px-6 py-5">
+          <p className="mb-4 text-xs text-text-secondary">
+            Search by username or email to invite someone to <strong>{lobby.name}</strong>.
+          </p>
+
+          <label htmlFor="add-member-search" className="mb-1.5 block text-xs font-medium text-text-secondary">
+            Search user
+          </label>
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" />
+            <input
+              id="add-member-search"
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Username or email"
+              className="h-12 w-full rounded-lg border border-border bg-input-bg pl-10 pr-4 text-sm text-text-primary placeholder:text-text-muted focus:border-brand-green focus:outline-none"
+            />
+          </div>
+
+          <div className="mt-4 max-h-64 space-y-1 overflow-y-auto">
+            {query.trim().length > 0 && query.trim().length < 2 && (
+              <p className="text-xs text-text-muted">Type at least 2 characters to search.</p>
+            )}
+
+            {isLoading && debouncedQuery.length >= 2 && (
+              <div className="flex flex-col gap-2" data-testid="add-member-search-loading">
+                {[0, 1].map((i) => (
+                  <div key={i} className="h-12 animate-pulse rounded-lg bg-gray-100" />
+                ))}
+              </div>
+            )}
+
+            {isError && (
+              <p className="text-sm text-text-secondary">Search failed — try again.</p>
+            )}
+
+            {!isLoading && !isError && debouncedQuery.length >= 2 && results?.content.length === 0 && (
+              <p className="text-sm text-text-secondary">No users found.</p>
+            )}
+
+            {!isLoading &&
+              !isError &&
+              results?.content.map((user) => (
+                <SearchResultRow
+                  key={user.id}
+                  user={user}
+                  isMember={lobby.memberIds.includes(user.id)}
+                  isInvited={invitedIds.has(user.id)}
+                  isSending={sendingId === user.id}
+                  error={rowErrors[user.id]}
+                  onInvite={() => handleInvite(user.id)}
+                />
+              ))}
+          </div>
+
+          <div className="mt-4 rounded-lg bg-bg px-3.5 py-3 text-xs text-text-secondary">
+            💡 You can also share an invite link: <span className="font-semibold text-brand-green">lined.app/invite/abc123</span>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-2.5 border-t border-border px-6 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-10 rounded-lg border border-border bg-white px-4 text-sm text-text-secondary hover:bg-gray-50"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/lined-web/src/components/lobby/AddMemberModal.tsx
+++ b/lined-web/src/components/lobby/AddMemberModal.tsx
@@ -1,57 +1,11 @@
 import { useState } from 'react';
 import { X, Search } from 'lucide-react';
 import { HTTPError } from 'ky';
-import type { LobbyDto, UserSearchResultDto } from '@/types';
+import type { LobbyDto } from '@/types';
 import { useUserSearch } from '@/hooks/useUsers';
 import { useCreateInvite } from '@/hooks/useInvites';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
-
-interface SearchResultRowProps {
-  user: UserSearchResultDto;
-  isMember: boolean;
-  isInvited: boolean;
-  isSending: boolean;
-  error?: string;
-  onInvite: () => void;
-}
-
-const SearchResultRow = ({
-  user,
-  isMember,
-  isInvited,
-  isSending,
-  error,
-  onInvite,
-}: SearchResultRowProps) => {
-  return (
-    <div
-      className={`flex items-center gap-3 rounded-lg p-2.5 ${isMember ? 'bg-brand-green-light' : ''}`}
-    >
-      <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-brand-green text-sm font-bold text-white">
-        {user.username.charAt(0).toUpperCase()}
-      </div>
-      <div className="min-w-0 flex-1">
-        <p className="text-sm font-semibold text-text-primary">{user.username}</p>
-        <p className="text-xs text-text-secondary">
-          @{user.username}
-          {isMember && ' · already in lobby'}
-        </p>
-        {error && <p className="mt-0.5 text-xs text-red-600">{error}</p>}
-      </div>
-      {isMember && <span className="text-lg text-task-done">✓</span>}
-      {!isMember && (
-        <button
-          type="button"
-          onClick={onInvite}
-          disabled={isInvited || isSending}
-          className="h-8 flex-shrink-0 rounded-lg bg-brand-green px-3.5 text-xs font-semibold text-white hover:bg-brand-green-dark disabled:opacity-60"
-        >
-          {isSending ? 'Inviting…' : isInvited ? 'Invite sent' : 'Invite'}
-        </button>
-      )}
-    </div>
-  );
-};
+import { SearchResultsList } from './SearchResultsList';
 
 interface AddMemberModalProps {
   lobby: LobbyDto;
@@ -135,35 +89,17 @@ export const AddMemberModal = ({ lobby, onClose }: AddMemberModalProps) => {
               <p className="text-xs text-text-muted">Type at least 2 characters to search.</p>
             )}
 
-            {isLoading && debouncedQuery.length >= 2 && (
-              <div className="flex flex-col gap-2" data-testid="add-member-search-loading">
-                {[0, 1].map((i) => (
-                  <div key={i} className="h-12 animate-pulse rounded-lg bg-gray-100" />
-                ))}
-              </div>
-            )}
-
-            {isError && (
-              <p className="text-sm text-text-secondary">Search failed — try again.</p>
-            )}
-
-            {!isLoading && !isError && debouncedQuery.length >= 2 && results?.content.length === 0 && (
-              <p className="text-sm text-text-secondary">No users found.</p>
-            )}
-
-            {!isLoading &&
-              !isError &&
-              results?.content.map((user) => (
-                <SearchResultRow
-                  key={user.id}
-                  user={user}
-                  isMember={lobby.memberIds.includes(user.id)}
-                  isInvited={invitedIds.has(user.id)}
-                  isSending={sendingId === user.id}
-                  error={rowErrors[user.id]}
-                  onInvite={() => handleInvite(user.id)}
-                />
-              ))}
+            <SearchResultsList
+              debouncedQuery={debouncedQuery}
+              isLoading={isLoading}
+              isError={isError}
+              results={results}
+              memberIds={lobby.memberIds}
+              invitedIds={invitedIds}
+              sendingId={sendingId}
+              rowErrors={rowErrors}
+              onInvite={handleInvite}
+            />
           </div>
 
           <div className="mt-4 rounded-lg bg-bg px-3.5 py-3 text-xs text-text-secondary">

--- a/lined-web/src/components/lobby/LobbyHeader.tsx
+++ b/lined-web/src/components/lobby/LobbyHeader.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { LobbyDto } from '@/types';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
@@ -8,6 +9,7 @@ import {
   LOBBY_TYPE_LABELS,
 } from '@/lib/constants';
 import { useUsers } from '@/hooks/useUsers';
+import { AddMemberModal } from './AddMemberModal';
 
 const MAX_AVATARS_SHOWN = 4;
 
@@ -18,6 +20,7 @@ interface LobbyHeaderProps {
 export const LobbyHeader = ({ lobby }: LobbyHeaderProps) => {
   const memberQueries = useUsers(lobby.memberIds);
   const shown = memberQueries.slice(0, MAX_AVATARS_SHOWN);
+  const [isAddMemberOpen, setIsAddMemberOpen] = useState(false);
 
   return (
     <div className={`border-t-4 bg-white ${LOBBY_TYPE_BORDER_CLASSES[lobby.lobbyType]}`}>
@@ -62,6 +65,7 @@ export const LobbyHeader = ({ lobby }: LobbyHeaderProps) => {
         <div className="flex flex-shrink-0 items-center gap-2">
           <button
             type="button"
+            onClick={() => setIsAddMemberOpen(true)}
             className="rounded-lg border border-border px-3 py-2 text-sm font-medium text-text-primary hover:bg-gray-50"
           >
             + Add member
@@ -74,6 +78,10 @@ export const LobbyHeader = ({ lobby }: LobbyHeaderProps) => {
           </Link>
         </div>
       </div>
+
+      {isAddMemberOpen && (
+        <AddMemberModal lobby={lobby} onClose={() => setIsAddMemberOpen(false)} />
+      )}
     </div>
   );
 };

--- a/lined-web/src/components/lobby/LobbyMemberList.tsx
+++ b/lined-web/src/components/lobby/LobbyMemberList.tsx
@@ -1,147 +1,39 @@
 import { useState } from 'react';
-import type { LobbyDto, LobbyInviteDto, UserDto } from '@/types';
+import type { LobbyDto, UserDto } from '@/types';
 import { useUsers } from '@/hooks/useUsers';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useUpdateLobbyOwner, useRemoveMember } from '@/hooks/useLobbies';
-import { useLobbyInvites, useResendInvite, useCancelInvite } from '@/hooks/useInvites';
+import { useLobbyInvites } from '@/hooks/useInvites';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
-import { MemberCard } from './MemberCard';
-import { PendingInviteRow } from './PendingInviteRow';
+import { MemberListContent } from './MemberListContent';
+import { PendingInvitesSection } from './PendingInvitesSection';
 
-type PendingAction = { kind: 'makeOwner' | 'remove'; member: UserDto } | null;
+type PendingActionKind = 'makeOwner' | 'remove';
+type PendingAction = { kind: PendingActionKind; member: UserDto } | null;
 
-interface MemberListContentProps {
-  memberQueries: ReturnType<typeof useUsers>;
-  lobby: LobbyDto;
-  currentUserId: number | undefined;
-  isOwnerViewer: boolean;
-  onMakeOwner: (member: UserDto) => void;
-  onRemove: (member: UserDto) => void;
-}
-
-const MemberListContent = ({
-  memberQueries,
-  lobby,
-  currentUserId,
-  isOwnerViewer,
-  onMakeOwner,
-  onRemove,
-}: MemberListContentProps) => {
-  if (memberQueries.some((q) => q.isLoading)) {
-    return (
-      <div className="flex flex-col gap-2" data-testid="lobby-members-loading">
-        {[0, 1].map((i) => (
-          <div key={i} className="h-20 animate-pulse rounded-lg bg-white" />
-        ))}
-      </div>
-    );
+const MEMBER_ACTION_CONFIG: Record<
+  PendingActionKind,
+  {
+    title: string;
+    confirmLabel: string;
+    danger: boolean;
+    getMessage: (member: UserDto, lobbyName: string) => string;
   }
-
-  if (memberQueries.some((q) => q.isError)) {
-    return <p className="text-sm text-text-secondary">Couldn&apos;t load members. Try again later.</p>;
-  }
-
-  return (
-    <div className="flex flex-col gap-2">
-      {memberQueries.map((q, i) => {
-        const member = q.data;
-        if (!member) return null;
-        const memberId = lobby.memberIds[i];
-        return (
-          <MemberCard
-            key={memberId}
-            member={member}
-            isOwner={memberId === lobby.ownerId}
-            isCurrentUser={memberId === currentUserId}
-            canManage={isOwnerViewer}
-            onMakeOwner={() => onMakeOwner(member)}
-            onRemove={() => onRemove(member)}
-          />
-        );
-      })}
-    </div>
-  );
-};
-
-interface PendingInvitesSectionProps {
-  lobbyId: number;
-  invites: LobbyInviteDto[] | undefined;
-  isLoading: boolean;
-  isError: boolean;
-}
-
-const PendingInvitesSection = ({
-  lobbyId,
-  invites,
-  isLoading,
-  isError,
-}: PendingInvitesSectionProps) => {
-  const resendInvite = useResendInvite(lobbyId);
-  const cancelInvite = useCancelInvite(lobbyId);
-  const [busyId, setBusyId] = useState<number | null>(null);
-  const [rowErrors, setRowErrors] = useState<Record<number, string>>({});
-
-  const clearRowError = (inviteId: number) =>
-    setRowErrors((prev) => {
-      if (!(inviteId in prev)) return prev;
-      const next = { ...prev };
-      delete next[inviteId];
-      return next;
-    });
-
-  const handleResend = (inviteId: number) => {
-    setBusyId(inviteId);
-    clearRowError(inviteId);
-    resendInvite.mutate(inviteId, {
-      onSettled: () => setBusyId(null),
-      onError: () =>
-        setRowErrors((prev) => ({ ...prev, [inviteId]: "Couldn't resend — try again" })),
-    });
-  };
-
-  const handleCancel = (inviteId: number) => {
-    setBusyId(inviteId);
-    clearRowError(inviteId);
-    cancelInvite.mutate(inviteId, {
-      onSettled: () => setBusyId(null),
-      onError: () =>
-        setRowErrors((prev) => ({ ...prev, [inviteId]: "Couldn't cancel — try again" })),
-    });
-  };
-
-  return (
-    <div className="mt-6">
-      <h3 className="mb-3 text-sm font-semibold text-text-primary">Pending Invites</h3>
-
-      {isLoading && (
-        <div className="h-16 animate-pulse rounded-xl bg-white" data-testid="pending-invites-loading" />
-      )}
-
-      {!isLoading && isError && (
-        <p className="text-sm text-text-secondary">Couldn&apos;t load pending invites.</p>
-      )}
-
-      {!isLoading && !isError && (invites == null || invites.length === 0) && (
-        <p className="text-sm text-text-secondary">No pending invites.</p>
-      )}
-
-      {!isLoading && !isError && invites && invites.length > 0 && (
-        <div className="flex flex-col gap-2">
-          {invites.map((invite) => (
-            <PendingInviteRow
-              key={invite.id}
-              invite={invite}
-              onResend={() => handleResend(invite.id)}
-              onCancel={() => handleCancel(invite.id)}
-              isResending={busyId === invite.id && resendInvite.isPending}
-              isCancelling={busyId === invite.id && cancelInvite.isPending}
-              error={rowErrors[invite.id]}
-            />
-          ))}
-        </div>
-      )}
-    </div>
-  );
+> = {
+  makeOwner: {
+    title: 'Make owner',
+    confirmLabel: 'Make owner',
+    danger: false,
+    getMessage: (member, lobbyName) =>
+      `Make @${member.username} the owner of "${lobbyName}"? You will become a regular member.`,
+  },
+  remove: {
+    title: 'Remove member',
+    confirmLabel: 'Remove',
+    danger: true,
+    getMessage: (member, lobbyName) =>
+      `Remove @${member.username} from "${lobbyName}"? They will lose access to shared events and tasks.`,
+  },
 };
 
 interface LobbyMemberListProps {
@@ -209,14 +101,13 @@ export const LobbyMemberList = ({ lobby }: LobbyMemberListProps) => {
 
       {pendingAction && (
         <ConfirmDialog
-          title={pendingAction.kind === 'makeOwner' ? 'Make owner' : 'Remove member'}
-          message={
-            pendingAction.kind === 'makeOwner'
-              ? `Make @${pendingAction.member.username} the owner of "${lobby.name}"? You will become a regular member.`
-              : `Remove @${pendingAction.member.username} from "${lobby.name}"? They will lose access to shared events and tasks.`
-          }
-          confirmLabel={pendingAction.kind === 'makeOwner' ? 'Make owner' : 'Remove'}
-          danger={pendingAction.kind === 'remove'}
+          title={MEMBER_ACTION_CONFIG[pendingAction.kind].title}
+          message={MEMBER_ACTION_CONFIG[pendingAction.kind].getMessage(
+            pendingAction.member,
+            lobby.name,
+          )}
+          confirmLabel={MEMBER_ACTION_CONFIG[pendingAction.kind].confirmLabel}
+          danger={MEMBER_ACTION_CONFIG[pendingAction.kind].danger}
           isPending={updateOwner.isPending || removeMember.isPending}
           error={actionError}
           onConfirm={handleConfirm}

--- a/lined-web/src/components/lobby/LobbyMemberList.tsx
+++ b/lined-web/src/components/lobby/LobbyMemberList.tsx
@@ -1,0 +1,228 @@
+import { useState } from 'react';
+import type { LobbyDto, LobbyInviteDto, UserDto } from '@/types';
+import { useUsers } from '@/hooks/useUsers';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useUpdateLobbyOwner, useRemoveMember } from '@/hooks/useLobbies';
+import { useLobbyInvites, useResendInvite, useCancelInvite } from '@/hooks/useInvites';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { MemberCard } from './MemberCard';
+import { PendingInviteRow } from './PendingInviteRow';
+
+type PendingAction = { kind: 'makeOwner' | 'remove'; member: UserDto } | null;
+
+interface MemberListContentProps {
+  memberQueries: ReturnType<typeof useUsers>;
+  lobby: LobbyDto;
+  currentUserId: number | undefined;
+  isOwnerViewer: boolean;
+  onMakeOwner: (member: UserDto) => void;
+  onRemove: (member: UserDto) => void;
+}
+
+const MemberListContent = ({
+  memberQueries,
+  lobby,
+  currentUserId,
+  isOwnerViewer,
+  onMakeOwner,
+  onRemove,
+}: MemberListContentProps) => {
+  if (memberQueries.some((q) => q.isLoading)) {
+    return (
+      <div className="flex flex-col gap-2" data-testid="lobby-members-loading">
+        {[0, 1].map((i) => (
+          <div key={i} className="h-20 animate-pulse rounded-lg bg-white" />
+        ))}
+      </div>
+    );
+  }
+
+  if (memberQueries.some((q) => q.isError)) {
+    return <p className="text-sm text-text-secondary">Couldn&apos;t load members. Try again later.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {memberQueries.map((q, i) => {
+        const member = q.data;
+        if (!member) return null;
+        const memberId = lobby.memberIds[i];
+        return (
+          <MemberCard
+            key={memberId}
+            member={member}
+            isOwner={memberId === lobby.ownerId}
+            isCurrentUser={memberId === currentUserId}
+            canManage={isOwnerViewer}
+            onMakeOwner={() => onMakeOwner(member)}
+            onRemove={() => onRemove(member)}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+interface PendingInvitesSectionProps {
+  lobbyId: number;
+  invites: LobbyInviteDto[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+const PendingInvitesSection = ({
+  lobbyId,
+  invites,
+  isLoading,
+  isError,
+}: PendingInvitesSectionProps) => {
+  const resendInvite = useResendInvite(lobbyId);
+  const cancelInvite = useCancelInvite(lobbyId);
+  const [busyId, setBusyId] = useState<number | null>(null);
+  const [rowErrors, setRowErrors] = useState<Record<number, string>>({});
+
+  const clearRowError = (inviteId: number) =>
+    setRowErrors((prev) => {
+      if (!(inviteId in prev)) return prev;
+      const next = { ...prev };
+      delete next[inviteId];
+      return next;
+    });
+
+  const handleResend = (inviteId: number) => {
+    setBusyId(inviteId);
+    clearRowError(inviteId);
+    resendInvite.mutate(inviteId, {
+      onSettled: () => setBusyId(null),
+      onError: () =>
+        setRowErrors((prev) => ({ ...prev, [inviteId]: "Couldn't resend — try again" })),
+    });
+  };
+
+  const handleCancel = (inviteId: number) => {
+    setBusyId(inviteId);
+    clearRowError(inviteId);
+    cancelInvite.mutate(inviteId, {
+      onSettled: () => setBusyId(null),
+      onError: () =>
+        setRowErrors((prev) => ({ ...prev, [inviteId]: "Couldn't cancel — try again" })),
+    });
+  };
+
+  return (
+    <div className="mt-6">
+      <h3 className="mb-3 text-sm font-semibold text-text-primary">Pending Invites</h3>
+
+      {isLoading && (
+        <div className="h-16 animate-pulse rounded-xl bg-white" data-testid="pending-invites-loading" />
+      )}
+
+      {!isLoading && isError && (
+        <p className="text-sm text-text-secondary">Couldn&apos;t load pending invites.</p>
+      )}
+
+      {!isLoading && !isError && (invites == null || invites.length === 0) && (
+        <p className="text-sm text-text-secondary">No pending invites.</p>
+      )}
+
+      {!isLoading && !isError && invites && invites.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {invites.map((invite) => (
+            <PendingInviteRow
+              key={invite.id}
+              invite={invite}
+              onResend={() => handleResend(invite.id)}
+              onCancel={() => handleCancel(invite.id)}
+              isResending={busyId === invite.id && resendInvite.isPending}
+              isCancelling={busyId === invite.id && cancelInvite.isPending}
+              error={rowErrors[invite.id]}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface LobbyMemberListProps {
+  lobby: LobbyDto;
+}
+
+export const LobbyMemberList = ({ lobby }: LobbyMemberListProps) => {
+  const { data: currentUser } = useCurrentUser();
+  const memberQueries = useUsers(lobby.memberIds);
+  const isOwnerViewer = currentUser != null && currentUser.id === lobby.ownerId;
+
+  const invitesQuery = useLobbyInvites(isOwnerViewer ? lobby.id : undefined);
+
+  const updateOwner = useUpdateLobbyOwner(lobby.id);
+  const removeMember = useRemoveMember(lobby.id);
+  const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const closeDialog = () => {
+    setPendingAction(null);
+    setActionError(null);
+  };
+
+  const handleConfirm = () => {
+    if (!pendingAction) return;
+    setActionError(null);
+    if (pendingAction.kind === 'makeOwner') {
+      updateOwner.mutate(pendingAction.member.id, {
+        onSuccess: () => closeDialog(),
+        onError: () => setActionError('Could not transfer ownership — please try again'),
+      });
+    } else {
+      removeMember.mutate(pendingAction.member.id, {
+        onSuccess: () => closeDialog(),
+        onError: () => setActionError('Could not remove this member — please try again'),
+      });
+    }
+  };
+
+  return (
+    <div className="p-6">
+      <div className="mb-5">
+        <span className="text-sm font-semibold text-text-primary">
+          Members · {lobby.memberIds.length}
+        </span>
+      </div>
+
+      <MemberListContent
+        memberQueries={memberQueries}
+        lobby={lobby}
+        currentUserId={currentUser?.id}
+        isOwnerViewer={isOwnerViewer}
+        onMakeOwner={(member) => setPendingAction({ kind: 'makeOwner', member })}
+        onRemove={(member) => setPendingAction({ kind: 'remove', member })}
+      />
+
+      {isOwnerViewer && (
+        <PendingInvitesSection
+          lobbyId={lobby.id}
+          invites={invitesQuery.data}
+          isLoading={invitesQuery.isLoading}
+          isError={invitesQuery.isError}
+        />
+      )}
+
+      {pendingAction && (
+        <ConfirmDialog
+          title={pendingAction.kind === 'makeOwner' ? 'Make owner' : 'Remove member'}
+          message={
+            pendingAction.kind === 'makeOwner'
+              ? `Make @${pendingAction.member.username} the owner of "${lobby.name}"? You will become a regular member.`
+              : `Remove @${pendingAction.member.username} from "${lobby.name}"? They will lose access to shared events and tasks.`
+          }
+          confirmLabel={pendingAction.kind === 'makeOwner' ? 'Make owner' : 'Remove'}
+          danger={pendingAction.kind === 'remove'}
+          isPending={updateOwner.isPending || removeMember.isPending}
+          error={actionError}
+          onConfirm={handleConfirm}
+          onCancel={closeDialog}
+        />
+      )}
+    </div>
+  );
+};

--- a/lined-web/src/components/lobby/MemberCard.tsx
+++ b/lined-web/src/components/lobby/MemberCard.tsx
@@ -1,0 +1,72 @@
+import type { UserDto } from '@/types';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { formatMonthYear } from '@/lib/calendarUtils';
+
+interface MemberCardProps {
+  member: UserDto;
+  isOwner: boolean;
+  isCurrentUser: boolean;
+  /** Whether the viewer (current user) may manage this member — owner-only actions. */
+  canManage: boolean;
+  onMakeOwner: () => void;
+  onRemove: () => void;
+}
+
+export const MemberCard = ({
+  member,
+  isOwner,
+  isCurrentUser,
+  canManage,
+  onMakeOwner,
+  onRemove,
+}: MemberCardProps) => {
+  return (
+    <div className="flex items-center gap-4 rounded-lg bg-white p-4 shadow-[var(--shadow-sm)]">
+      <Avatar size="lg">
+        <AvatarFallback className="bg-brand-green text-sm font-semibold text-white">
+          {member.username.charAt(0).toUpperCase()}
+        </AvatarFallback>
+      </Avatar>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <p className="text-sm font-semibold text-text-primary">{member.username}</p>
+          <span
+            className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+              isOwner ? 'bg-brand-green/10 text-brand-green' : 'bg-gray-100 text-text-secondary'
+            }`}
+          >
+            {isOwner ? 'Owner' : 'Member'}
+          </span>
+        </div>
+        <p className="text-xs text-text-secondary">@{member.username}</p>
+        {/* No "joined lobby at" timestamp exists on the API — substitute the account creation date. */}
+        <p className="text-xs text-text-muted">Member since {formatMonthYear(new Date(member.createdAt))}</p>
+      </div>
+
+      <div className="flex flex-shrink-0 items-center gap-2">
+        {isCurrentUser && (
+          <span className="px-2 text-xs text-text-muted">That&apos;s you</span>
+        )}
+        {!isCurrentUser && canManage && (
+          <>
+            <button
+              type="button"
+              onClick={onMakeOwner}
+              className="h-8 rounded-lg border border-border px-3 text-xs font-medium text-text-primary hover:bg-gray-50"
+            >
+              Make owner
+            </button>
+            <button
+              type="button"
+              onClick={onRemove}
+              className="h-8 rounded-lg border border-red-200 px-3 text-xs font-medium text-red-600 hover:bg-red-50"
+            >
+              Remove
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/lined-web/src/components/lobby/MemberListContent.tsx
+++ b/lined-web/src/components/lobby/MemberListContent.tsx
@@ -1,0 +1,56 @@
+import type { LobbyDto, UserDto } from '@/types';
+import type { useUsers } from '@/hooks/useUsers';
+import { MemberCard } from './MemberCard';
+
+interface MemberListContentProps {
+  memberQueries: ReturnType<typeof useUsers>;
+  lobby: LobbyDto;
+  currentUserId: number | undefined;
+  isOwnerViewer: boolean;
+  onMakeOwner: (member: UserDto) => void;
+  onRemove: (member: UserDto) => void;
+}
+
+export const MemberListContent = ({
+  memberQueries,
+  lobby,
+  currentUserId,
+  isOwnerViewer,
+  onMakeOwner,
+  onRemove,
+}: MemberListContentProps) => {
+  if (memberQueries.some((q) => q.isLoading)) {
+    return (
+      <div className="flex flex-col gap-2" data-testid="lobby-members-loading">
+        {[0, 1].map((i) => (
+          <div key={i} className="h-20 animate-pulse rounded-lg bg-white" />
+        ))}
+      </div>
+    );
+  }
+
+  if (memberQueries.some((q) => q.isError)) {
+    return <p className="text-sm text-text-secondary">Couldn&apos;t load members. Try again later.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {memberQueries.map((q, i) => {
+        const member = q.data;
+        if (!member) return null;
+        const memberId = lobby.memberIds[i];
+        return (
+          <MemberCard
+            key={memberId}
+            member={member}
+            isOwner={memberId === lobby.ownerId}
+            isCurrentUser={memberId === currentUserId}
+            canManage={isOwnerViewer}
+            onMakeOwner={() => onMakeOwner(member)}
+            onRemove={() => onRemove(member)}
+          />
+        );
+      })}
+    </div>
+  );
+};

--- a/lined-web/src/components/lobby/PendingInviteRow.tsx
+++ b/lined-web/src/components/lobby/PendingInviteRow.tsx
@@ -1,0 +1,58 @@
+import type { LobbyInviteDto } from '@/types';
+import { useUser } from '@/hooks/useUsers';
+
+interface PendingInviteRowProps {
+  invite: LobbyInviteDto;
+  onResend: () => void;
+  onCancel: () => void;
+  isResending: boolean;
+  isCancelling: boolean;
+  error?: string;
+}
+
+export const PendingInviteRow = ({
+  invite,
+  onResend,
+  onCancel,
+  isResending,
+  isCancelling,
+  error,
+}: PendingInviteRowProps) => {
+  const { data: invitee, isLoading } = useUser(invite.inviteeId);
+  const sentAt = new Date(invite.sentAt).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  return (
+    <div className="flex items-center gap-3.5 rounded-xl bg-white p-4 shadow-[var(--shadow-sm)]">
+      <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-gray-200 text-lg text-text-secondary">
+        ?
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-text-primary">
+          {isLoading ? 'Loading…' : (invitee?.username ?? `User #${invite.inviteeId}`)}
+        </p>
+        <p className="mt-0.5 text-xs text-text-secondary">Invite sent · {sentAt}</p>
+        {error && <p className="mt-0.5 text-xs text-red-600">{error}</p>}
+      </div>
+      <button
+        type="button"
+        onClick={onResend}
+        disabled={isResending || isCancelling}
+        className="h-8 flex-shrink-0 rounded-lg border border-border px-3 text-xs font-medium text-text-primary hover:bg-gray-50 disabled:opacity-60"
+      >
+        {isResending ? 'Resending…' : 'Resend'}
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={isResending || isCancelling}
+        className="h-8 flex-shrink-0 rounded-lg border border-red-200 px-3 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-60"
+      >
+        {isCancelling ? 'Cancelling…' : 'Cancel'}
+      </button>
+    </div>
+  );
+};

--- a/lined-web/src/components/lobby/PendingInvitesSection.tsx
+++ b/lined-web/src/components/lobby/PendingInvitesSection.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import type { LobbyInviteDto } from '@/types';
+import { useResendInvite, useCancelInvite } from '@/hooks/useInvites';
+import { PendingInviteRow } from './PendingInviteRow';
+
+interface PendingInvitesSectionProps {
+  lobbyId: number;
+  invites: LobbyInviteDto[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export const PendingInvitesSection = ({
+  lobbyId,
+  invites,
+  isLoading,
+  isError,
+}: PendingInvitesSectionProps) => {
+  const resendInvite = useResendInvite(lobbyId);
+  const cancelInvite = useCancelInvite(lobbyId);
+  const [busyId, setBusyId] = useState<number | null>(null);
+  const [rowErrors, setRowErrors] = useState<Record<number, string>>({});
+
+  const clearRowError = (inviteId: number) =>
+    setRowErrors((prev) => {
+      if (!(inviteId in prev)) return prev;
+      const next = { ...prev };
+      delete next[inviteId];
+      return next;
+    });
+
+  const handleResend = (inviteId: number) => {
+    setBusyId(inviteId);
+    clearRowError(inviteId);
+    resendInvite.mutate(inviteId, {
+      onSettled: () => setBusyId(null),
+      onError: () =>
+        setRowErrors((prev) => ({ ...prev, [inviteId]: "Couldn't resend — try again" })),
+    });
+  };
+
+  const handleCancel = (inviteId: number) => {
+    setBusyId(inviteId);
+    clearRowError(inviteId);
+    cancelInvite.mutate(inviteId, {
+      onSettled: () => setBusyId(null),
+      onError: () =>
+        setRowErrors((prev) => ({ ...prev, [inviteId]: "Couldn't cancel — try again" })),
+    });
+  };
+
+  return (
+    <div className="mt-6">
+      <h3 className="mb-3 text-sm font-semibold text-text-primary">Pending Invites</h3>
+
+      {isLoading && (
+        <div className="h-16 animate-pulse rounded-xl bg-white" data-testid="pending-invites-loading" />
+      )}
+
+      {!isLoading && isError && (
+        <p className="text-sm text-text-secondary">Couldn&apos;t load pending invites.</p>
+      )}
+
+      {!isLoading && !isError && (invites == null || invites.length === 0) && (
+        <p className="text-sm text-text-secondary">No pending invites.</p>
+      )}
+
+      {!isLoading && !isError && invites && invites.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {invites.map((invite) => (
+            <PendingInviteRow
+              key={invite.id}
+              invite={invite}
+              onResend={() => handleResend(invite.id)}
+              onCancel={() => handleCancel(invite.id)}
+              isResending={busyId === invite.id && resendInvite.isPending}
+              isCancelling={busyId === invite.id && cancelInvite.isPending}
+              error={rowErrors[invite.id]}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/lined-web/src/components/lobby/SearchResultRow.tsx
+++ b/lined-web/src/components/lobby/SearchResultRow.tsx
@@ -1,0 +1,48 @@
+import type { UserSearchResultDto } from '@/types';
+
+interface SearchResultRowProps {
+  user: UserSearchResultDto;
+  isMember: boolean;
+  isInvited: boolean;
+  isSending: boolean;
+  error?: string;
+  onInvite: () => void;
+}
+
+export const SearchResultRow = ({
+  user,
+  isMember,
+  isInvited,
+  isSending,
+  error,
+  onInvite,
+}: SearchResultRowProps) => {
+  return (
+    <div
+      className={`flex items-center gap-3 rounded-lg p-2.5 ${isMember ? 'bg-brand-green-light' : ''}`}
+    >
+      <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-brand-green text-sm font-bold text-white">
+        {user.username.charAt(0).toUpperCase()}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-text-primary">{user.username}</p>
+        <p className="text-xs text-text-secondary">
+          @{user.username}
+          {isMember && ' · already in lobby'}
+        </p>
+        {error && <p className="mt-0.5 text-xs text-red-600">{error}</p>}
+      </div>
+      {isMember && <span className="text-lg text-task-done">✓</span>}
+      {!isMember && (
+        <button
+          type="button"
+          onClick={onInvite}
+          disabled={isInvited || isSending}
+          className="h-8 flex-shrink-0 rounded-lg bg-brand-green px-3.5 text-xs font-semibold text-white hover:bg-brand-green-dark disabled:opacity-60"
+        >
+          {isSending ? 'Inviting…' : isInvited ? 'Invite sent' : 'Invite'}
+        </button>
+      )}
+    </div>
+  );
+};

--- a/lined-web/src/components/lobby/SearchResultsList.tsx
+++ b/lined-web/src/components/lobby/SearchResultsList.tsx
@@ -1,0 +1,62 @@
+import type { UserPageDto } from '@/types';
+import { SearchResultRow } from './SearchResultRow';
+
+interface SearchResultsListProps {
+  debouncedQuery: string;
+  isLoading: boolean;
+  isError: boolean;
+  results: UserPageDto | undefined;
+  memberIds: number[];
+  invitedIds: Set<number>;
+  sendingId: number | null;
+  rowErrors: Record<number, string>;
+  onInvite: (userId: number) => void;
+}
+
+export const SearchResultsList = ({
+  debouncedQuery,
+  isLoading,
+  isError,
+  results,
+  memberIds,
+  invitedIds,
+  sendingId,
+  rowErrors,
+  onInvite,
+}: SearchResultsListProps) => {
+  const hasQuery = debouncedQuery.length >= 2;
+
+  if (isLoading && hasQuery) {
+    return (
+      <div className="flex flex-col gap-2" data-testid="add-member-search-loading">
+        {[0, 1].map((i) => (
+          <div key={i} className="h-12 animate-pulse rounded-lg bg-gray-100" />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <p className="text-sm text-text-secondary">Search failed — try again.</p>;
+  }
+
+  if (hasQuery && results?.content.length === 0) {
+    return <p className="text-sm text-text-secondary">No users found.</p>;
+  }
+
+  return (
+    <>
+      {results?.content.map((user) => (
+        <SearchResultRow
+          key={user.id}
+          user={user}
+          isMember={memberIds.includes(user.id)}
+          isInvited={invitedIds.has(user.id)}
+          isSending={sendingId === user.id}
+          error={rowErrors[user.id]}
+          onInvite={() => onInvite(user.id)}
+        />
+      ))}
+    </>
+  );
+};

--- a/lined-web/src/components/lobby/__tests__/AddMemberModal.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/AddMemberModal.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders, screen, userEvent, waitFor } from '@/test/utils';
+import { server } from '@/test/server';
+import { MOCK_LOBBIES } from '@/test/data';
+import { AddMemberModal } from '../AddMemberModal';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+const lobby = MOCK_LOBBIES[0]!; // id 1, memberIds [1, 2]
+
+describe('AddMemberModal', () => {
+  it('renders the title, search input, and invite-link hint', () => {
+    expect.assertions(3);
+    renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Add Member')).toBeInTheDocument();
+    expect(screen.getByLabelText('Search user')).toBeInTheDocument();
+    expect(screen.getByText(/You can also share an invite link/)).toBeInTheDocument();
+  });
+
+  it('prompts for at least 2 characters before searching', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
+
+    await user.type(screen.getByLabelText('Search user'), 'n');
+
+    expect(
+      await screen.findByText('Type at least 2 characters to search.'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows matching users once the debounced query resolves', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
+
+    await user.type(screen.getByLabelText('Search user'), 'nastia');
+
+    expect(await screen.findByText('nastia_k', {}, { timeout: 2000 })).toBeInTheDocument();
+    expect(screen.getByText('nastia_bondar')).toBeInTheDocument();
+  });
+
+  it('marks an existing member as already in the lobby with no Invite button', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
+
+    await user.type(screen.getByLabelText('Search user'), 'nastia_k');
+    await screen.findByText('nastia_k', {}, { timeout: 2000 });
+
+    expect(screen.getByText('@nastia_k · already in lobby')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Invite' })).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when no users match', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
+
+    await user.type(screen.getByLabelText('Search user'), 'nobody_here');
+
+    expect(await screen.findByText('No users found.', {}, { timeout: 2000 })).toBeInTheDocument();
+  });
+
+  it('shows a search-failed message on a 500', async () => {
+    expect.assertions(1);
+    server.use(http.get(`${BASE}/users/search`, () => new HttpResponse(null, { status: 500 })));
+    const user = userEvent.setup();
+    renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
+
+    await user.type(screen.getByLabelText('Search user'), 'nastia');
+
+    expect(await screen.findByText('Search failed — try again.', {}, { timeout: 2000 })).toBeInTheDocument();
+  });
+
+  it('invites an invitable user (with no pending invite) and flips the row to "Invite sent"', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
+    await user.type(screen.getByLabelText('Search user'), 'natascha_m');
+    await screen.findByText('natascha_m', {}, { timeout: 2000 });
+
+    await user.click(screen.getByRole('button', { name: 'Invite' }));
+
+    expect(await screen.findByRole('button', { name: 'Invite sent' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Invite sent' })).toBeDisabled();
+  });
+
+  it('shows a 409 conflict message inline when the invite already exists', async () => {
+    expect.assertions(1);
+    server.use(
+      http.post(
+        `${BASE}/lobbies/:lobbyId/invites`,
+        () =>
+          HttpResponse.json(
+            { code: 'CONFLICT', message: 'A pending invite already exists for this user' },
+            { status: 409 },
+          ),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
+    await user.type(screen.getByLabelText('Search user'), 'nastia_bondar');
+    await screen.findByText('nastia_bondar', {}, { timeout: 2000 });
+
+    await user.click(screen.getByRole('button', { name: 'Invite' }));
+
+    expect(
+      await screen.findByText('Already a member or already invited'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a generic error message when the invite request fails unexpectedly (500)', async () => {
+    expect.assertions(1);
+    server.use(
+      http.post(`${BASE}/lobbies/:lobbyId/invites`, () => new HttpResponse(null, { status: 500 })),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
+    await user.type(screen.getByLabelText('Search user'), 'nastia_bondar');
+    await screen.findByText('nastia_bondar', {}, { timeout: 2000 });
+
+    await user.click(screen.getByRole('button', { name: 'Invite' }));
+
+    expect(await screen.findByText("Couldn't send invite — try again")).toBeInTheDocument();
+  });
+
+  it('calls onClose when Done is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderWithProviders(<AddMemberModal lobby={lobby} onClose={onClose} />);
+
+    await user.click(screen.getByRole('button', { name: 'Done' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when the close (X) button is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderWithProviders(<AddMemberModal lobby={lobby} onClose={onClose} />);
+
+    await user.click(screen.getByLabelText('Close'));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+});

--- a/lined-web/src/components/lobby/__tests__/AddMemberModal.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/AddMemberModal.test.tsx
@@ -3,19 +3,21 @@ import { http, HttpResponse } from 'msw';
 import { renderWithProviders, screen, userEvent, waitFor } from '@/test/utils';
 import { server } from '@/test/server';
 import { MOCK_LOBBIES } from '@/test/data';
+import { ROLES, ADD_MEMBER_MODAL_TEXT } from '@/test/lobbyMemberContent';
 import { AddMemberModal } from '../AddMemberModal';
 
 const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
 const lobby = MOCK_LOBBIES[0]!; // id 1, memberIds [1, 2]
+const SEARCH_TIMEOUT = { timeout: 2000 };
 
 describe('AddMemberModal', () => {
   it('renders the title, search input, and invite-link hint', () => {
     expect.assertions(3);
     renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
 
-    expect(screen.getByText('Add Member')).toBeInTheDocument();
-    expect(screen.getByLabelText('Search user')).toBeInTheDocument();
-    expect(screen.getByText(/You can also share an invite link/)).toBeInTheDocument();
+    expect(screen.getByText(ADD_MEMBER_MODAL_TEXT.title)).toBeInTheDocument();
+    expect(screen.getByLabelText(ADD_MEMBER_MODAL_TEXT.searchLabel)).toBeInTheDocument();
+    expect(screen.getByText(ADD_MEMBER_MODAL_TEXT.inviteLinkHint)).toBeInTheDocument();
   });
 
   it('prompts for at least 2 characters before searching', async () => {
@@ -23,11 +25,9 @@ describe('AddMemberModal', () => {
     const user = userEvent.setup();
     renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
 
-    await user.type(screen.getByLabelText('Search user'), 'n');
+    await user.type(screen.getByLabelText(ADD_MEMBER_MODAL_TEXT.searchLabel), 'n');
 
-    expect(
-      await screen.findByText('Type at least 2 characters to search.'),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(ADD_MEMBER_MODAL_TEXT.minCharsHint)).toBeInTheDocument();
   });
 
   it('shows matching users once the debounced query resolves', async () => {
@@ -35,9 +35,9 @@ describe('AddMemberModal', () => {
     const user = userEvent.setup();
     renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
 
-    await user.type(screen.getByLabelText('Search user'), 'nastia');
+    await user.type(screen.getByLabelText(ADD_MEMBER_MODAL_TEXT.searchLabel), 'nastia');
 
-    expect(await screen.findByText('nastia_k', {}, { timeout: 2000 })).toBeInTheDocument();
+    expect(await screen.findByText('nastia_k', {}, SEARCH_TIMEOUT)).toBeInTheDocument();
     expect(screen.getByText('nastia_bondar')).toBeInTheDocument();
   });
 
@@ -46,11 +46,15 @@ describe('AddMemberModal', () => {
     const user = userEvent.setup();
     renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
 
-    await user.type(screen.getByLabelText('Search user'), 'nastia_k');
-    await screen.findByText('nastia_k', {}, { timeout: 2000 });
+    await user.type(screen.getByLabelText(ADD_MEMBER_MODAL_TEXT.searchLabel), 'nastia_k');
+    await screen.findByText('nastia_k', {}, SEARCH_TIMEOUT);
 
-    expect(screen.getByText('@nastia_k · already in lobby')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Invite' })).not.toBeInTheDocument();
+    expect(
+      screen.getByText(`@nastia_k · ${ADD_MEMBER_MODAL_TEXT.alreadyMemberSuffix}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole(ROLES.button, { name: ADD_MEMBER_MODAL_TEXT.inviteButtonName }),
+    ).not.toBeInTheDocument();
   });
 
   it('shows an empty state when no users match', async () => {
@@ -58,9 +62,11 @@ describe('AddMemberModal', () => {
     const user = userEvent.setup();
     renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
 
-    await user.type(screen.getByLabelText('Search user'), 'nobody_here');
+    await user.type(screen.getByLabelText(ADD_MEMBER_MODAL_TEXT.searchLabel), 'nobody_here');
 
-    expect(await screen.findByText('No users found.', {}, { timeout: 2000 })).toBeInTheDocument();
+    expect(
+      await screen.findByText(ADD_MEMBER_MODAL_TEXT.noUsersFound, {}, SEARCH_TIMEOUT),
+    ).toBeInTheDocument();
   });
 
   it('shows a search-failed message on a 500', async () => {
@@ -69,22 +75,28 @@ describe('AddMemberModal', () => {
     const user = userEvent.setup();
     renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
 
-    await user.type(screen.getByLabelText('Search user'), 'nastia');
+    await user.type(screen.getByLabelText(ADD_MEMBER_MODAL_TEXT.searchLabel), 'nastia');
 
-    expect(await screen.findByText('Search failed — try again.', {}, { timeout: 2000 })).toBeInTheDocument();
+    expect(
+      await screen.findByText(ADD_MEMBER_MODAL_TEXT.searchFailed, {}, SEARCH_TIMEOUT),
+    ).toBeInTheDocument();
   });
 
   it('invites an invitable user (with no pending invite) and flips the row to "Invite sent"', async () => {
     expect.assertions(2);
     const user = userEvent.setup();
     renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
-    await user.type(screen.getByLabelText('Search user'), 'natascha_m');
-    await screen.findByText('natascha_m', {}, { timeout: 2000 });
+    await user.type(screen.getByLabelText(ADD_MEMBER_MODAL_TEXT.searchLabel), 'natascha_m');
+    await screen.findByText('natascha_m', {}, SEARCH_TIMEOUT);
 
-    await user.click(screen.getByRole('button', { name: 'Invite' }));
+    await user.click(screen.getByRole(ROLES.button, { name: ADD_MEMBER_MODAL_TEXT.inviteButtonName }));
 
-    expect(await screen.findByRole('button', { name: 'Invite sent' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Invite sent' })).toBeDisabled();
+    expect(
+      await screen.findByRole(ROLES.button, { name: ADD_MEMBER_MODAL_TEXT.inviteSentButtonName }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole(ROLES.button, { name: ADD_MEMBER_MODAL_TEXT.inviteSentButtonName }),
+    ).toBeDisabled();
   });
 
   it('shows a 409 conflict message inline when the invite already exists', async () => {
@@ -101,14 +113,12 @@ describe('AddMemberModal', () => {
     );
     const user = userEvent.setup();
     renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
-    await user.type(screen.getByLabelText('Search user'), 'nastia_bondar');
-    await screen.findByText('nastia_bondar', {}, { timeout: 2000 });
+    await user.type(screen.getByLabelText(ADD_MEMBER_MODAL_TEXT.searchLabel), 'nastia_bondar');
+    await screen.findByText('nastia_bondar', {}, SEARCH_TIMEOUT);
 
-    await user.click(screen.getByRole('button', { name: 'Invite' }));
+    await user.click(screen.getByRole(ROLES.button, { name: ADD_MEMBER_MODAL_TEXT.inviteButtonName }));
 
-    expect(
-      await screen.findByText('Already a member or already invited'),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(ADD_MEMBER_MODAL_TEXT.conflictError)).toBeInTheDocument();
   });
 
   it('shows a generic error message when the invite request fails unexpectedly (500)', async () => {
@@ -118,12 +128,12 @@ describe('AddMemberModal', () => {
     );
     const user = userEvent.setup();
     renderWithProviders(<AddMemberModal lobby={lobby} onClose={vi.fn()} />);
-    await user.type(screen.getByLabelText('Search user'), 'nastia_bondar');
-    await screen.findByText('nastia_bondar', {}, { timeout: 2000 });
+    await user.type(screen.getByLabelText(ADD_MEMBER_MODAL_TEXT.searchLabel), 'nastia_bondar');
+    await screen.findByText('nastia_bondar', {}, SEARCH_TIMEOUT);
 
-    await user.click(screen.getByRole('button', { name: 'Invite' }));
+    await user.click(screen.getByRole(ROLES.button, { name: ADD_MEMBER_MODAL_TEXT.inviteButtonName }));
 
-    expect(await screen.findByText("Couldn't send invite — try again")).toBeInTheDocument();
+    expect(await screen.findByText(ADD_MEMBER_MODAL_TEXT.genericInviteError)).toBeInTheDocument();
   });
 
   it('calls onClose when Done is clicked', async () => {
@@ -132,7 +142,7 @@ describe('AddMemberModal', () => {
     const onClose = vi.fn();
     renderWithProviders(<AddMemberModal lobby={lobby} onClose={onClose} />);
 
-    await user.click(screen.getByRole('button', { name: 'Done' }));
+    await user.click(screen.getByRole(ROLES.button, { name: ADD_MEMBER_MODAL_TEXT.doneButtonName }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -143,7 +153,7 @@ describe('AddMemberModal', () => {
     const onClose = vi.fn();
     renderWithProviders(<AddMemberModal lobby={lobby} onClose={onClose} />);
 
-    await user.click(screen.getByLabelText('Close'));
+    await user.click(screen.getByLabelText(ADD_MEMBER_MODAL_TEXT.closeButtonName));
 
     await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
   });

--- a/lined-web/src/components/lobby/__tests__/LobbyHeader.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/LobbyHeader.test.tsx
@@ -3,6 +3,7 @@ import { http, HttpResponse } from 'msw';
 import { renderWithProviders, screen, userEvent } from '@/test/utils';
 import { server } from '@/test/server';
 import { MOCK_LOBBIES } from '@/test/data';
+import { ADD_MEMBER_MODAL_TEXT } from '@/test/lobbyMemberContent';
 import { LobbyHeader } from '../LobbyHeader';
 
 const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
@@ -51,9 +52,9 @@ describe('LobbyHeader', () => {
     const user = userEvent.setup();
     renderWithProviders(<LobbyHeader lobby={lobby} />);
 
-    expect(screen.queryByText('Add Member')).not.toBeInTheDocument();
+    expect(screen.queryByText(ADD_MEMBER_MODAL_TEXT.title)).not.toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: '+ Add member' }));
 
-    expect(screen.getByText('Add Member')).toBeInTheDocument();
+    expect(screen.getByText(ADD_MEMBER_MODAL_TEXT.title)).toBeInTheDocument();
   });
 });

--- a/lined-web/src/components/lobby/__tests__/LobbyHeader.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/LobbyHeader.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { renderWithProviders, screen } from '@/test/utils';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
 import { server } from '@/test/server';
 import { MOCK_LOBBIES } from '@/test/data';
 import { LobbyHeader } from '../LobbyHeader';
@@ -44,5 +44,16 @@ describe('LobbyHeader', () => {
 
     const avatars = await screen.findByText('?');
     expect(avatars).toBeInTheDocument();
+  });
+
+  it('opens the Add Member modal when "+ Add member" is clicked', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyHeader lobby={lobby} />);
+
+    expect(screen.queryByText('Add Member')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: '+ Add member' }));
+
+    expect(screen.getByText('Add Member')).toBeInTheDocument();
   });
 });

--- a/lined-web/src/components/lobby/__tests__/LobbyMemberList.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/LobbyMemberList.test.tsx
@@ -4,6 +4,14 @@ import { renderWithProviders, screen, userEvent, waitFor } from '@/test/utils';
 import { server } from '@/test/server';
 import { MOCK_LOBBIES } from '@/test/data';
 import { useAuthStore } from '@/store/auth';
+import {
+  ROLES,
+  TEST_IDS,
+  NUMBERS,
+  MEMBER_CARD_TEXT,
+  PENDING_INVITE_TEXT,
+  LOBBY_MEMBER_LIST_TEXT,
+} from '@/test/lobbyMemberContent';
 import { LobbyMemberList } from '../LobbyMemberList';
 
 const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
@@ -18,17 +26,19 @@ describe('LobbyMemberList', () => {
     expect.assertions(1);
     renderWithProviders(<LobbyMemberList lobby={lobby} />);
 
-    expect(screen.getByTestId('lobby-members-loading')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.lobbyMembersLoading)).toBeInTheDocument();
   });
 
   it('renders the member count, role badges, and "that\'s you" for the current user', async () => {
     expect.assertions(4);
     renderWithProviders(<LobbyMemberList lobby={lobby} />);
 
-    expect(await screen.findByText('Owner')).toBeInTheDocument();
-    expect(screen.getByText('Members · 2')).toBeInTheDocument();
-    expect(screen.getByText('Member')).toBeInTheDocument();
-    expect(screen.getByText("That's you")).toBeInTheDocument();
+    expect(await screen.findByText(MEMBER_CARD_TEXT.ownerBadge)).toBeInTheDocument();
+    expect(
+      screen.getByText(LOBBY_MEMBER_LIST_TEXT.membersHeading(NUMBERS.aliceAndAnastasiiaMemberCount)),
+    ).toBeInTheDocument();
+    expect(screen.getByText(MEMBER_CARD_TEXT.memberBadge)).toBeInTheDocument();
+    expect(screen.getByText(MEMBER_CARD_TEXT.thatsYou)).toBeInTheDocument();
   });
 
   it('shows an error message when a member profile fails to load', async () => {
@@ -36,9 +46,7 @@ describe('LobbyMemberList', () => {
     server.use(http.get(`${BASE}/users/:id`, () => new HttpResponse(null, { status: 500 })));
     renderWithProviders(<LobbyMemberList lobby={lobby} />);
 
-    expect(
-      await screen.findByText("Couldn't load members. Try again later."),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(LOBBY_MEMBER_LIST_TEXT.loadMembersError)).toBeInTheDocument();
   });
 
   it('shows owner-only management actions and the Pending Invites section for the owner', async () => {
@@ -46,9 +54,15 @@ describe('LobbyMemberList', () => {
     renderWithProviders(<LobbyMemberList lobby={lobby} />);
     await screen.findByText('nastia_k');
 
-    expect(screen.getByRole('button', { name: 'Make owner' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
-    expect(await screen.findByText('Pending Invites')).toBeInTheDocument();
+    expect(
+      screen.getByRole(ROLES.button, { name: MEMBER_CARD_TEXT.makeOwnerButtonName }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole(ROLES.button, { name: MEMBER_CARD_TEXT.removeButtonName }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(LOBBY_MEMBER_LIST_TEXT.pendingInvitesHeading),
+    ).toBeInTheDocument();
   });
 
   it('hides management actions and the Pending Invites section for a non-owner viewer', async () => {
@@ -56,9 +70,13 @@ describe('LobbyMemberList', () => {
     useAuthStore.setState({ userId: 2, token: 'token' });
     renderWithProviders(<LobbyMemberList lobby={lobby} />);
 
-    expect(await screen.findByText("That's you")).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Make owner' })).not.toBeInTheDocument();
-    expect(screen.queryByText('Pending Invites')).not.toBeInTheDocument();
+    expect(await screen.findByText(MEMBER_CARD_TEXT.thatsYou)).toBeInTheDocument();
+    expect(
+      screen.queryByRole(ROLES.button, { name: MEMBER_CARD_TEXT.makeOwnerButtonName }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(LOBBY_MEMBER_LIST_TEXT.pendingInvitesHeading),
+    ).not.toBeInTheDocument();
   });
 
   it('resolves and renders the pending invite for the owner', async () => {
@@ -74,7 +92,7 @@ describe('LobbyMemberList', () => {
     server.use(http.get(`${BASE}/lobbies/:lobbyId/invites`, () => HttpResponse.json([])));
     renderWithProviders(<LobbyMemberList lobby={lobby} />);
 
-    expect(await screen.findByText('No pending invites.')).toBeInTheDocument();
+    expect(await screen.findByText(LOBBY_MEMBER_LIST_TEXT.noPendingInvites)).toBeInTheDocument();
   });
 
   it('shows an error message when pending invites fail to load', async () => {
@@ -84,7 +102,7 @@ describe('LobbyMemberList', () => {
     );
     renderWithProviders(<LobbyMemberList lobby={lobby} />);
 
-    expect(await screen.findByText("Couldn't load pending invites.")).toBeInTheDocument();
+    expect(await screen.findByText(LOBBY_MEMBER_LIST_TEXT.loadInvitesError)).toBeInTheDocument();
   });
 
   it('resends a pending invite', async () => {
@@ -93,10 +111,12 @@ describe('LobbyMemberList', () => {
     renderWithProviders(<LobbyMemberList lobby={lobby} />);
     await screen.findByText('nastia_bondar');
 
-    await user.click(screen.getByRole('button', { name: 'Resend' }));
+    await user.click(screen.getByRole(ROLES.button, { name: PENDING_INVITE_TEXT.resendButtonName }));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Resend' })).toBeEnabled();
+      expect(
+        screen.getByRole(ROLES.button, { name: PENDING_INVITE_TEXT.resendButtonName }),
+      ).toBeEnabled();
     });
   });
 
@@ -112,9 +132,9 @@ describe('LobbyMemberList', () => {
     renderWithProviders(<LobbyMemberList lobby={lobby} />);
     await screen.findByText('nastia_bondar');
 
-    await user.click(screen.getByRole('button', { name: 'Resend' }));
+    await user.click(screen.getByRole(ROLES.button, { name: PENDING_INVITE_TEXT.resendButtonName }));
 
-    expect(await screen.findByText("Couldn't resend — try again")).toBeInTheDocument();
+    expect(await screen.findByText(LOBBY_MEMBER_LIST_TEXT.resendError)).toBeInTheDocument();
   });
 
   it('cancels a pending invite without leaving it stuck in a pending state', async () => {
@@ -123,10 +143,12 @@ describe('LobbyMemberList', () => {
     renderWithProviders(<LobbyMemberList lobby={lobby} />);
     await screen.findByText('nastia_bondar');
 
-    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await user.click(screen.getByRole(ROLES.button, { name: PENDING_INVITE_TEXT.cancelButtonName }));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+      expect(
+        screen.getByRole(ROLES.button, { name: PENDING_INVITE_TEXT.cancelButtonName }),
+      ).toBeEnabled();
     });
   });
 
@@ -136,18 +158,22 @@ describe('LobbyMemberList', () => {
     renderWithProviders(<LobbyMemberList lobby={lobby} />);
     await screen.findByText('nastia_k');
 
-    await user.click(screen.getByRole('button', { name: 'Make owner' }));
+    await user.click(screen.getByRole(ROLES.button, { name: MEMBER_CARD_TEXT.makeOwnerButtonName }));
     expect(
       screen.getByText(
         'Make @nastia_k the owner of "Alex & Anastasiia"? You will become a regular member.',
       ),
     ).toBeInTheDocument();
 
-    const [, confirmButton] = screen.getAllByRole('button', { name: 'Make owner' });
+    const [, confirmButton] = screen.getAllByRole(ROLES.button, {
+      name: MEMBER_CARD_TEXT.makeOwnerButtonName,
+    });
     await user.click(confirmButton!);
 
     await waitFor(() => {
-      expect(screen.queryByRole('heading', { name: 'Make owner' })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole(ROLES.heading, { name: MEMBER_CARD_TEXT.makeOwnerButtonName }),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -158,13 +184,13 @@ describe('LobbyMemberList', () => {
     renderWithProviders(<LobbyMemberList lobby={lobby} />);
     await screen.findByText('nastia_k');
 
-    await user.click(screen.getByRole('button', { name: 'Make owner' }));
-    const [, confirmButton] = screen.getAllByRole('button', { name: 'Make owner' });
+    await user.click(screen.getByRole(ROLES.button, { name: MEMBER_CARD_TEXT.makeOwnerButtonName }));
+    const [, confirmButton] = screen.getAllByRole(ROLES.button, {
+      name: MEMBER_CARD_TEXT.makeOwnerButtonName,
+    });
     await user.click(confirmButton!);
 
-    expect(
-      await screen.findByText('Could not transfer ownership — please try again'),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(LOBBY_MEMBER_LIST_TEXT.makeOwnerError)).toBeInTheDocument();
   });
 
   it('opens a confirm dialog and removes the member when "Remove" is confirmed', async () => {
@@ -173,12 +199,14 @@ describe('LobbyMemberList', () => {
     renderWithProviders(<LobbyMemberList lobby={lobby} />);
     await screen.findByText('nastia_k');
 
-    await user.click(screen.getByRole('button', { name: 'Remove' }));
-    const [, confirmButton] = screen.getAllByRole('button', { name: 'Remove' });
+    await user.click(screen.getByRole(ROLES.button, { name: MEMBER_CARD_TEXT.removeButtonName }));
+    const [, confirmButton] = screen.getAllByRole(ROLES.button, {
+      name: MEMBER_CARD_TEXT.removeButtonName,
+    });
     await user.click(confirmButton!);
 
     await waitFor(() => {
-      expect(screen.queryByRole('heading', { name: 'Remove member' })).not.toBeInTheDocument();
+      expect(screen.queryByRole(ROLES.heading, { name: 'Remove member' })).not.toBeInTheDocument();
     });
   });
 
@@ -194,12 +222,12 @@ describe('LobbyMemberList', () => {
     renderWithProviders(<LobbyMemberList lobby={lobby} />);
     await screen.findByText('nastia_k');
 
-    await user.click(screen.getByRole('button', { name: 'Remove' }));
-    const [, confirmButton] = screen.getAllByRole('button', { name: 'Remove' });
+    await user.click(screen.getByRole(ROLES.button, { name: MEMBER_CARD_TEXT.removeButtonName }));
+    const [, confirmButton] = screen.getAllByRole(ROLES.button, {
+      name: MEMBER_CARD_TEXT.removeButtonName,
+    });
     await user.click(confirmButton!);
 
-    expect(
-      await screen.findByText('Could not remove this member — please try again'),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(LOBBY_MEMBER_LIST_TEXT.removeError)).toBeInTheDocument();
   });
 });

--- a/lined-web/src/components/lobby/__tests__/LobbyMemberList.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/LobbyMemberList.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders, screen, userEvent, waitFor } from '@/test/utils';
+import { server } from '@/test/server';
+import { MOCK_LOBBIES } from '@/test/data';
+import { useAuthStore } from '@/store/auth';
+import { LobbyMemberList } from '../LobbyMemberList';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+const lobby = MOCK_LOBBIES[0]!; // id 1, ownerId 1, memberIds [1, 2] (Alex owner, nastia_k member)
+
+describe('LobbyMemberList', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ userId: 1, token: 'token' });
+  });
+
+  it('shows a loading state while members are being fetched', () => {
+    expect.assertions(1);
+    renderWithProviders(<LobbyMemberList lobby={lobby} />);
+
+    expect(screen.getByTestId('lobby-members-loading')).toBeInTheDocument();
+  });
+
+  it('renders the member count, role badges, and "that\'s you" for the current user', async () => {
+    expect.assertions(4);
+    renderWithProviders(<LobbyMemberList lobby={lobby} />);
+
+    expect(await screen.findByText('Owner')).toBeInTheDocument();
+    expect(screen.getByText('Members · 2')).toBeInTheDocument();
+    expect(screen.getByText('Member')).toBeInTheDocument();
+    expect(screen.getByText("That's you")).toBeInTheDocument();
+  });
+
+  it('shows an error message when a member profile fails to load', async () => {
+    expect.assertions(1);
+    server.use(http.get(`${BASE}/users/:id`, () => new HttpResponse(null, { status: 500 })));
+    renderWithProviders(<LobbyMemberList lobby={lobby} />);
+
+    expect(
+      await screen.findByText("Couldn't load members. Try again later."),
+    ).toBeInTheDocument();
+  });
+
+  it('shows owner-only management actions and the Pending Invites section for the owner', async () => {
+    expect.assertions(3);
+    renderWithProviders(<LobbyMemberList lobby={lobby} />);
+    await screen.findByText('nastia_k');
+
+    expect(screen.getByRole('button', { name: 'Make owner' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+    expect(await screen.findByText('Pending Invites')).toBeInTheDocument();
+  });
+
+  it('hides management actions and the Pending Invites section for a non-owner viewer', async () => {
+    expect.assertions(3);
+    useAuthStore.setState({ userId: 2, token: 'token' });
+    renderWithProviders(<LobbyMemberList lobby={lobby} />);
+
+    expect(await screen.findByText("That's you")).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Make owner' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Pending Invites')).not.toBeInTheDocument();
+  });
+
+  it('resolves and renders the pending invite for the owner', async () => {
+    expect.assertions(2);
+    renderWithProviders(<LobbyMemberList lobby={lobby} />);
+
+    expect(await screen.findByText('nastia_bondar')).toBeInTheDocument();
+    expect(screen.getByText('Invite sent · Mar 27, 2026')).toBeInTheDocument();
+  });
+
+  it('shows a friendly empty state when there are no pending invites', async () => {
+    expect.assertions(1);
+    server.use(http.get(`${BASE}/lobbies/:lobbyId/invites`, () => HttpResponse.json([])));
+    renderWithProviders(<LobbyMemberList lobby={lobby} />);
+
+    expect(await screen.findByText('No pending invites.')).toBeInTheDocument();
+  });
+
+  it('shows an error message when pending invites fail to load', async () => {
+    expect.assertions(1);
+    server.use(
+      http.get(`${BASE}/lobbies/:lobbyId/invites`, () => new HttpResponse(null, { status: 500 })),
+    );
+    renderWithProviders(<LobbyMemberList lobby={lobby} />);
+
+    expect(await screen.findByText("Couldn't load pending invites.")).toBeInTheDocument();
+  });
+
+  it('resends a pending invite', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyMemberList lobby={lobby} />);
+    await screen.findByText('nastia_bondar');
+
+    await user.click(screen.getByRole('button', { name: 'Resend' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Resend' })).toBeEnabled();
+    });
+  });
+
+  it('shows an inline error when resending an invite fails', async () => {
+    expect.assertions(1);
+    server.use(
+      http.post(
+        `${BASE}/lobbies/:lobbyId/invites/:inviteId/resend`,
+        () => new HttpResponse(null, { status: 500 }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyMemberList lobby={lobby} />);
+    await screen.findByText('nastia_bondar');
+
+    await user.click(screen.getByRole('button', { name: 'Resend' }));
+
+    expect(await screen.findByText("Couldn't resend — try again")).toBeInTheDocument();
+  });
+
+  it('cancels a pending invite without leaving it stuck in a pending state', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyMemberList lobby={lobby} />);
+    await screen.findByText('nastia_bondar');
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+    });
+  });
+
+  it('opens a confirm dialog and PATCHes ownership when "Make owner" is confirmed', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyMemberList lobby={lobby} />);
+    await screen.findByText('nastia_k');
+
+    await user.click(screen.getByRole('button', { name: 'Make owner' }));
+    expect(
+      screen.getByText(
+        'Make @nastia_k the owner of "Alex & Anastasiia"? You will become a regular member.',
+      ),
+    ).toBeInTheDocument();
+
+    const [, confirmButton] = screen.getAllByRole('button', { name: 'Make owner' });
+    await user.click(confirmButton!);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: 'Make owner' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows an inline error and keeps the dialog open when the make-owner PATCH fails', async () => {
+    expect.assertions(1);
+    server.use(http.patch(`${BASE}/lobbies/:id`, () => new HttpResponse(null, { status: 500 })));
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyMemberList lobby={lobby} />);
+    await screen.findByText('nastia_k');
+
+    await user.click(screen.getByRole('button', { name: 'Make owner' }));
+    const [, confirmButton] = screen.getAllByRole('button', { name: 'Make owner' });
+    await user.click(confirmButton!);
+
+    expect(
+      await screen.findByText('Could not transfer ownership — please try again'),
+    ).toBeInTheDocument();
+  });
+
+  it('opens a confirm dialog and removes the member when "Remove" is confirmed', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyMemberList lobby={lobby} />);
+    await screen.findByText('nastia_k');
+
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+    const [, confirmButton] = screen.getAllByRole('button', { name: 'Remove' });
+    await user.click(confirmButton!);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: 'Remove member' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows an inline error and keeps the dialog open when removing a member fails', async () => {
+    expect.assertions(1);
+    server.use(
+      http.delete(
+        `${BASE}/lobbies/:lobbyId/members/:userId`,
+        () => new HttpResponse(null, { status: 500 }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyMemberList lobby={lobby} />);
+    await screen.findByText('nastia_k');
+
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+    const [, confirmButton] = screen.getAllByRole('button', { name: 'Remove' });
+    await user.click(confirmButton!);
+
+    expect(
+      await screen.findByText('Could not remove this member — please try again'),
+    ).toBeInTheDocument();
+  });
+});

--- a/lined-web/src/components/lobby/__tests__/MemberCard.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/MemberCard.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
+import type { UserDto } from '@/types';
+import { MemberCard } from '../MemberCard';
+
+const member: UserDto = {
+  id: 2,
+  username: 'nastia_k',
+  email: 'anastasiia@lined.app',
+  createdAt: '2025-02-01T12:00:00Z',
+  roles: ['ROLE_USER'],
+  activePlan: null,
+  activeUntil: null,
+};
+
+describe('MemberCard', () => {
+  it('renders the username, @handle, and "Member since" date', () => {
+    expect.assertions(3);
+    renderWithProviders(
+      <MemberCard
+        member={member}
+        isOwner={false}
+        isCurrentUser={false}
+        canManage={false}
+        onMakeOwner={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('nastia_k')).toBeInTheDocument();
+    expect(screen.getByText('@nastia_k')).toBeInTheDocument();
+    expect(screen.getByText('Member since February 2025')).toBeInTheDocument();
+  });
+
+  it('shows the Owner badge for the lobby owner', () => {
+    expect.assertions(2);
+    renderWithProviders(
+      <MemberCard
+        member={member}
+        isOwner={true}
+        isCurrentUser={false}
+        canManage={false}
+        onMakeOwner={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Owner')).toBeInTheDocument();
+    expect(screen.queryByText('Member')).not.toBeInTheDocument();
+  });
+
+  it('shows the Member badge for a non-owner', () => {
+    expect.assertions(1);
+    renderWithProviders(
+      <MemberCard
+        member={member}
+        isOwner={false}
+        isCurrentUser={false}
+        canManage={false}
+        onMakeOwner={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Member')).toBeInTheDocument();
+  });
+
+  it('shows "That\'s you" and hides management actions for the current user', () => {
+    expect.assertions(3);
+    renderWithProviders(
+      <MemberCard
+        member={member}
+        isOwner={false}
+        isCurrentUser={true}
+        canManage={true}
+        onMakeOwner={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("That's you")).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Make owner' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
+  });
+
+  it('hides "Make owner"/"Remove" actions when the viewer cannot manage members', () => {
+    expect.assertions(2);
+    renderWithProviders(
+      <MemberCard
+        member={member}
+        isOwner={false}
+        isCurrentUser={false}
+        canManage={false}
+        onMakeOwner={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Make owner' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
+  });
+
+  it('shows "Make owner"/"Remove" actions for the owner viewing another member', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    const onMakeOwner = vi.fn();
+    const onRemove = vi.fn();
+    renderWithProviders(
+      <MemberCard
+        member={member}
+        isOwner={false}
+        isCurrentUser={false}
+        canManage={true}
+        onMakeOwner={onMakeOwner}
+        onRemove={onRemove}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Make owner' }));
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+
+    expect(onMakeOwner).toHaveBeenCalledTimes(1);
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lined-web/src/components/lobby/__tests__/MemberCard.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/MemberCard.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, screen, userEvent } from '@/test/utils';
 import type { UserDto } from '@/types';
+import { ROLES, MEMBER_CARD_TEXT } from '@/test/lobbyMemberContent';
 import { MemberCard } from '../MemberCard';
 
 const member: UserDto = {
@@ -27,8 +28,8 @@ describe('MemberCard', () => {
       />,
     );
 
-    expect(screen.getByText('nastia_k')).toBeInTheDocument();
-    expect(screen.getByText('@nastia_k')).toBeInTheDocument();
+    expect(screen.getByText(member.username)).toBeInTheDocument();
+    expect(screen.getByText(`@${member.username}`)).toBeInTheDocument();
     expect(screen.getByText('Member since February 2025')).toBeInTheDocument();
   });
 
@@ -45,8 +46,8 @@ describe('MemberCard', () => {
       />,
     );
 
-    expect(screen.getByText('Owner')).toBeInTheDocument();
-    expect(screen.queryByText('Member')).not.toBeInTheDocument();
+    expect(screen.getByText(MEMBER_CARD_TEXT.ownerBadge)).toBeInTheDocument();
+    expect(screen.queryByText(MEMBER_CARD_TEXT.memberBadge)).not.toBeInTheDocument();
   });
 
   it('shows the Member badge for a non-owner', () => {
@@ -62,7 +63,7 @@ describe('MemberCard', () => {
       />,
     );
 
-    expect(screen.getByText('Member')).toBeInTheDocument();
+    expect(screen.getByText(MEMBER_CARD_TEXT.memberBadge)).toBeInTheDocument();
   });
 
   it('shows "That\'s you" and hides management actions for the current user', () => {
@@ -78,9 +79,13 @@ describe('MemberCard', () => {
       />,
     );
 
-    expect(screen.getByText("That's you")).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Make owner' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
+    expect(screen.getByText(MEMBER_CARD_TEXT.thatsYou)).toBeInTheDocument();
+    expect(
+      screen.queryByRole(ROLES.button, { name: MEMBER_CARD_TEXT.makeOwnerButtonName }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole(ROLES.button, { name: MEMBER_CARD_TEXT.removeButtonName }),
+    ).not.toBeInTheDocument();
   });
 
   it('hides "Make owner"/"Remove" actions when the viewer cannot manage members', () => {
@@ -96,8 +101,12 @@ describe('MemberCard', () => {
       />,
     );
 
-    expect(screen.queryByRole('button', { name: 'Make owner' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole(ROLES.button, { name: MEMBER_CARD_TEXT.makeOwnerButtonName }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole(ROLES.button, { name: MEMBER_CARD_TEXT.removeButtonName }),
+    ).not.toBeInTheDocument();
   });
 
   it('shows "Make owner"/"Remove" actions for the owner viewing another member', async () => {
@@ -116,8 +125,8 @@ describe('MemberCard', () => {
       />,
     );
 
-    await user.click(screen.getByRole('button', { name: 'Make owner' }));
-    await user.click(screen.getByRole('button', { name: 'Remove' }));
+    await user.click(screen.getByRole(ROLES.button, { name: MEMBER_CARD_TEXT.makeOwnerButtonName }));
+    await user.click(screen.getByRole(ROLES.button, { name: MEMBER_CARD_TEXT.removeButtonName }));
 
     expect(onMakeOwner).toHaveBeenCalledTimes(1);
     expect(onRemove).toHaveBeenCalledTimes(1);

--- a/lined-web/src/components/lobby/__tests__/PendingInviteRow.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/PendingInviteRow.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
+import { server } from '@/test/server';
+import type { LobbyInviteDto } from '@/types';
+import { PendingInviteRow } from '../PendingInviteRow';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+
+const invite: LobbyInviteDto = {
+  id: 2,
+  lobbyId: 1,
+  inviterId: 1,
+  inviteeId: 3,
+  status: 'PENDING',
+  sentAt: '2026-03-27T10:00:00Z',
+  createdAt: '2026-03-27T10:00:00Z',
+  updatedAt: '2026-03-27T10:00:00Z',
+};
+
+describe('PendingInviteRow', () => {
+  it('resolves and renders the invitee username with the sent date', async () => {
+    expect.assertions(2);
+    renderWithProviders(
+      <PendingInviteRow
+        invite={invite}
+        onResend={vi.fn()}
+        onCancel={vi.fn()}
+        isResending={false}
+        isCancelling={false}
+      />,
+    );
+
+    expect(await screen.findByText('nastia_bondar')).toBeInTheDocument();
+    expect(screen.getByText('Invite sent · Mar 27, 2026')).toBeInTheDocument();
+  });
+
+  it('falls back to a numeric label if the invitee profile fails to load', async () => {
+    expect.assertions(1);
+    server.use(http.get(`${BASE}/users/:id`, () => new HttpResponse(null, { status: 404 })));
+    renderWithProviders(
+      <PendingInviteRow
+        invite={invite}
+        onResend={vi.fn()}
+        onCancel={vi.fn()}
+        isResending={false}
+        isCancelling={false}
+      />,
+    );
+
+    expect(await screen.findByText('User #3')).toBeInTheDocument();
+  });
+
+  it('calls onResend when Resend is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onResend = vi.fn();
+    renderWithProviders(
+      <PendingInviteRow
+        invite={invite}
+        onResend={onResend}
+        onCancel={vi.fn()}
+        isResending={false}
+        isCancelling={false}
+      />,
+    );
+    await screen.findByText('nastia_bondar');
+
+    await user.click(screen.getByRole('button', { name: 'Resend' }));
+
+    expect(onResend).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when Cancel is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    renderWithProviders(
+      <PendingInviteRow
+        invite={invite}
+        onResend={vi.fn()}
+        onCancel={onCancel}
+        isResending={false}
+        isCancelling={false}
+      />,
+    );
+    await screen.findByText('nastia_bondar');
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a pending "Resending…" label and disables both buttons while resending', async () => {
+    expect.assertions(2);
+    renderWithProviders(
+      <PendingInviteRow
+        invite={invite}
+        onResend={vi.fn()}
+        onCancel={vi.fn()}
+        isResending={true}
+        isCancelling={false}
+      />,
+    );
+
+    expect(await screen.findByRole('button', { name: 'Resending…' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  });
+
+  it('shows an inline error message when provided', async () => {
+    expect.assertions(1);
+    renderWithProviders(
+      <PendingInviteRow
+        invite={invite}
+        onResend={vi.fn()}
+        onCancel={vi.fn()}
+        isResending={false}
+        isCancelling={false}
+        error="Couldn't resend — try again"
+      />,
+    );
+
+    expect(await screen.findByText("Couldn't resend — try again")).toBeInTheDocument();
+  });
+});

--- a/lined-web/src/components/lobby/__tests__/PendingInviteRow.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/PendingInviteRow.test.tsx
@@ -3,6 +3,7 @@ import { http, HttpResponse } from 'msw';
 import { renderWithProviders, screen, userEvent } from '@/test/utils';
 import { server } from '@/test/server';
 import type { LobbyInviteDto } from '@/types';
+import { ROLES, PENDING_INVITE_TEXT } from '@/test/lobbyMemberContent';
 import { PendingInviteRow } from '../PendingInviteRow';
 
 const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
@@ -66,7 +67,7 @@ describe('PendingInviteRow', () => {
     );
     await screen.findByText('nastia_bondar');
 
-    await user.click(screen.getByRole('button', { name: 'Resend' }));
+    await user.click(screen.getByRole(ROLES.button, { name: PENDING_INVITE_TEXT.resendButtonName }));
 
     expect(onResend).toHaveBeenCalledTimes(1);
   });
@@ -86,7 +87,7 @@ describe('PendingInviteRow', () => {
     );
     await screen.findByText('nastia_bondar');
 
-    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await user.click(screen.getByRole(ROLES.button, { name: PENDING_INVITE_TEXT.cancelButtonName }));
 
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
@@ -103,8 +104,12 @@ describe('PendingInviteRow', () => {
       />,
     );
 
-    expect(await screen.findByRole('button', { name: 'Resending…' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(
+      await screen.findByRole(ROLES.button, { name: PENDING_INVITE_TEXT.resendingLabel }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole(ROLES.button, { name: PENDING_INVITE_TEXT.cancelButtonName }),
+    ).toBeDisabled();
   });
 
   it('shows an inline error message when provided', async () => {

--- a/lined-web/src/hooks/__tests__/useDebouncedValue.test.ts
+++ b/lined-web/src/hooks/__tests__/useDebouncedValue.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDebouncedValue } from '../useDebouncedValue';
+
+describe('useDebouncedValue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the initial value immediately', () => {
+    expect.assertions(1);
+    const { result } = renderHook(() => useDebouncedValue('a', 300));
+
+    expect(result.current).toBe('a');
+  });
+
+  it('does not update before the delay elapses', () => {
+    expect.assertions(1);
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 300), {
+      initialProps: { value: 'a' },
+    });
+
+    rerender({ value: 'ab' });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe('a');
+  });
+
+  it('updates to the latest value once the delay elapses', () => {
+    expect.assertions(1);
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 300), {
+      initialProps: { value: 'a' },
+    });
+
+    rerender({ value: 'ab' });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe('ab');
+  });
+
+  it('resets the timer on rapid successive changes, keeping only the last value', () => {
+    expect.assertions(1);
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 300), {
+      initialProps: { value: 'a' },
+    });
+
+    rerender({ value: 'ab' });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    rerender({ value: 'abc' });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe('a');
+  });
+});

--- a/lined-web/src/hooks/useDebouncedValue.ts
+++ b/lined-web/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+export function useDebouncedValue<T>(value: T, delayMs = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/lined-web/src/hooks/useDebouncedValue.ts
+++ b/lined-web/src/hooks/useDebouncedValue.ts
@@ -1,6 +1,11 @@
 import { useEffect, useState } from 'react';
 
-export function useDebouncedValue<T>(value: T, delayMs = 300): T {
+/**
+ * Returns `value`, but only after it has stopped changing for `delayMs`.
+ * Useful for search inputs, where we want to wait for the user to stop
+ * typing before firing a query.
+ */
+export const useDebouncedValue = <T>(value: T, delayMs = 300): T => {
   const [debounced, setDebounced] = useState(value);
 
   useEffect(() => {
@@ -9,4 +14,4 @@ export function useDebouncedValue<T>(value: T, delayMs = 300): T {
   }, [value, delayMs]);
 
   return debounced;
-}
+};

--- a/lined-web/src/hooks/useInvites.ts
+++ b/lined-web/src/hooks/useInvites.ts
@@ -15,7 +15,7 @@ export const useLobbyInvites = (lobbyId: number | undefined) =>
     enabled: lobbyId != null,
   });
 
-export function useCreateInvite(lobbyId: number) {
+export const useCreateInvite = (lobbyId: number) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (target: InviteTarget) => createInvite(lobbyId, target),
@@ -23,9 +23,9 @@ export function useCreateInvite(lobbyId: number) {
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lobbyInvites(lobbyId) });
     },
   });
-}
+};
 
-export function useResendInvite(lobbyId: number) {
+export const useResendInvite = (lobbyId: number) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (inviteId: number) => resendInvite(lobbyId, inviteId),
@@ -33,9 +33,9 @@ export function useResendInvite(lobbyId: number) {
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lobbyInvites(lobbyId) });
     },
   });
-}
+};
 
-export function useCancelInvite(lobbyId: number) {
+export const useCancelInvite = (lobbyId: number) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (inviteId: number) => cancelInvite(lobbyId, inviteId),
@@ -43,4 +43,4 @@ export function useCancelInvite(lobbyId: number) {
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lobbyInvites(lobbyId) });
     },
   });
-}
+};

--- a/lined-web/src/hooks/useInvites.ts
+++ b/lined-web/src/hooks/useInvites.ts
@@ -1,0 +1,46 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  createInvite,
+  listLobbyInvites,
+  resendInvite,
+  cancelInvite,
+  type InviteTarget,
+} from '@/api/invites';
+import { QUERY_KEYS } from '@/lib/constants';
+
+export const useLobbyInvites = (lobbyId: number | undefined) =>
+  useQuery({
+    queryKey: QUERY_KEYS.lobbyInvites(lobbyId ?? 0),
+    queryFn: () => listLobbyInvites(lobbyId!),
+    enabled: lobbyId != null,
+  });
+
+export function useCreateInvite(lobbyId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (target: InviteTarget) => createInvite(lobbyId, target),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lobbyInvites(lobbyId) });
+    },
+  });
+}
+
+export function useResendInvite(lobbyId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (inviteId: number) => resendInvite(lobbyId, inviteId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lobbyInvites(lobbyId) });
+    },
+  });
+}
+
+export function useCancelInvite(lobbyId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (inviteId: number) => cancelInvite(lobbyId, inviteId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lobbyInvites(lobbyId) });
+    },
+  });
+}

--- a/lined-web/src/hooks/useLobbies.ts
+++ b/lined-web/src/hooks/useLobbies.ts
@@ -28,7 +28,7 @@ export function useCreateLobby() {
   });
 }
 
-export function useUpdateLobbyOwner(lobbyId: number) {
+export const useUpdateLobbyOwner = (lobbyId: number) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (ownerId: number) => updateLobby(lobbyId, { ownerId }),
@@ -36,9 +36,9 @@ export function useUpdateLobbyOwner(lobbyId: number) {
       queryClient.setQueryData<LobbyDto>(QUERY_KEYS.lobbyDetail(lobbyId), lobby);
     },
   });
-}
+};
 
-export function useRemoveMember(lobbyId: number) {
+export const useRemoveMember = (lobbyId: number) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (userId: number) => removeMember(lobbyId, userId),
@@ -47,4 +47,4 @@ export function useRemoveMember(lobbyId: number) {
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lobbies });
     },
   });
-}
+};

--- a/lined-web/src/hooks/useLobbies.ts
+++ b/lined-web/src/hooks/useLobbies.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getMyLobbies, getLobby, createLobby } from '@/api/lobbies';
+import { getMyLobbies, getLobby, createLobby, updateLobby, removeMember } from '@/api/lobbies';
 import { QUERY_KEYS } from '@/lib/constants';
+import type { LobbyDto } from '@/types';
 
 export function useMyLobbies() {
   return useQuery({
@@ -22,6 +23,27 @@ export function useCreateLobby() {
   return useMutation({
     mutationFn: createLobby,
     onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lobbies });
+    },
+  });
+}
+
+export function useUpdateLobbyOwner(lobbyId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (ownerId: number) => updateLobby(lobbyId, { ownerId }),
+    onSuccess: (lobby) => {
+      queryClient.setQueryData<LobbyDto>(QUERY_KEYS.lobbyDetail(lobbyId), lobby);
+    },
+  });
+}
+
+export function useRemoveMember(lobbyId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (userId: number) => removeMember(lobbyId, userId),
+    onSuccess: (lobby) => {
+      queryClient.setQueryData<LobbyDto>(QUERY_KEYS.lobbyDetail(lobbyId), lobby);
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lobbies });
     },
   });

--- a/lined-web/src/hooks/useUsers.ts
+++ b/lined-web/src/hooks/useUsers.ts
@@ -1,5 +1,5 @@
 import { useQuery, useQueries } from '@tanstack/react-query';
-import { getUser } from '@/api/users';
+import { getUser, searchUsers } from '@/api/users';
 import { QUERY_KEYS } from '@/lib/constants';
 
 export function useUser(id: number | undefined) {
@@ -16,4 +16,11 @@ export const useUsers = (ids: number[]) =>
       queryKey: QUERY_KEYS.user(id),
       queryFn: () => getUser(id),
     })),
+  });
+
+export const useUserSearch = (query: string) =>
+  useQuery({
+    queryKey: QUERY_KEYS.userSearch(query),
+    queryFn: () => searchUsers(query),
+    enabled: query.trim().length >= 2,
   });

--- a/lined-web/src/lib/constants.ts
+++ b/lined-web/src/lib/constants.ts
@@ -56,6 +56,7 @@ export const TASK_STATUS_BADGE_CLASSES: Record<TaskStatus, string> = {
 export const QUERY_KEYS = {
   users: ['users'] as const,
   user: (id: number) => ['users', id] as const,
+  userSearch: (q: string) => ['users', 'search', q] as const,
   lobbies: ['lobbies'] as const,
   lobbyDetail: (id: number) => ['lobbies', id] as const,
   lobbyFreeSlots: (id: number) => ['lobbies', id, 'free-slots'] as const,

--- a/lined-web/src/pages/LobbyPage.tsx
+++ b/lined-web/src/pages/LobbyPage.tsx
@@ -3,6 +3,7 @@ import { useLobby } from '@/hooks/useLobbies';
 import { LobbyHeader } from '@/components/lobby/LobbyHeader';
 import { LobbyTabBar, type LobbyTab } from '@/components/lobby/LobbyTabBar';
 import { LobbyTaskList } from '@/components/lobby/LobbyTaskList';
+import { LobbyMemberList } from '@/components/lobby/LobbyMemberList';
 
 const VALID_TABS: LobbyTab[] = ['calendar', 'tasks', 'members'];
 
@@ -56,9 +57,7 @@ export function LobbyPage() {
         <p className="p-6 text-sm text-text-secondary">Lobby calendar coming soon...</p>
       )}
 
-      {activeTab === 'members' && (
-        <p className="p-6 text-sm text-text-secondary">Lobby members coming soon...</p>
-      )}
+      {activeTab === 'members' && <LobbyMemberList lobby={lobby} />}
     </div>
   );
 }

--- a/lined-web/src/pages/__tests__/LobbyPage.test.tsx
+++ b/lined-web/src/pages/__tests__/LobbyPage.test.tsx
@@ -38,7 +38,7 @@ describe('LobbyPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows placeholder copy for the calendar and members tabs', async () => {
+  it('shows placeholder copy for the calendar tab', async () => {
     expect.assertions(2);
     renderLobbyPage('/lobbies/1?tab=calendar');
 
@@ -46,11 +46,18 @@ describe('LobbyPage', () => {
     expect(screen.queryByText('Plan dinner for Saturday')).not.toBeInTheDocument();
   });
 
+  it('shows the real member list on the members tab', async () => {
+    expect.assertions(1);
+    renderLobbyPage('/lobbies/1?tab=members');
+
+    expect(await screen.findByText('Members · 2')).toBeInTheDocument();
+  });
+
   it('switches to the tasks tab and updates the URL when clicked', async () => {
     expect.assertions(2);
     const user = userEvent.setup();
     renderLobbyPage('/lobbies/1?tab=members');
-    await screen.findByText('Lobby members coming soon...');
+    await screen.findByText('Members · 2');
 
     await user.click(screen.getByRole('tab', { name: '✅ Tasks' }));
 

--- a/lined-web/src/test/data.ts
+++ b/lined-web/src/test/data.ts
@@ -27,6 +27,24 @@ export const MOCK_USERS: UserDto[] = [
     activePlan: 'PRO_MONTHLY',
     activeUntil: '2026-05-01T12:00:00Z',
   },
+  {
+    id: 3,
+    username: 'nastia_bondar',
+    email: 'nastia.bondar@lined.app',
+    createdAt: '2025-06-10T09:00:00Z',
+    roles: ['ROLE_USER'],
+    activePlan: null,
+    activeUntil: null,
+  },
+  {
+    id: 4,
+    username: 'natascha_m',
+    email: 'natascha@lined.app',
+    createdAt: '2025-08-22T09:00:00Z',
+    roles: ['ROLE_USER'],
+    activePlan: null,
+    activeUntil: null,
+  },
 ];
 
 export const MOCK_LOBBIES: LobbyDto[] = [
@@ -219,6 +237,16 @@ export const MOCK_LOBBY_INVITES: LobbyInviteDto[] = [
     sentAt: '2026-07-15T10:00:00Z',
     createdAt: '2026-07-15T10:00:00Z',
     updatedAt: '2026-07-15T10:00:00Z',
+  },
+  {
+    id: 2,
+    lobbyId: 1,
+    inviterId: 1,
+    inviteeId: 3,
+    status: 'PENDING',
+    sentAt: '2026-03-27T10:00:00Z',
+    createdAt: '2026-03-27T10:00:00Z',
+    updatedAt: '2026-03-27T10:00:00Z',
   },
 ];
 

--- a/lined-web/src/test/handlers/users.ts
+++ b/lined-web/src/test/handlers/users.ts
@@ -4,12 +4,8 @@ import { MOCK_USERS, MOCK_LOBBIES } from '../data';
 const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
 
 export const userHandlers = [
-  http.get(`${BASE}/users/:id`, ({ params }) => {
-    const user = MOCK_USERS.find((u) => u.id === Number(params['id']));
-    if (!user) return new HttpResponse(null, { status: 404 });
-    return HttpResponse.json(user);
-  }),
-
+  // Must come before /users/:id — otherwise ":id" greedily matches the literal
+  // "search" segment and this handler never runs.
   http.get(`${BASE}/users/search`, ({ request }) => {
     const url = new URL(request.url);
     const q = url.searchParams.get('q')?.toLowerCase() ?? '';
@@ -25,6 +21,12 @@ export const userHandlers = [
       totalElements: matches.length,
       totalPages: 1,
     });
+  }),
+
+  http.get(`${BASE}/users/:id`, ({ params }) => {
+    const user = MOCK_USERS.find((u) => u.id === Number(params['id']));
+    if (!user) return new HttpResponse(null, { status: 404 });
+    return HttpResponse.json(user);
   }),
 
   http.post(`${BASE}/users`, async ({ request }) => {

--- a/lined-web/src/test/lobbyMemberContent.ts
+++ b/lined-web/src/test/lobbyMemberContent.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared accessible names / roles / test ids / copy for the lobby Members
+ * tab and Add Member modal, so their tests don't each hardcode the same
+ * strings and drift out of sync when the copy changes.
+ */
+
+export const ROLES = {
+  button: 'button',
+  heading: 'heading',
+} as const;
+
+export const TEST_IDS = {
+  confirmDialogBackdrop: 'confirm-dialog-backdrop',
+  lobbyMembersLoading: 'lobby-members-loading',
+  pendingInvitesLoading: 'pending-invites-loading',
+  addMemberSearchLoading: 'add-member-search-loading',
+} as const;
+
+export const NUMBERS = {
+  aliceAndAnastasiiaMemberCount: 2,
+} as const;
+
+export const CONFIRM_DIALOG_TEXT = {
+  pleaseWaitLabel: 'Please wait…',
+  cancelButtonName: 'Cancel',
+} as const;
+
+export const MEMBER_CARD_TEXT = {
+  ownerBadge: 'Owner',
+  memberBadge: 'Member',
+  thatsYou: "That's you",
+  makeOwnerButtonName: 'Make owner',
+  removeButtonName: 'Remove',
+} as const;
+
+export const PENDING_INVITE_TEXT = {
+  resendButtonName: 'Resend',
+  resendingLabel: 'Resending…',
+  cancelButtonName: 'Cancel',
+} as const;
+
+export const LOBBY_MEMBER_LIST_TEXT = {
+  membersHeading: (count: number) => `Members · ${count}`,
+  pendingInvitesHeading: 'Pending Invites',
+  noPendingInvites: 'No pending invites.',
+  loadMembersError: "Couldn't load members. Try again later.",
+  loadInvitesError: "Couldn't load pending invites.",
+  resendError: "Couldn't resend — try again",
+  makeOwnerError: 'Could not transfer ownership — please try again',
+  removeError: 'Could not remove this member — please try again',
+} as const;
+
+export const ADD_MEMBER_MODAL_TEXT = {
+  title: 'Add Member',
+  searchLabel: 'Search user',
+  minCharsHint: 'Type at least 2 characters to search.',
+  noUsersFound: 'No users found.',
+  searchFailed: 'Search failed — try again.',
+  inviteButtonName: 'Invite',
+  inviteSentButtonName: 'Invite sent',
+  alreadyMemberSuffix: 'already in lobby',
+  conflictError: 'Already a member or already invited',
+  genericInviteError: "Couldn't send invite — try again",
+  doneButtonName: 'Done',
+  closeButtonName: 'Close',
+  inviteLinkHint: /You can also share an invite link/,
+} as const;

--- a/lined-web/src/test/smoke.test.ts
+++ b/lined-web/src/test/smoke.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { MOCK_USERS, MOCK_LOBBIES, MOCK_TASKS, MOCK_EVENTS } from './data';
 
 describe('Mock data', () => {
-  it('has two users matching mockup personas', () => {
-    expect(MOCK_USERS).toHaveLength(2);
+  it('has users matching mockup personas, including invitable non-members', () => {
+    expect(MOCK_USERS).toHaveLength(4);
     expect(MOCK_USERS[0]?.username).toBe('alex_johnson');
     expect(MOCK_USERS[1]?.username).toBe('nastia_k');
   });


### PR DESCRIPTION
## Summary

Implements Task 6 from `lined-web/docs/UI_TASKS.md` — the Lobby detail page's Members tab and the "+ Add member" modal, wired to the (already-implemented) invite/membership REST API.

- **`LobbyMemberList`** — "Members · N" header, `MemberCard` rows (avatar, Owner/Member badge, `@username`, "Member since" date substituted for the missing "joined at" field), "That's you" for the viewer, and owner-only "Make owner"/"Remove" actions behind a shared `ConfirmDialog`.
- **Pending Invites** (owner-only) — resolves each invitee, Resend/Cancel actions with per-row pending/error state.
- **`AddMemberModal`** — debounced (300ms) user search; result rows show one of three states: already-member ✓, invitable (Invite button), or invite-sent; a 409 response surfaces "Already a member or already invited" inline.
- New hooks: `useUserSearch`, `useUpdateLobbyOwner`, `useRemoveMember`, and `useInvites.ts` (`useLobbyInvites`/`useCreateInvite`/`useResendInvite`/`useCancelInvite`).
- Shared, reusable `ConfirmDialog` and `useDebouncedValue` hook.
- Owner-only affordances are gated by comparing the current user against `lobby.ownerId`, matching the backend's `accessPolicy.ensureOwner` (403) enforcement.
- **Bugfix**: MSW's `/users/:id` handler was registered before `/users/search`, so `:id` greedily matched the literal "search" segment and the search endpoint 404'd — reordered so `/users/search` is matched first. This was blocking Add Member search in both the dev MSW server and tests.
- Two more mock users added (`nastia_bondar`, `natascha_m`) plus a second mock pending invite, so the Add Member modal can demonstrate all three search-result states without touching MSW handler logic.
- `docs/UI_TASKS.md`: row 6 status `TODO` → `DONE`.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 174/174 passing (32 new tests across `ConfirmDialog`, `MemberCard`, `PendingInviteRow`, `LobbyMemberList`, `AddMemberModal`, `useDebouncedValue`; each test uses `expect.assertions`)
- [x] `npm run build` — succeeds
- [x] Manual verification against `mockups/index.html#lobby-members` / `#add-member` at 1280×800 in the dev server (MSW mock API):
  - Members tab renders real members with role badges, "That's you", owner-only actions, and the Pending Invites section
  - Add Member search shows already-member (✓), invitable (Invite), and invite-sent states; a duplicate invite surfaces the 409 message inline
  - "Make owner" confirm dialog transfers ownership and live-swaps the role badges (viewer's owner-only actions correctly disappear once they're no longer owner)
  - No console errors observed

🤖 Generated with [Claude Code](https://claude.com/claude-code)