### PR TITLE
feat(web): Lobby Calendar tab (Task 7)

### DIFF
--- a/lined-web/docs/UI_TASKS.md
+++ b/lined-web/docs/UI_TASKS.md
@@ -39,15 +39,15 @@ exist for every task, including `create-lobby` (task 4), `calendar-month`
 - Zustand stores: `auth` (persisted userId), `calendar` (view state), `createMenu` (create-lobby + event/task/reserveSlot overlay state)
 - Hooks: `useMyLobbies`, `useLobby`, `useCreateLobby`, `useUpdateLobbyOwner`, `useRemoveMember`, `useWeekEvents`, `useCreateEvent`, `useDeleteEvent`, `useUsers`, `useUserSearch`, `useLobbyTasks`, `useUpdateTask`, `useLobbyInvites`, `useCreateInvite`, `useResendInvite`, `useCancelInvite`
 - MSW handlers + smoke tests
-- **Lobby detail page** — `LobbyHeader`, `LobbyTabBar`, `LobbyTaskList`, `TaskRow`: type-accent header with resolved member avatars, `?tab=`-synced tab bar, and a live Tasks tab (filter pills with counts, due-date sort, checkbox status toggle). Calendar tab remains a "coming soon" placeholder until Task 7.
+- **Lobby detail page** — `LobbyHeader`, `LobbyTabBar`, `LobbyTaskList`, `TaskRow`: type-accent header with resolved member avatars, `?tab=`-synced tab bar, and a live Tasks tab (filter pills with counts, due-date sort, checkbox status toggle).
 - **Lobby Members tab & Add Member modal** — `LobbyMemberList`, `MemberCard`, `PendingInviteRow`, `AddMemberModal`, shared `ConfirmDialog`: role badges, owner-only "Make owner"/"Remove" actions with confirm dialogs, owner-only Pending Invites section (resend/cancel), and debounced user search with already-member/invitable/invite-sent states.
+- **Lobby Calendar tab** — `LobbyCalendarView`, `DayAgendaModal`: week grid scoped to one lobby (events filtered client-side, colored by lobby type), free-slot bands from `GET /api/lobbies/{id}/free-slots`, a simplified 2-item legend, lobby-locked event creation, and day-overflow handling (lane layout for overlapping events, a "+N more" pill past 4 visible events, click-to-open day agenda listing all events + free slots for that day). `WeekGrid` was generalised (prop-driven free slots/legend, opt-in `onDayClick`) without changing the global calendar's behaviour.
 
 **Stubs only ("coming soon" placeholders):**
 SignInPage, SignUpPage, DashboardPage, TasksPage,
 UserSettingsPage, LobbySettingsPage.
 
-**Not started:** AddTaskDrawer, ReserveSlotModal, kanban board, lobby
-calendar tab.
+**Not started:** AddTaskDrawer, ReserveSlotModal, kanban board.
 
 ## Backend API summary
 
@@ -81,7 +81,7 @@ calendar tab.
 | 4 | `feature/ui-04-create-menu-lobby-modal` | "+ Create" dropdown menu and Create Lobby modal (type picker) | [tasks/UI-04-create-menu-lobby-modal.md](tasks/UI-04-create-menu-lobby-modal.md) | DONE |
 | 5 | `feature/ui-05-lobby-tasks-tab` | Lobby detail page: header, tab bar, Tasks tab (filter pills, task rows) | [tasks/UI-05-lobby-tasks-tab.md](tasks/UI-05-lobby-tasks-tab.md) | DONE |
 | 6 | `feature/ui-06-lobby-members` | Lobby Members tab + Add Member modal (user search, invite, remove) | [tasks/UI-06-lobby-members.md](tasks/UI-06-lobby-members.md) | DONE |
-| 7 | `feature/ui-07-lobby-calendar` | Lobby Calendar tab (week grid scoped to lobby, free-slot bands) | [tasks/UI-07-lobby-calendar.md](tasks/UI-07-lobby-calendar.md) | TODO |
+| 7 | `feature/ui-07-lobby-calendar` | Lobby Calendar tab (week grid scoped to lobby, free-slot bands) | [tasks/UI-07-lobby-calendar.md](tasks/UI-07-lobby-calendar.md) | DONE |
 | 8 | `feature/ui-08-add-task-drawer` | Add Task drawer (title, assignee picker, due date, status) | [tasks/UI-08-add-task-drawer.md](tasks/UI-08-add-task-drawer.md) | TODO |
 | 9 | `feature/ui-09-tasks-kanban` | Global Tasks Board: 3-column kanban with filters and status transitions | [tasks/UI-09-tasks-kanban.md](tasks/UI-09-tasks-kanban.md) | TODO |
 | 10 | `feature/ui-10-calendar-enhancements` | Calendar polish: edit event, month view, legend | [tasks/UI-10-calendar-enhancements.md](tasks/UI-10-calendar-enhancements.md) | TODO |

--- a/lined-web/src/components/CreateEventModal.tsx
+++ b/lined-web/src/components/CreateEventModal.tsx
@@ -1,13 +1,17 @@
 import { useState } from 'react';
 import { X } from 'lucide-react';
+import { HTTPError } from 'ky';
 import type { EventDto, LobbyDto } from '@/types';
 import { useCreateEvent } from '@/hooks/useEvents';
 import { toDatetimeLocal, fromDatetimeLocal } from '@/lib/calendarUtils';
+import { AuthAlert } from '@/components/AuthAlert';
 
 interface CreateEventModalProps {
   lobbies: LobbyDto[];
   onClose: () => void;
   onCreated: (event: EventDto) => void;
+  /** When set, the lobby field is locked to this id and shown as read-only. */
+  lockedLobbyId?: number;
 }
 
 interface FormState {
@@ -22,8 +26,11 @@ export function CreateEventModal({
   lobbies,
   onClose,
   onCreated,
+  lockedLobbyId,
 }: CreateEventModalProps) {
   const createEvent = useCreateEvent();
+  const lockedLobby =
+    lockedLobbyId != null ? lobbies.find((l) => l.id === lockedLobbyId) : undefined;
 
   // Default: start = now rounded to next hour, end = +1h
   const defaultStart = (() => {
@@ -36,7 +43,7 @@ export function CreateEventModal({
 
   const [form, setForm] = useState<FormState>({
     title: '',
-    lobbyId: String(lobbies[0]?.id ?? ''),
+    lobbyId: String(lockedLobbyId ?? lobbies[0]?.id ?? ''),
     startAt: toDatetimeLocal(defaultStart),
     endAt: toDatetimeLocal(defaultEnd),
     shared: true,
@@ -115,18 +122,24 @@ export function CreateEventModal({
               <label className="mb-1.5 block text-xs font-medium text-text-secondary">
                 Lobby
               </label>
-              <select
-                required
-                value={form.lobbyId}
-                onChange={(e) => set('lobbyId', e.target.value)}
-                className="h-12 w-full rounded-lg border border-border bg-input-bg px-4 text-sm text-text-primary focus:border-brand-green focus:outline-none"
-              >
-                {lobbies.map((l) => (
-                  <option key={l.id} value={l.id}>
-                    {l.name}
-                  </option>
-                ))}
-              </select>
+              {lockedLobby ? (
+                <div className="flex h-12 w-full items-center rounded-lg border border-border bg-input-bg px-4 text-sm text-text-primary">
+                  {lockedLobby.name}
+                </div>
+              ) : (
+                <select
+                  required
+                  value={form.lobbyId}
+                  onChange={(e) => set('lobbyId', e.target.value)}
+                  className="h-12 w-full rounded-lg border border-border bg-input-bg px-4 text-sm text-text-primary focus:border-brand-green focus:outline-none"
+                >
+                  {lobbies.map((l) => (
+                    <option key={l.id} value={l.id}>
+                      {l.name}
+                    </option>
+                  ))}
+                </select>
+              )}
             </div>
 
             {/* Start / End */}
@@ -164,6 +177,10 @@ export function CreateEventModal({
               checked={form.shared}
               onChange={(v) => set('shared', v)}
             />
+
+            {createEvent.isError && (
+              <AuthAlert message={getCreateEventErrorMessage(createEvent.error)} />
+            )}
           </div>
 
           {/* Footer */}
@@ -187,6 +204,13 @@ export function CreateEventModal({
       </div>
     </div>
   );
+}
+
+function getCreateEventErrorMessage(error: unknown): string {
+  if (error instanceof HTTPError && error.response.status === 400) {
+    return 'Enter a valid title and time range';
+  }
+  return "Couldn't create event — please try again";
 }
 
 // ─── ToggleRow ────────────────────────────────────────────────────────────────

--- a/lined-web/src/components/WeekGrid.tsx
+++ b/lined-web/src/components/WeekGrid.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { EventDto, LobbyDto } from '@/types';
 import {
   addDays,
+  assignEventLanes,
   computeFreeSlots,
   formatDayLabel,
   formatHour,
@@ -13,22 +14,29 @@ import {
   HOUR_HEIGHT,
   isSameDay,
   isToday,
+  type EventLane,
+  type FreeSlot,
 } from '@/lib/calendarUtils';
 
 // ─── Legend ──────────────────────────────────────────────────────────────────
 
-const LEGEND_ITEMS = [
+export interface LegendItem {
+  label: string;
+  color: string;
+}
+
+const DEFAULT_LEGEND_ITEMS: LegendItem[] = [
   { label: 'Couple', color: 'var(--color-lobby-couple)' },
   { label: 'Family', color: 'var(--color-lobby-family)' },
   { label: 'Friends', color: 'var(--color-lobby-friends)' },
   { label: 'Work', color: 'var(--color-lobby-work)' },
   { label: 'Free slot', color: '#B4EBD0' },
-] as const;
+];
 
-function CalendarLegend() {
+function CalendarLegend({ items }: { items: LegendItem[] }) {
   return (
     <div className="flex flex-shrink-0 items-center gap-5 border-t border-border bg-white px-8 py-2">
-      {LEGEND_ITEMS.map(({ label, color }) => (
+      {items.map(({ label, color }) => (
         <div key={label} className="flex items-center gap-1.5 text-[11px] text-text-secondary">
           <span
             className="h-2.5 w-2.5 rounded-full"
@@ -79,20 +87,31 @@ interface CalendarEventProps {
   lobby?: LobbyDto;
   isSelected: boolean;
   onClick: () => void;
+  lane?: number;
+  laneCount?: number;
 }
 
-function CalendarEvent({ event, lobby, isSelected, onClick }: CalendarEventProps) {
+function CalendarEvent({ event, lobby, isSelected, onClick, lane, laneCount }: CalendarEventProps) {
   const top = getEventTop(event.startAt);
   const height = Math.max(getEventHeight(event.startAt, event.endAt), 24);
   const lobbyType = lobby?.lobbyType.toLowerCase() ?? 'couple';
 
+  const horizontal: React.CSSProperties =
+    laneCount != null && laneCount > 1
+      ? {
+          left: `calc(${((lane ?? 0) / laneCount) * 100}% + 2px)`,
+          width: `calc(${100 / laneCount}% - 4px)`,
+        }
+      : { left: 3, right: 3 };
+
   return (
     <button
       onClick={onClick}
-      className="absolute left-[3px] right-[3px] overflow-hidden rounded-[6px] px-[6px] py-1 text-left text-white transition-opacity hover:opacity-100"
+      className="absolute overflow-hidden rounded-[6px] px-[6px] py-1 text-left text-white transition-opacity hover:opacity-100"
       style={{
         top,
         height,
+        ...horizontal,
         backgroundColor: `var(--color-lobby-${lobbyType})`,
         opacity: isSelected ? 1 : 0.92,
         outline: isSelected ? '2px solid white' : 'none',
@@ -133,26 +152,28 @@ function FreeSlotBand({ startHour, endHour }: FreeSlotBandProps) {
 // ─── DayColumn ────────────────────────────────────────────────────────────────
 
 interface DayColumnProps {
-  day: Date;
   events: EventDto[];
   lobbyMap: Map<number, LobbyDto>;
   today: boolean;
   selectedEventId: number | null;
   onEventClick: (id: number) => void;
-  showFreeSlots: boolean;
+  freeSlots: FreeSlot[];
+  lanes?: Map<number, EventLane>;
+  overflowCount?: number;
+  onShowMore?: () => void;
 }
 
 function DayColumn({
-  day: _day,
   events,
   lobbyMap,
   today,
   selectedEventId,
   onEventClick,
-  showFreeSlots,
+  freeSlots,
+  lanes,
+  overflowCount = 0,
+  onShowMore,
 }: DayColumnProps) {
-  const freeSlots = showFreeSlots ? computeFreeSlots(events) : [];
-
   return (
     <div
       className={`relative flex-1 border-l border-border ${today ? 'bg-brand-green-light/25' : ''}`}
@@ -168,15 +189,31 @@ function DayColumn({
       ))}
 
       {/* Events */}
-      {events.map((event) => (
-        <CalendarEvent
-          key={event.id}
-          event={event}
-          lobby={lobbyMap.get(event.lobbyId)}
-          isSelected={event.id === selectedEventId}
-          onClick={() => onEventClick(event.id)}
-        />
-      ))}
+      {events.map((event) => {
+        const laneInfo = lanes?.get(event.id);
+        return (
+          <CalendarEvent
+            key={event.id}
+            event={event}
+            lobby={lobbyMap.get(event.lobbyId)}
+            isSelected={event.id === selectedEventId}
+            onClick={() => onEventClick(event.id)}
+            lane={laneInfo?.lane}
+            laneCount={laneInfo?.laneCount}
+          />
+        );
+      })}
+
+      {/* Overflow pill — opens the day agenda view for the remaining events */}
+      {overflowCount > 0 && onShowMore && (
+        <button
+          type="button"
+          onClick={onShowMore}
+          className="absolute right-1 top-1 z-20 rounded-full bg-text-primary/80 px-2 py-0.5 text-[10px] font-semibold text-white hover:bg-text-primary"
+        >
+          +{overflowCount} more
+        </button>
+      )}
 
       {/* Current-time indicator */}
       {today && <NowLine />}
@@ -192,7 +229,23 @@ interface WeekGridProps {
   lobbies: LobbyDto[];
   selectedEventId: number | null;
   onEventClick: (id: number) => void;
+  /** Overrides the default (client-computed) free-slot bands for a day. */
+  getFreeSlotsForDay?: (day: Date, dayEvents: EventDto[]) => FreeSlot[];
+  /** Overrides the default 5-item legend. */
+  legendItems?: LegendItem[];
+  /**
+   * Opt-in: when provided, day headers become clickable, overlapping events
+   * are laid out side-by-side, and days with more than `maxVisibleEvents`
+   * events show a "+N more" pill — all calling back with the day and its
+   * full event list. Omitted by the global calendar to keep it unchanged.
+   */
+  onDayClick?: (day: Date, dayEvents: EventDto[]) => void;
+  /** Only used when `onDayClick` is provided. Defaults to 4. */
+  maxVisibleEvents?: number;
 }
+
+const defaultGetFreeSlotsForDay = (_day: Date, dayEvents: EventDto[]): FreeSlot[] =>
+  dayEvents.length > 0 ? computeFreeSlots(dayEvents) : [];
 
 export function WeekGrid({
   weekStart,
@@ -200,6 +253,10 @@ export function WeekGrid({
   lobbies,
   selectedEventId,
   onEventClick,
+  getFreeSlotsForDay = defaultGetFreeSlotsForDay,
+  legendItems = DEFAULT_LEGEND_ITEMS,
+  onDayClick,
+  maxVisibleEvents = 4,
 }: WeekGridProps) {
   const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
   const lobbyMap = new Map(lobbies.map((l) => [l.id, l]));
@@ -220,14 +277,25 @@ export function WeekGrid({
       <div className="flex flex-shrink-0 border-b border-border bg-white" style={{ paddingLeft: 56 }}>
         {weekDays.map((day) => {
           const today = isToday(day);
+          const dayEvents = events.filter((e) => isSameDay(new Date(e.startAt), day));
           return (
             <div
               key={day.toISOString()}
+              role={onDayClick ? 'button' : undefined}
+              tabIndex={onDayClick ? 0 : undefined}
+              onClick={onDayClick ? () => onDayClick(day, dayEvents) : undefined}
+              onKeyDown={
+                onDayClick
+                  ? (e) => {
+                      if (e.key === 'Enter' || e.key === ' ') onDayClick(day, dayEvents);
+                    }
+                  : undefined
+              }
               className={`relative flex-1 py-2 text-center text-xs select-none ${
                 today
                   ? 'bg-brand-green-light font-semibold text-brand-green-dark'
                   : 'text-text-secondary'
-              }`}
+              } ${onDayClick ? 'cursor-pointer hover:bg-gray-50' : ''}`}
             >
               {formatDayLabel(day)}
               {today && (
@@ -258,16 +326,39 @@ export function WeekGrid({
             const dayEvents = events.filter((e) =>
               isSameDay(new Date(e.startAt), day),
             );
+            const freeSlots = getFreeSlotsForDay(day, dayEvents);
+
+            if (!onDayClick) {
+              return (
+                <DayColumn
+                  key={day.toISOString()}
+                  events={dayEvents}
+                  lobbyMap={lobbyMap}
+                  today={isToday(day)}
+                  selectedEventId={selectedEventId}
+                  onEventClick={onEventClick}
+                  freeSlots={freeSlots}
+                />
+              );
+            }
+
+            const sorted = [...dayEvents].sort((a, b) => a.startAt.localeCompare(b.startAt));
+            const visible = sorted.slice(0, maxVisibleEvents);
+            const overflowCount = dayEvents.length - visible.length;
+            const lanes = assignEventLanes(visible);
+
             return (
               <DayColumn
                 key={day.toISOString()}
-                day={day}
-                events={dayEvents}
+                events={visible}
                 lobbyMap={lobbyMap}
                 today={isToday(day)}
                 selectedEventId={selectedEventId}
                 onEventClick={onEventClick}
-                showFreeSlots={dayEvents.length > 0}
+                freeSlots={freeSlots}
+                lanes={lanes}
+                overflowCount={overflowCount}
+                onShowMore={() => onDayClick(day, dayEvents)}
               />
             );
           })}
@@ -275,7 +366,7 @@ export function WeekGrid({
       </div>
 
       {/* Legend */}
-      <CalendarLegend />
+      <CalendarLegend items={legendItems} />
     </div>
   );
 }

--- a/lined-web/src/components/__tests__/CreateEventModal.test.tsx
+++ b/lined-web/src/components/__tests__/CreateEventModal.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders, screen, userEvent, waitFor } from '@/test/utils';
+import { server } from '@/test/server';
+import { MOCK_LOBBIES } from '@/test/data';
+import { CreateEventModal } from '../CreateEventModal';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+const LOBBY = MOCK_LOBBIES[0]!; // id 1, COUPLE
+
+describe('CreateEventModal', () => {
+  it('shows an editable lobby select when not locked', () => {
+    expect.assertions(2);
+    renderWithProviders(
+      <CreateEventModal lobbies={MOCK_LOBBIES} onClose={vi.fn()} onCreated={vi.fn()} />,
+    );
+
+    const select = screen.getByRole('combobox');
+    expect(select).toBeInTheDocument();
+    expect(select).toBeEnabled();
+  });
+
+  it('shows a static lobby name and no select when locked', () => {
+    expect.assertions(2);
+    renderWithProviders(
+      <CreateEventModal
+        lobbies={[LOBBY]}
+        lockedLobbyId={LOBBY.id}
+        onClose={vi.fn()}
+        onCreated={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.getByText(LOBBY.name)).toBeInTheDocument();
+  });
+
+  it('does not submit when the title is blank', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onCreated = vi.fn();
+    renderWithProviders(
+      <CreateEventModal lobbies={MOCK_LOBBIES} onClose={vi.fn()} onCreated={onCreated} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Create Event' }));
+
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+
+  it('submits with the locked lobby id and calls onCreated on success', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onCreated = vi.fn();
+    renderWithProviders(
+      <CreateEventModal
+        lobbies={[LOBBY]}
+        lockedLobbyId={LOBBY.id}
+        onClose={vi.fn()}
+        onCreated={onCreated}
+      />,
+    );
+
+    await user.type(screen.getByPlaceholderText(/movie night/i), 'Board game night');
+    await user.click(screen.getByRole('button', { name: 'Create Event' }));
+
+    await waitFor(() =>
+      expect(onCreated).toHaveBeenCalledWith(
+        expect.objectContaining({ lobbyId: LOBBY.id }),
+      ),
+    );
+  });
+
+  it('surfaces an inline error on a 400 response', async () => {
+    expect.assertions(1);
+    server.use(
+      http.post(`${BASE}/calendar/events`, () =>
+        HttpResponse.json(
+          { code: 'VALIDATION_ERROR', message: 'title must not be blank' },
+          { status: 400 },
+        ),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(
+      <CreateEventModal lobbies={MOCK_LOBBIES} onClose={vi.fn()} onCreated={vi.fn()} />,
+    );
+
+    await user.type(screen.getByPlaceholderText(/movie night/i), 'Board game night');
+    await user.click(screen.getByRole('button', { name: 'Create Event' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Enter a valid title and time range',
+    );
+  });
+
+  it('surfaces a generic error on a 500 response', async () => {
+    expect.assertions(1);
+    server.use(http.post(`${BASE}/calendar/events`, () => new HttpResponse(null, { status: 500 })));
+    const user = userEvent.setup();
+    renderWithProviders(
+      <CreateEventModal lobbies={MOCK_LOBBIES} onClose={vi.fn()} onCreated={vi.fn()} />,
+    );
+
+    await user.type(screen.getByPlaceholderText(/movie night/i), 'Board game night');
+    await user.click(screen.getByRole('button', { name: 'Create Event' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      "Couldn't create event — please try again",
+    );
+  });
+});

--- a/lined-web/src/components/__tests__/WeekGrid.test.tsx
+++ b/lined-web/src/components/__tests__/WeekGrid.test.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { EventDto, LobbyDto } from '@/types';
+import { getWeekStart } from '@/lib/calendarUtils';
+import { WeekGrid } from '../WeekGrid';
+
+const LOBBY: LobbyDto = {
+  id: 1,
+  name: 'Alex & Anastasiia',
+  lobbyType: 'COUPLE',
+  ownerId: 1,
+  memberIds: [1, 2],
+};
+
+const WEEK_START = getWeekStart(new Date('2026-03-30T00:00:00')); // a Monday
+
+const dayAt = (offsetDays: number, hour: number): Date => {
+  const d = new Date(WEEK_START);
+  d.setDate(d.getDate() + offsetDays);
+  d.setHours(hour, 0, 0, 0);
+  return d;
+};
+
+const makeEvent = (id: number, offsetDays: number, hour: number, durationHours = 1): EventDto => {
+  const start = dayAt(offsetDays, hour);
+  const end = new Date(start.getTime() + durationHours * 60 * 60 * 1000);
+  return {
+    id,
+    title: `Event ${id}`,
+    location: null,
+    shared: true,
+    startAt: start.toISOString(),
+    endAt: end.toISOString(),
+    timezone: 'UTC',
+    lobbyId: LOBBY.id,
+    ownerId: 1,
+    createdAt: '2026-01-01T00:00:00Z',
+  };
+};
+
+// 5 same-day events, so any overflow behavior (opt-in only) has something to bite on.
+const fiveEventsOnMonday: EventDto[] = Array.from({ length: 5 }, (_, i) =>
+  makeEvent(i + 1, 0, 9 + i),
+);
+
+describe('WeekGrid — regression guard (global calendar, no onDayClick)', () => {
+  it('renders every event with no cap and no overflow pill', () => {
+    expect.assertions(fiveEventsOnMonday.length + 1);
+    render(
+      <WeekGrid
+        weekStart={WEEK_START}
+        events={fiveEventsOnMonday}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+      />,
+    );
+
+    for (const event of fiveEventsOnMonday) {
+      expect(screen.getByText(event.title)).toBeInTheDocument();
+    }
+    expect(screen.queryByText(/more$/)).not.toBeInTheDocument();
+  });
+
+  it('renders the default 5-item legend', () => {
+    expect.assertions(1);
+    render(
+      <WeekGrid
+        weekStart={WEEK_START}
+        events={[]}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Free slot')).toBeInTheDocument();
+  });
+});
+
+describe('WeekGrid — legendItems override', () => {
+  it('renders the supplied legend instead of the default', () => {
+    expect.assertions(2);
+    render(
+      <WeekGrid
+        weekStart={WEEK_START}
+        events={[]}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        legendItems={[{ label: 'Shared event', color: '#000' }]}
+      />,
+    );
+
+    expect(screen.getByText('Shared event')).toBeInTheDocument();
+    expect(screen.queryByText('Couple')).not.toBeInTheDocument();
+  });
+});
+
+describe('WeekGrid — getFreeSlotsForDay override', () => {
+  it('uses the supplied free slots instead of computeFreeSlots', () => {
+    expect.assertions(1);
+    render(
+      <WeekGrid
+        weekStart={WEEK_START}
+        events={[]}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        getFreeSlotsForDay={() => [{ startHour: 9, endHour: 10 }]}
+      />,
+    );
+
+    expect(screen.getAllByText('Free slot').length).toBeGreaterThan(0);
+  });
+});
+
+describe('WeekGrid — onDayClick opt-in (lobby calendar behavior)', () => {
+  it('caps visible events and shows a "+N more" pill', () => {
+    expect.assertions(2);
+    render(
+      <WeekGrid
+        weekStart={WEEK_START}
+        events={fiveEventsOnMonday}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        onDayClick={vi.fn()}
+        maxVisibleEvents={4}
+      />,
+    );
+
+    expect(screen.queryByText('Event 5')).not.toBeInTheDocument();
+    expect(screen.getByText('+1 more')).toBeInTheDocument();
+  });
+
+  it('calls onDayClick with the full day event list when the pill is clicked', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    const onDayClick = vi.fn();
+    render(
+      <WeekGrid
+        weekStart={WEEK_START}
+        events={fiveEventsOnMonday}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        onDayClick={onDayClick}
+        maxVisibleEvents={4}
+      />,
+    );
+
+    await user.click(screen.getByText('+1 more'));
+
+    expect(onDayClick).toHaveBeenCalledTimes(1);
+    const [, dayEvents] = onDayClick.mock.calls[0] as [Date, EventDto[]];
+    expect(dayEvents).toHaveLength(5);
+  });
+
+  it('calls onDayClick when the day header is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onDayClick = vi.fn();
+    render(
+      <WeekGrid
+        weekStart={WEEK_START}
+        events={fiveEventsOnMonday}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        onDayClick={onDayClick}
+      />,
+    );
+
+    await user.click(screen.getByText('Mon 30'));
+
+    expect(onDayClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders overlapping events at fractional widths (lane assignment)', () => {
+    expect.assertions(2);
+    const overlapping = [makeEvent(10, 0, 9, 2), makeEvent(11, 0, 10, 1)];
+    render(
+      <WeekGrid
+        weekStart={WEEK_START}
+        events={overlapping}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        onDayClick={vi.fn()}
+      />,
+    );
+
+    const first = screen.getByText('Event 10').closest('button');
+    const second = screen.getByText('Event 11').closest('button');
+    expect(first?.style.width).toBe('calc(50% - 4px)');
+    expect(second?.style.width).toBe('calc(50% - 4px)');
+  });
+});

--- a/lined-web/src/components/lobby/DayAgendaModal.tsx
+++ b/lined-web/src/components/lobby/DayAgendaModal.tsx
@@ -1,0 +1,109 @@
+import { X, MapPin, Sparkles } from 'lucide-react';
+import type { EventDto, LobbyDto } from '@/types';
+import { formatClockTime, formatFullDate, formatHourRange, type FreeSlot } from '@/lib/calendarUtils';
+
+interface DayAgendaModalProps {
+  day: Date;
+  events: EventDto[];
+  freeSlots: FreeSlot[];
+  lobby: LobbyDto;
+  selectedEventId: number | null;
+  onEventClick: (id: number) => void;
+  onClose: () => void;
+}
+
+export function DayAgendaModal({
+  day,
+  events,
+  freeSlots,
+  lobby,
+  selectedEventId,
+  onEventClick,
+  onClose,
+}: DayAgendaModalProps) {
+  const sorted = [...events].sort((a, b) => a.startAt.localeCompare(b.startAt));
+  const accentColor = `var(--color-lobby-${lobby.lobbyType.toLowerCase()})`;
+
+  return (
+    /* Backdrop */
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/45"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      {/* Dialog */}
+      <div className="flex max-h-[80vh] w-[420px] max-w-[90vw] flex-col overflow-hidden rounded-2xl bg-white shadow-[var(--shadow-lg)]">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-5 pb-3">
+          <h2 className="text-base font-bold text-text-primary">{formatFullDate(day)}</h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-text-muted hover:text-text-secondary"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="overflow-y-auto px-6 pb-6">
+          {sorted.length === 0 ? (
+            <p className="py-2 text-sm text-text-secondary">No events today.</p>
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {sorted.map((event) => (
+                <li key={event.id}>
+                  <button
+                    type="button"
+                    onClick={() => onEventClick(event.id)}
+                    className={`w-full rounded-lg border px-3.5 py-2.5 text-left transition-colors hover:bg-gray-50 ${
+                      event.id === selectedEventId ? 'border-brand-green' : 'border-border'
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="h-2 w-2 flex-shrink-0 rounded-full"
+                        style={{ backgroundColor: accentColor }}
+                      />
+                      <span className="text-sm font-semibold text-text-primary">
+                        {formatClockTime(new Date(event.startAt))} –{' '}
+                        {formatClockTime(new Date(event.endAt))}
+                      </span>
+                    </div>
+                    <div className="mt-1 text-sm text-text-primary">{event.title}</div>
+                    {event.location && (
+                      <div className="mt-0.5 flex items-center gap-1 text-xs text-text-secondary">
+                        <MapPin className="h-3 w-3 flex-shrink-0" />
+                        {event.location}
+                      </div>
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {freeSlots.length > 0 && (
+            <div className="mt-4">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-secondary">
+                Both free
+              </h3>
+              <ul className="flex flex-col gap-1.5">
+                {freeSlots.map((slot, i) => (
+                  <li
+                    key={i}
+                    className="flex items-center gap-1.5 rounded-lg px-3.5 py-2 text-sm text-brand-green-dark"
+                    style={{ backgroundColor: '#B4EBD0', opacity: 0.6 }}
+                  >
+                    <Sparkles className="h-3.5 w-3.5 flex-shrink-0" />
+                    {formatHourRange(slot.startHour, slot.endHour)}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lined-web/src/components/lobby/LobbyCalendarView.tsx
+++ b/lined-web/src/components/lobby/LobbyCalendarView.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import type { LobbyDto } from '@/types';
+import { CalendarTopBar } from '@/components/CalendarTopBar';
+import { CreateEventModal } from '@/components/CreateEventModal';
+import { EventDetailPanel } from '@/components/EventDetailPanel';
+import { WeekGrid, type LegendItem } from '@/components/WeekGrid';
+import { DayAgendaModal } from '@/components/lobby/DayAgendaModal';
+import { useLobbyWeekEvents, useDeleteEvent } from '@/hooks/useEvents';
+import { useLobbyFreeSlots } from '@/hooks/useDashboard';
+import { addDays, getWeekStart, isSameDay } from '@/lib/calendarUtils';
+import { freeSlotsForDay } from '@/lib/freeSlots';
+import type { ViewMode } from '@/store/calendar';
+
+interface LobbyCalendarViewProps {
+  lobby: LobbyDto;
+}
+
+export function LobbyCalendarView({ lobby }: LobbyCalendarViewProps) {
+  const [weekStart, setWeekStart] = useState(() => getWeekStart());
+  const [viewMode, setViewMode] = useState<ViewMode>('week');
+  const [selectedEventId, setSelectedEventId] = useState<number | null>(null);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [agendaDay, setAgendaDay] = useState<Date | null>(null);
+
+  const { data: events, isLoading, isError } = useLobbyWeekEvents(lobby.id, weekStart);
+  const { data: freeSlots } = useLobbyFreeSlots(lobby.id, weekStart);
+  const deleteEvent = useDeleteEvent();
+
+  const selectedEvent =
+    selectedEventId != null ? (events?.find((e) => e.id === selectedEventId) ?? null) : null;
+
+  const legendItems: LegendItem[] = [
+    { label: 'Shared event', color: `var(--color-lobby-${lobby.lobbyType.toLowerCase()})` },
+    { label: 'Free slot (both available)', color: '#B4EBD0' },
+  ];
+
+  function handleDelete() {
+    if (selectedEventId == null) return;
+    deleteEvent.mutate(selectedEventId, {
+      onSuccess: () => setSelectedEventId(null),
+    });
+  }
+
+  return (
+    <div className="relative flex h-[calc(100vh-160px)] flex-col overflow-hidden">
+      <CalendarTopBar
+        weekStart={weekStart}
+        viewMode={viewMode}
+        onPrevWeek={() => setWeekStart((s) => addDays(s, -7))}
+        onNextWeek={() => setWeekStart((s) => addDays(s, 7))}
+        onToday={() => setWeekStart(getWeekStart())}
+        onViewModeChange={setViewMode}
+        onNewEvent={() => setIsCreateModalOpen(true)}
+      />
+
+      {isLoading ? (
+        <div className="flex-1 p-6" data-testid="lobby-calendar-loading">
+          <div className="h-full animate-pulse rounded-xl bg-bg" />
+        </div>
+      ) : isError ? (
+        <p className="p-6 text-sm text-text-secondary">
+          Couldn&apos;t load the calendar. Try again later.
+        </p>
+      ) : (
+        <div className="flex flex-1 min-h-0 overflow-hidden">
+          <WeekGrid
+            weekStart={weekStart}
+            events={events ?? []}
+            lobbies={[lobby]}
+            selectedEventId={selectedEventId}
+            onEventClick={setSelectedEventId}
+            getFreeSlotsForDay={(day) => freeSlotsForDay(freeSlots ?? [], day)}
+            legendItems={legendItems}
+            onDayClick={(day) => setAgendaDay(day)}
+            maxVisibleEvents={4}
+          />
+
+          {selectedEvent && (
+            <EventDetailPanel
+              event={selectedEvent}
+              lobby={lobby}
+              onClose={() => setSelectedEventId(null)}
+              onEdit={() => {
+                /* TODO: open edit modal (Task 10) */
+              }}
+              onDelete={handleDelete}
+            />
+          )}
+        </div>
+      )}
+
+      {isCreateModalOpen && (
+        <CreateEventModal
+          lobbies={[lobby]}
+          lockedLobbyId={lobby.id}
+          onClose={() => setIsCreateModalOpen(false)}
+          onCreated={(event) => {
+            setIsCreateModalOpen(false);
+            setSelectedEventId(event.id);
+          }}
+        />
+      )}
+
+      {agendaDay && (
+        <DayAgendaModal
+          day={agendaDay}
+          events={(events ?? []).filter((e) => isSameDay(new Date(e.startAt), agendaDay))}
+          freeSlots={freeSlotsForDay(freeSlots ?? [], agendaDay)}
+          lobby={lobby}
+          selectedEventId={selectedEventId}
+          onEventClick={(id) => {
+            setAgendaDay(null);
+            setSelectedEventId(id);
+          }}
+          onClose={() => setAgendaDay(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/lined-web/src/components/lobby/__tests__/DayAgendaModal.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/DayAgendaModal.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { EventDto, LobbyDto } from '@/types';
+import { DayAgendaModal } from '../DayAgendaModal';
+
+const LOBBY: LobbyDto = {
+  id: 1,
+  name: 'Alex & Anastasiia',
+  lobbyType: 'COUPLE',
+  ownerId: 1,
+  memberIds: [1, 2],
+};
+
+const DAY = new Date('2026-03-28T00:00:00');
+
+const makeEvent = (id: number, startHour: number, location: string | null = null): EventDto => ({
+  id,
+  title: `Event ${id}`,
+  location,
+  shared: true,
+  startAt: `2026-03-28T${String(startHour).padStart(2, '0')}:00:00`,
+  endAt: `2026-03-28T${String(startHour + 1).padStart(2, '0')}:00:00`,
+  timezone: 'UTC',
+  lobbyId: 1,
+  ownerId: 1,
+  createdAt: '2026-01-01T00:00:00Z',
+});
+
+describe('DayAgendaModal', () => {
+  it('renders events sorted chronologically with time and title', () => {
+    expect.assertions(2);
+    const later = makeEvent(1, 16);
+    const earlier = makeEvent(2, 9);
+    render(
+      <DayAgendaModal
+        day={DAY}
+        events={[later, earlier]}
+        freeSlots={[]}
+        lobby={LOBBY}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const rows = screen.getAllByRole('button', { name: /Event \d/ });
+    expect(rows[0]).toHaveTextContent('Event 2');
+    expect(rows[1]).toHaveTextContent('Event 1');
+  });
+
+  it('omits the location line for an event without a location', () => {
+    expect.assertions(1);
+    render(
+      <DayAgendaModal
+        day={DAY}
+        events={[makeEvent(1, 9, null)]}
+        freeSlots={[]}
+        lobby={LOBBY}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText('Home')).not.toBeInTheDocument();
+  });
+
+  it('renders a location line when present', () => {
+    expect.assertions(1);
+    render(
+      <DayAgendaModal
+        day={DAY}
+        events={[makeEvent(1, 9, 'Home')]}
+        freeSlots={[]}
+        lobby={LOBBY}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Home')).toBeInTheDocument();
+  });
+
+  it('renders free-slot rows via formatHourRange', () => {
+    expect.assertions(1);
+    render(
+      <DayAgendaModal
+        day={DAY}
+        events={[]}
+        freeSlots={[{ startHour: 14, endHour: 17 }]}
+        lobby={LOBBY}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('2–5 PM')).toBeInTheDocument();
+  });
+
+  it('shows "No events today" for an empty day while still listing free slots', () => {
+    expect.assertions(2);
+    render(
+      <DayAgendaModal
+        day={DAY}
+        events={[]}
+        freeSlots={[{ startHour: 14, endHour: 17 }]}
+        lobby={LOBBY}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('No events today.')).toBeInTheDocument();
+    expect(screen.getByText('2–5 PM')).toBeInTheDocument();
+  });
+
+  it('calls onEventClick when an event row is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onEventClick = vi.fn();
+    render(
+      <DayAgendaModal
+        day={DAY}
+        events={[makeEvent(1, 9)]}
+        freeSlots={[]}
+        lobby={LOBBY}
+        selectedEventId={null}
+        onEventClick={onEventClick}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByText('Event 1'));
+
+    expect(onEventClick).toHaveBeenCalledWith(1);
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <DayAgendaModal
+        day={DAY}
+        events={[]}
+        freeSlots={[]}
+        lobby={LOBBY}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    await user.click(screen.getByLabelText('Close'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lined-web/src/components/lobby/__tests__/LobbyCalendarView.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/LobbyCalendarView.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders, screen, userEvent, waitFor } from '@/test/utils';
+import { server } from '@/test/server';
+import { MOCK_LOBBIES } from '@/test/data';
+import type { EventDto } from '@/types';
+import { LobbyCalendarView } from '../LobbyCalendarView';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+const LOBBY = MOCK_LOBBIES[0]!; // id 1, COUPLE
+
+const todayStr = new Date().toISOString().slice(0, 10);
+
+const makeEvent = (id: number, lobbyId: number, hour: number, title: string): EventDto => ({
+  id,
+  title,
+  location: null,
+  shared: true,
+  startAt: `${todayStr}T${String(hour).padStart(2, '0')}:00:00Z`,
+  endAt: `${todayStr}T${String(hour + 1).padStart(2, '0')}:00:00Z`,
+  timezone: 'UTC',
+  lobbyId,
+  ownerId: 1,
+  createdAt: '2026-01-01T00:00:00Z',
+});
+
+describe('LobbyCalendarView', () => {
+  it('shows a loading state before events resolve', () => {
+    expect.assertions(1);
+    renderWithProviders(<LobbyCalendarView lobby={LOBBY} />);
+
+    expect(screen.getByTestId('lobby-calendar-loading')).toBeInTheDocument();
+  });
+
+  it('shows an error message when the events request fails', async () => {
+    expect.assertions(1);
+    server.use(http.get(`${BASE}/calendar/events`, () => new HttpResponse(null, { status: 500 })));
+    renderWithProviders(<LobbyCalendarView lobby={LOBBY} />);
+
+    expect(
+      await screen.findByText("Couldn't load the calendar. Try again later."),
+    ).toBeInTheDocument();
+  });
+
+  it('renders only this lobby\'s events, filtering out other lobbies\'', async () => {
+    expect.assertions(2);
+    server.use(
+      http.get(`${BASE}/calendar/events`, () =>
+        HttpResponse.json([
+          makeEvent(1, LOBBY.id, 9, 'Morning Coffee'),
+          makeEvent(2, 3, 10, 'Team Lunch'),
+        ]),
+      ),
+    );
+    renderWithProviders(<LobbyCalendarView lobby={LOBBY} />);
+
+    expect(await screen.findByText('Morning Coffee')).toBeInTheDocument();
+    expect(screen.queryByText('Team Lunch')).not.toBeInTheDocument();
+  });
+
+  it('renders a free-slot band inside the visible week', async () => {
+    expect.assertions(1);
+    server.use(
+      http.get(`${BASE}/calendar/events`, () => HttpResponse.json([])),
+      http.get(`${BASE}/lobbies/:id/free-slots`, () =>
+        HttpResponse.json([{ start: `${todayStr}T14:00:00Z`, end: `${todayStr}T17:00:00Z` }]),
+      ),
+    );
+    renderWithProviders(<LobbyCalendarView lobby={LOBBY} />);
+
+    await waitFor(() => {
+      if (screen.queryAllByText('Free slot').length === 0) throw new Error('not yet rendered');
+    });
+    expect(screen.getAllByText('Free slot').length).toBeGreaterThan(0);
+  });
+
+  it('shows a "+N more" pill for a busy day and opens the day agenda listing all events', async () => {
+    expect.assertions(2);
+    const events = Array.from({ length: 5 }, (_, i) =>
+      makeEvent(i + 1, LOBBY.id, 9 + i, `Event ${i + 1}`),
+    );
+    server.use(http.get(`${BASE}/calendar/events`, () => HttpResponse.json(events)));
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyCalendarView lobby={LOBBY} />);
+    await screen.findByText('Event 1');
+
+    await user.click(screen.getByText('+1 more'));
+    await screen.findAllByText(/Event \d/);
+
+    expect(screen.queryByText('No events today.')).not.toBeInTheDocument();
+    expect(screen.getAllByText(/Event \d/).length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('opens the event detail panel from the day agenda and closes the agenda', async () => {
+    expect.assertions(1);
+    const events = Array.from({ length: 5 }, (_, i) =>
+      makeEvent(i + 1, LOBBY.id, 9 + i, `Event ${i + 1}`),
+    );
+    server.use(http.get(`${BASE}/calendar/events`, () => HttpResponse.json(events)));
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyCalendarView lobby={LOBBY} />);
+    await screen.findByText('Event 1');
+    await user.click(screen.getByText('+1 more'));
+    await screen.findAllByText(/Event \d/);
+
+    const [agendaEventRow] = screen.getAllByText('Event 5');
+    await user.click(agendaEventRow!);
+
+    expect(await screen.findByRole('button', { name: 'Edit event' })).toBeInTheDocument();
+  });
+
+  it('"+ New event" opens CreateEventModal with the lobby locked', async () => {
+    expect.assertions(2);
+    server.use(http.get(`${BASE}/calendar/events`, () => HttpResponse.json([])));
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyCalendarView lobby={LOBBY} />);
+
+    await user.click(screen.getByRole('button', { name: /new event/i }));
+
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.getByText(LOBBY.name)).toBeInTheDocument();
+  });
+
+  it('clicking an event opens the detail panel and delete closes it', async () => {
+    expect.assertions(1);
+    server.use(
+      http.get(`${BASE}/calendar/events`, () =>
+        HttpResponse.json([makeEvent(1, LOBBY.id, 9, 'Morning Coffee')]),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyCalendarView lobby={LOBBY} />);
+    await user.click(await screen.findByText('Morning Coffee'));
+    await screen.findByRole('button', { name: 'Edit event' });
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      if (screen.queryByRole('button', { name: 'Edit event' })) throw new Error('still open');
+    });
+    expect(screen.queryByRole('button', { name: 'Edit event' })).not.toBeInTheDocument();
+  });
+});

--- a/lined-web/src/hooks/useDashboard.ts
+++ b/lined-web/src/hooks/useDashboard.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import type { FreeSlotDto } from '@/types';
 import { getFreeSlots } from '@/api/lobbies';
 import { QUERY_KEYS } from '@/lib/constants';
 import { addDays } from '@/lib/calendarUtils';
@@ -62,4 +63,17 @@ export function useFreeSlotBanner(): {
       otherUsername: otherUserQuery.data?.username ?? null,
     },
   };
+}
+
+const LOBBY_FREE_SLOTS_WINDOW_DAYS = 7;
+
+/** Free slots for one lobby over the visible week, used by the lobby calendar tab. */
+export function useLobbyFreeSlots(lobbyId: number, weekStart: Date) {
+  const from = weekStart.toISOString();
+  const to = addDays(weekStart, LOBBY_FREE_SLOTS_WINDOW_DAYS).toISOString();
+
+  return useQuery<FreeSlotDto[]>({
+    queryKey: [...QUERY_KEYS.lobbyFreeSlots(lobbyId), from.slice(0, 10)],
+    queryFn: () => getFreeSlots(lobbyId, from, to),
+  });
 }

--- a/lined-web/src/hooks/useEvents.ts
+++ b/lined-web/src/hooks/useEvents.ts
@@ -13,6 +13,18 @@ export function useWeekEvents(weekStart: Date) {
   });
 }
 
+/** Week events scoped to one lobby. The backend has no per-lobby filter param, so filter client-side. */
+export function useLobbyWeekEvents(lobbyId: number, weekStart: Date) {
+  const from = weekStart.toISOString();
+  const to = addDays(weekStart, 7).toISOString();
+
+  return useQuery({
+    queryKey: [...QUERY_KEYS.events, 'lobby', lobbyId, from],
+    queryFn: () => listEvents({ from, to }),
+    select: (events) => events.filter((e) => e.lobbyId === lobbyId),
+  });
+}
+
 const UPCOMING_EVENTS_WINDOW_DAYS = 14;
 const UPCOMING_EVENTS_LIMIT = 5;
 

--- a/lined-web/src/lib/__tests__/calendarUtils.test.ts
+++ b/lined-web/src/lib/__tests__/calendarUtils.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { EventDto } from '@/types';
 import {
   getGreeting,
   formatFullDate,
   formatRelativeEventTime,
   formatFreeSlotRange,
   formatTaskDueDate,
+  formatHourRange,
+  assignEventLanes,
 } from '../calendarUtils';
 
 afterEach(() => {
@@ -146,5 +149,88 @@ describe('formatTaskDueDate', () => {
     const result = formatTaskDueDate('2026-04-01', 'TODO');
     expect(result.label).toBe('Apr 1');
     expect(result.isUrgent).toBe(false);
+  });
+});
+
+describe('formatHourRange', () => {
+  it('formats a same-AM/PM whole-hour range', () => {
+    expect.assertions(1);
+    expect(formatHourRange(14, 17)).toBe('2–5 PM');
+  });
+
+  it('formats a range crossing AM to PM', () => {
+    expect.assertions(1);
+    expect(formatHourRange(9, 12)).toBe('9 AM–12 PM');
+  });
+
+  it('includes minutes for a half-hour boundary', () => {
+    expect.assertions(1);
+    expect(formatHourRange(9.5, 11)).toBe('9:30–11 AM');
+  });
+});
+
+describe('assignEventLanes', () => {
+  const makeEvent = (id: number, startAt: string, endAt: string): EventDto => ({
+    id,
+    title: `Event ${id}`,
+    location: null,
+    shared: true,
+    startAt,
+    endAt,
+    timezone: 'UTC',
+    lobbyId: 1,
+    ownerId: 1,
+    createdAt: '2026-01-01T00:00:00Z',
+  });
+
+  it('returns an empty map for no events', () => {
+    expect.assertions(1);
+    expect(assignEventLanes([]).size).toBe(0);
+  });
+
+  it('assigns lane 0 with laneCount 1 to non-overlapping events', () => {
+    expect.assertions(2);
+    const events = [
+      makeEvent(1, '2026-03-28T09:00:00Z', '2026-03-28T10:00:00Z'),
+      makeEvent(2, '2026-03-28T11:00:00Z', '2026-03-28T12:00:00Z'),
+    ];
+    const lanes = assignEventLanes(events);
+    expect(lanes.get(1)).toEqual({ lane: 0, laneCount: 1 });
+    expect(lanes.get(2)).toEqual({ lane: 0, laneCount: 1 });
+  });
+
+  it('assigns two lanes to a pair of overlapping events', () => {
+    expect.assertions(2);
+    const events = [
+      makeEvent(1, '2026-03-28T09:00:00Z', '2026-03-28T10:30:00Z'),
+      makeEvent(2, '2026-03-28T10:00:00Z', '2026-03-28T11:00:00Z'),
+    ];
+    const lanes = assignEventLanes(events);
+    expect(lanes.get(1)).toEqual({ lane: 0, laneCount: 2 });
+    expect(lanes.get(2)).toEqual({ lane: 1, laneCount: 2 });
+  });
+
+  it('assigns three lanes to a three-way overlap', () => {
+    expect.assertions(1);
+    const events = [
+      makeEvent(1, '2026-03-28T09:00:00Z', '2026-03-28T12:00:00Z'),
+      makeEvent(2, '2026-03-28T10:00:00Z', '2026-03-28T11:00:00Z'),
+      makeEvent(3, '2026-03-28T10:30:00Z', '2026-03-28T13:00:00Z'),
+    ];
+    const lanes = assignEventLanes(events);
+    const laneCounts = [1, 2, 3].map((id) => lanes.get(id)?.laneCount);
+    expect(laneCounts).toEqual([3, 3, 3]);
+  });
+
+  it('starts a fresh lane cluster once the previous cluster fully ends', () => {
+    expect.assertions(2);
+    const events = [
+      makeEvent(1, '2026-03-28T09:00:00Z', '2026-03-28T10:00:00Z'),
+      makeEvent(2, '2026-03-28T09:00:00Z', '2026-03-28T10:00:00Z'),
+      makeEvent(3, '2026-03-28T12:00:00Z', '2026-03-28T13:00:00Z'),
+    ];
+    const lanes = assignEventLanes(events);
+    expect(lanes.get(1)?.laneCount).toBe(2);
+    expect(lanes.get(3)).toEqual({ lane: 0, laneCount: 1 });
   });
 });

--- a/lined-web/src/lib/__tests__/freeSlots.test.ts
+++ b/lined-web/src/lib/__tests__/freeSlots.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import type { FreeSlotDto } from '@/types';
+import { freeSlotsForDay } from '../freeSlots';
+
+const DAY = new Date('2026-03-28T00:00:00');
+const OTHER_DAY = new Date('2026-03-29T00:00:00');
+
+describe('freeSlotsForDay', () => {
+  it('returns an empty array for no slots', () => {
+    expect.assertions(1);
+    expect(freeSlotsForDay([], DAY)).toEqual([]);
+  });
+
+  it('converts a same-day slot to grid-relative hours', () => {
+    expect.assertions(1);
+    const slots: FreeSlotDto[] = [
+      { start: '2026-03-28T14:00:00', end: '2026-03-28T17:00:00' },
+    ];
+    expect(freeSlotsForDay(slots, DAY)).toEqual([{ startHour: 14, endHour: 17 }]);
+  });
+
+  it('skips a slot that does not touch the given day', () => {
+    expect.assertions(1);
+    const slots: FreeSlotDto[] = [
+      { start: '2026-03-28T14:00:00', end: '2026-03-28T17:00:00' },
+    ];
+    expect(freeSlotsForDay(slots, OTHER_DAY)).toEqual([]);
+  });
+
+  it('clips a slot to the grid start/end bounds', () => {
+    expect.assertions(1);
+    const slots: FreeSlotDto[] = [
+      { start: '2026-03-28T06:00:00', end: '2026-03-28T23:00:00' },
+    ];
+    expect(freeSlotsForDay(slots, DAY)).toEqual([{ startHour: 8, endHour: 22 }]);
+  });
+
+  it('handles multiple slots in the same day', () => {
+    expect.assertions(1);
+    const slots: FreeSlotDto[] = [
+      { start: '2026-03-28T09:00:00', end: '2026-03-28T10:00:00' },
+      { start: '2026-03-28T15:00:00', end: '2026-03-28T16:00:00' },
+    ];
+    expect(freeSlotsForDay(slots, DAY)).toEqual([
+      { startHour: 9, endHour: 10 },
+      { startHour: 15, endHour: 16 },
+    ]);
+  });
+});

--- a/lined-web/src/lib/calendarUtils.ts
+++ b/lined-web/src/lib/calendarUtils.ts
@@ -223,6 +223,87 @@ export function computeFreeSlots(events: EventDto[]): FreeSlot[] {
   return freeSlots;
 }
 
+/** "2–5 PM", "9 AM–12 PM" for a grid-relative hour range. */
+export function formatHourRange(startHour: number, endHour: number): string {
+  const formatHourAmPm = (hour: number): { value: string; ampm: 'AM' | 'PM' } => {
+    const wholeHour = Math.floor(hour);
+    const ampm = wholeHour >= 12 ? 'PM' : 'AM';
+    const h = wholeHour % 12 || 12;
+    const minutes = Math.round((hour - wholeHour) * 60);
+    const value = minutes === 0 ? `${h}` : `${h}:${minutes.toString().padStart(2, '0')}`;
+    return { value, ampm };
+  };
+
+  const start = formatHourAmPm(startHour);
+  const end = formatHourAmPm(endHour);
+
+  return start.ampm === end.ampm
+    ? `${start.value}–${end.value} ${end.ampm}`
+    : `${start.value} ${start.ampm}–${end.value} ${end.ampm}`;
+}
+
+export interface EventLane {
+  lane: number;
+  laneCount: number;
+}
+
+/**
+ * Greedy sweep-line layout: assigns each event to the first lane whose
+ * previous occupant has already ended, opening a new lane otherwise. Events
+ * that overlap in time end up in the same "cluster" and share its lane count.
+ */
+export function assignEventLanes(events: EventDto[]): Map<number, EventLane> {
+  const result = new Map<number, EventLane>();
+  if (events.length === 0) return result;
+
+  const sorted = [...events].sort(
+    (a, b) => new Date(a.startAt).getTime() - new Date(b.startAt).getTime(),
+  );
+
+  let clusterEventIds: number[] = [];
+  let clusterLaneCount = 0;
+  let clusterEnd = -Infinity;
+
+  const flushCluster = () => {
+    for (const id of clusterEventIds) {
+      const lane = result.get(id)?.lane ?? 0;
+      result.set(id, { lane, laneCount: clusterLaneCount });
+    }
+  };
+
+  const laneEnds: number[] = [];
+
+  for (const event of sorted) {
+    const start = new Date(event.startAt).getTime();
+    const end = new Date(event.endAt).getTime();
+
+    if (start >= clusterEnd) {
+      flushCluster();
+      clusterEventIds = [];
+      clusterLaneCount = 0;
+      laneEnds.length = 0;
+      clusterEnd = -Infinity;
+    }
+
+    let lane = laneEnds.findIndex((laneEndTime) => laneEndTime <= start);
+    if (lane === -1) {
+      lane = laneEnds.length;
+      laneEnds.push(end);
+    } else {
+      laneEnds[lane] = end;
+    }
+
+    result.set(event.id, { lane, laneCount: 1 });
+    clusterEventIds.push(event.id);
+    clusterLaneCount = laneEnds.length;
+    clusterEnd = Math.max(clusterEnd, end);
+  }
+
+  flushCluster();
+
+  return result;
+}
+
 /** Format a Date as "YYYY-MM-DDTHH:mm" for datetime-local inputs. */
 export function toDatetimeLocal(date: Date): string {
   const pad = (n: number) => n.toString().padStart(2, '0');

--- a/lined-web/src/lib/freeSlots.ts
+++ b/lined-web/src/lib/freeSlots.ts
@@ -1,0 +1,31 @@
+import type { FreeSlotDto } from '@/types';
+import { GRID_END_HOUR, GRID_START_HOUR, isSameDay, type FreeSlot } from './calendarUtils';
+
+const toHour = (d: Date): number => d.getHours() + d.getMinutes() / 60;
+
+/**
+ * Converts server-side ISO-range free slots into grid-relative hour ranges
+ * for a single calendar day, clipped to the visible grid bounds.
+ */
+export function freeSlotsForDay(slots: FreeSlotDto[], day: Date): FreeSlot[] {
+  const result: FreeSlot[] = [];
+
+  for (const slot of slots) {
+    const start = new Date(slot.start);
+    const end = new Date(slot.end);
+    if (!isSameDay(start, day) && !isSameDay(end, day)) continue;
+
+    const startHour = isSameDay(start, day)
+      ? Math.max(toHour(start), GRID_START_HOUR)
+      : GRID_START_HOUR;
+    const endHour = isSameDay(end, day)
+      ? Math.min(toHour(end), GRID_END_HOUR)
+      : GRID_END_HOUR;
+
+    if (endHour > startHour) {
+      result.push({ startHour, endHour });
+    }
+  }
+
+  return result;
+}

--- a/lined-web/src/pages/LobbyPage.tsx
+++ b/lined-web/src/pages/LobbyPage.tsx
@@ -4,6 +4,7 @@ import { LobbyHeader } from '@/components/lobby/LobbyHeader';
 import { LobbyTabBar, type LobbyTab } from '@/components/lobby/LobbyTabBar';
 import { LobbyTaskList } from '@/components/lobby/LobbyTaskList';
 import { LobbyMemberList } from '@/components/lobby/LobbyMemberList';
+import { LobbyCalendarView } from '@/components/lobby/LobbyCalendarView';
 
 const VALID_TABS: LobbyTab[] = ['calendar', 'tasks', 'members'];
 
@@ -53,9 +54,7 @@ export function LobbyPage() {
 
       {activeTab === 'tasks' && <LobbyTaskList lobbyId={lobby.id} />}
 
-      {activeTab === 'calendar' && (
-        <p className="p-6 text-sm text-text-secondary">Lobby calendar coming soon...</p>
-      )}
+      {activeTab === 'calendar' && <LobbyCalendarView lobby={lobby} />}
 
       {activeTab === 'members' && <LobbyMemberList lobby={lobby} />}
     </div>

--- a/lined-web/src/pages/__tests__/LobbyPage.test.tsx
+++ b/lined-web/src/pages/__tests__/LobbyPage.test.tsx
@@ -38,11 +38,11 @@ describe('LobbyPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows placeholder copy for the calendar tab', async () => {
+  it('renders the lobby calendar on the calendar tab', async () => {
     expect.assertions(2);
     renderLobbyPage('/lobbies/1?tab=calendar');
 
-    expect(await screen.findByText('Lobby calendar coming soon...')).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /new event/i })).toBeInTheDocument();
     expect(screen.queryByText('Plan dinner for Saturday')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

Implements [UI-07 — Lobby Calendar Tab](lined-web/docs/tasks/UI-07-lobby-calendar.md): replaces the "coming soon" placeholder on the lobby detail page's Calendar tab with a week grid scoped to that lobby — only its events, colored by lobby type, plus "✨ Both free" bands from `GET /api/lobbies/{id}/free-slots`.

- `WeekGrid` refactored to be prop-driven (`getFreeSlotsForDay`, `legendItems`, opt-in `onDayClick`) instead of rebuilt — the global `/calendar` page passes no new props and is unaffected (covered by a regression test).
- New `src/lib/freeSlots.ts` converts server free-slot windows into grid-relative hour ranges.
- `CreateEventModal` gained a `lockedLobbyId` prop (read-only lobby field) and inline error surfacing on failed creates.
- **Busy-day handling**: overlapping same-time events now lay out in side-by-side lanes instead of fully overlapping (a real bug on the existing global calendar too); days past 4 visible events show a "+N more" pill. Clicking a day header or the pill opens `DayAgendaModal` — the full chronological agenda for that day plus its free slots.
- New hooks `useLobbyWeekEvents` (client-side lobbyId filter — no backend query param exists) and `useLobbyFreeSlots`.
- Loading skeleton and an inline error message on failed event fetches.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm run test:run` (216/216 passing), `npm run build` all pass from `lined-web/`
- [x] Verified in the dev server (MSW): only the target lobby's events render, colored correctly; free-slot band renders in the correct week/day; "+ New event" opens the modal with the lobby locked; clicking a day header opens the day agenda; clicking an event there closes the agenda and opens the detail panel; Delete closes the panel; global `/calendar` unaffected (all 5 legend items, no cap/pill)
- [x] `docs/UI_TASKS.md` Task 7 status updated to DONE

🤖 Generated with [Claude Code](https://claude.com/claude-code)