### PR TITLE
feat(web): Reserve Free Slot modal (Task 11)

### DIFF
--- a/lined-web/docs/UI_TASKS.md
+++ b/lined-web/docs/UI_TASKS.md
@@ -44,12 +44,11 @@ exist for every task, including `create-lobby` (task 4), `calendar-month`
 - **Lobby Calendar tab** — `LobbyCalendarView`, `DayAgendaModal`: week grid scoped to one lobby (events filtered client-side, colored by lobby type), free-slot bands from `GET /api/lobbies/{id}/free-slots`, a simplified 2-item legend, lobby-locked event creation, and day-overflow handling (lane layout for overlapping events, a "+N more" pill past 4 visible events, click-to-open day agenda listing all events + free slots for that day). `WeekGrid` was generalised (prop-driven free slots/legend, opt-in `onDayClick`) without changing the global calendar's behaviour.
 - **Add Task drawer** — `AddTaskDrawer`, `AssigneePicker`: right-side 420px sheet with title, description, assignee picker (reusable circular avatar single-select), due date (past-date warning, non-blocking), status, and notify-assignee toggle. Single-step `POST /api/tasks` create (status/description/priority/notifyAssignee all sent directly, no PATCH follow-up). Opens from the lobby Tasks tab (lobby-locked) and the global "+ Create" menu (lobby selector, since no lobby context exists there).
 - **Global Tasks Board (kanban)** — `KanbanBoard`, `KanbanColumn`, `KanbanCard`, `KanbanFilters`: three status columns (To Do / In Progress / Done) built by client-side grouping of `useMyTasks()` (`GET /api/tasks/mine`), with lobby/member/date (All/Overdue/This Week) filters, priority bars, lobby tags, due dates, assignee avatars, done-card dimming/strikethrough, ←/→ status moves plus native HTML5 drag-and-drop between columns (both optimistic `PATCH`, rollback on error), and delete-with-confirm (`DELETE`). "+ New task" and column "+"/"+ Add task" open `AddTaskDrawer` with the column's status preselected via `useCreateMenuStore`.
+- **Reserve Free Slot modal** — `ReserveSlotModal`: three modes resolved from an optional `ReserveSlotInitial` (lobbyId/start/end) — a full slot (dashboard banner, lobby free-band click) shows a read-only lobby/member card; a time-only slot (global-calendar free-band click, no lobby context) shows an editable lobby select; no slot (create-menu entry) computes per-lobby candidates via `useFreeSlotCandidates` and lets the user pick one. Submits a shared `POST /api/calendar/events` with `notifyMembers`; read-only attendee row (lobby members auto-included). `WeekGrid` gained an opt-in `onFreeSlotClick` to make free bands clickable.
 
 **Stubs only ("coming soon" placeholders):**
 SignInPage, SignUpPage, DashboardPage,
 UserSettingsPage, LobbySettingsPage.
-
-**Not started:** ReserveSlotModal.
 
 ## Backend API summary
 
@@ -87,7 +86,7 @@ UserSettingsPage, LobbySettingsPage.
 | 8 | `feature/ui-08-add-task-drawer` | Add Task drawer (title, assignee picker, due date, status) | [tasks/UI-08-add-task-drawer.md](tasks/UI-08-add-task-drawer.md) | DONE |
 | 9 | `feature/ui-09-tasks-kanban` | Global Tasks Board: 3-column kanban with filters and status transitions | [tasks/UI-09-tasks-kanban.md](tasks/UI-09-tasks-kanban.md) | DONE |
 | 10 | `feature/ui-10-calendar-enhancements` | Calendar polish: edit event, month view, legend | [tasks/UI-10-calendar-enhancements.md](tasks/UI-10-calendar-enhancements.md) | DONE |
-| 11 | `feature/ui-11-reserve-slot` | Free-slot detection surfacing + Reserve Free Slot modal | [tasks/UI-11-reserve-slot.md](tasks/UI-11-reserve-slot.md) | TODO |
+| 11 | `feature/ui-11-reserve-slot` | Free-slot detection surfacing + Reserve Free Slot modal | [tasks/UI-11-reserve-slot.md](tasks/UI-11-reserve-slot.md) | DONE |
 | 12 | `feature/ui-12-user-settings` | User Settings page: profile, notifications, appearance, danger zone | [tasks/UI-12-user-settings.md](tasks/UI-12-user-settings.md) | TODO |
 | 13 | `feature/ui-13-lobby-settings` | Lobby Settings page: general, notifications, leave/delete lobby | [tasks/UI-13-lobby-settings.md](tasks/UI-13-lobby-settings.md) | TODO |
 | 14 | `feature/ui-14-subscription-page` | Subscription & Plan page: current plan, available plans, subscribe/cancel, history | [tasks/UI-14-subscription-page.md](tasks/UI-14-subscription-page.md) | TODO |

--- a/lined-web/src/components/AddTaskDrawer.tsx
+++ b/lined-web/src/components/AddTaskDrawer.tsx
@@ -6,6 +6,7 @@ import { useUsers } from '@/hooks/useUsers';
 import { TASK_STATUS_LABELS } from '@/lib/constants';
 import { AuthAlert } from '@/components/AuthAlert';
 import { FormField } from '@/components/FormField';
+import { ToggleRow } from '@/components/ToggleRow';
 import { AssigneePicker } from '@/components/lobby/AssigneePicker';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetFooter } from '@/components/ui/sheet';
 
@@ -188,29 +189,12 @@ export function AddTaskDrawer({
               </select>
             </div>
 
-            <div className="flex items-center justify-between border-b border-border pb-1 pt-1">
-              <div>
-                <div className="text-sm font-medium text-text-primary">Notify assignee</div>
-                <div className="mt-0.5 text-xs text-text-secondary">
-                  Send a notification when the task is assigned
-                </div>
-              </div>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={notifyAssignee}
-                onClick={() => setNotifyAssignee((v) => !v)}
-                className={`relative h-6 w-11 flex-shrink-0 rounded-full transition-colors ${
-                  notifyAssignee ? 'bg-brand-green' : 'bg-border'
-                }`}
-              >
-                <span
-                  className={`absolute top-[3px] h-[18px] w-[18px] rounded-full bg-white shadow-sm transition-[left] ${
-                    notifyAssignee ? 'left-[23px]' : 'left-[3px]'
-                  }`}
-                />
-              </button>
-            </div>
+            <ToggleRow
+              label="Notify assignee"
+              description="Send a notification when the task is assigned"
+              checked={notifyAssignee}
+              onChange={setNotifyAssignee}
+            />
 
             {createTask.isError && <AuthAlert message={getCreateTaskErrorMessage(createTask.error)} />}
           </div>

--- a/lined-web/src/components/AppShell.tsx
+++ b/lined-web/src/components/AppShell.tsx
@@ -4,7 +4,9 @@ import { TopBar } from './TopBar';
 import { CreateLobbyModal } from './CreateLobbyModal';
 import { CreateEventModal } from './CreateEventModal';
 import { AddTaskDrawer } from './AddTaskDrawer';
+import { ReserveSlotModal } from './ReserveSlotModal';
 import { useCreateMenuStore } from '@/store/createMenu';
+import { useCalendarStore } from '@/store/calendar';
 import { useMyLobbies } from '@/hooks/useLobbies';
 
 export function AppShell() {
@@ -15,7 +17,9 @@ export function AppShell() {
   const closeCreateLobby = useCreateMenuStore((s) => s.closeCreateLobby);
   const overlay = useCreateMenuStore((s) => s.overlay);
   const taskInitialStatus = useCreateMenuStore((s) => s.taskInitialStatus);
+  const reserveSlotInitial = useCreateMenuStore((s) => s.reserveSlotInitial);
   const closeOverlay = useCreateMenuStore((s) => s.closeOverlay);
+  const setSelectedEventId = useCalendarStore((s) => s.setSelectedEventId);
   const { data: lobbies = [] } = useMyLobbies();
 
   return (
@@ -46,6 +50,19 @@ export function AppShell() {
               lockedLobbyId={lockedLobbyId}
               initialStatus={taskInitialStatus ?? undefined}
               onClose={closeOverlay}
+            />
+          )}
+
+          {overlay === 'reserveSlot' && (
+            <ReserveSlotModal
+              lobbies={lobbies}
+              initial={reserveSlotInitial}
+              onClose={closeOverlay}
+              onReserved={(event) => {
+                closeOverlay();
+                setSelectedEventId(event.id);
+                navigate('/calendar');
+              }}
             />
           )}
         </main>

--- a/lined-web/src/components/CalendarTopBar.tsx
+++ b/lined-web/src/components/CalendarTopBar.tsx
@@ -1,5 +1,15 @@
-import { ChevronLeft, ChevronRight, Plus } from 'lucide-react';
+import { ChevronLeft, ChevronRight, ListFilter, Plus } from 'lucide-react';
 import type { ViewMode } from '@/store/calendar';
+import type { LobbyDto } from '@/types';
+import { LOBBY_TYPE_LABELS } from '@/lib/constants';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuGroup,
+} from '@/components/ui/dropdown-menu';
 
 interface CalendarTopBarProps {
   title: string;
@@ -9,6 +19,11 @@ interface CalendarTopBarProps {
   onToday: () => void;
   onViewModeChange: (mode: ViewMode) => void;
   onNewEvent: () => void;
+  /** Opt-in: when there's more than one lobby to filter, shows a "Filters"
+   *  dropdown of lobby-visibility checkboxes (omitted on the single-lobby view). */
+  lobbies?: LobbyDto[];
+  hiddenLobbyIds?: number[];
+  onToggleLobby?: (lobbyId: number) => void;
 }
 
 export function CalendarTopBar({
@@ -19,7 +34,11 @@ export function CalendarTopBar({
   onToday,
   onViewModeChange,
   onNewEvent,
+  lobbies,
+  hiddenLobbyIds = [],
+  onToggleLobby,
 }: CalendarTopBarProps) {
+  const showLobbyFilter = lobbies != null && onToggleLobby != null && lobbies.length > 1;
   return (
     <div className="flex h-16 flex-shrink-0 items-center gap-4 border-b border-border bg-white px-8 shadow-[var(--shadow-sm)]">
       {/* Month / week navigation */}
@@ -69,6 +88,43 @@ export function CalendarTopBar({
       </div>
 
       <div className="flex-1" />
+
+      {/* Lobby filter — hide/show individual lobbies' events, like Google/Outlook's calendar checklists */}
+      {showLobbyFilter && (
+        <DropdownMenu>
+          <DropdownMenuTrigger className="flex h-9 items-center gap-1.5 rounded-lg border border-border bg-white px-3 text-sm text-text-secondary hover:bg-gray-50">
+            <ListFilter className="h-4 w-4" />
+            Filters
+            {hiddenLobbyIds.length > 0 && (
+              <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-brand-green px-1 text-[10px] font-semibold text-white">
+                {hiddenLobbyIds.length}
+              </span>
+            )}
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-56">
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>Show lobbies</DropdownMenuLabel>
+              {lobbies!.map((lobby) => (
+                <DropdownMenuCheckboxItem
+                  key={lobby.id}
+                  checked={!hiddenLobbyIds.includes(lobby.id)}
+                  onCheckedChange={() => onToggleLobby!(lobby.id)}
+                  className="gap-2.5"
+                >
+                  <span
+                    className="h-2.5 w-2.5 flex-shrink-0 rounded-full"
+                    style={{ backgroundColor: `var(--color-lobby-${lobby.lobbyType.toLowerCase()})` }}
+                  />
+                  <span className="truncate">{lobby.name}</span>
+                  <span className="ml-auto flex-shrink-0 text-xs text-text-muted">
+                    {LOBBY_TYPE_LABELS[lobby.lobbyType]}
+                  </span>
+                </DropdownMenuCheckboxItem>
+              ))}
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
 
       {/* + New event */}
       <button

--- a/lined-web/src/components/CreateEventModal.tsx
+++ b/lined-web/src/components/CreateEventModal.tsx
@@ -5,6 +5,7 @@ import type { EventDto, LobbyDto } from '@/types';
 import { useCreateEvent, useUpdateEvent } from '@/hooks/useEvents';
 import { toDatetimeLocal, fromDatetimeLocal } from '@/lib/calendarUtils';
 import { AuthAlert } from '@/components/AuthAlert';
+import { ToggleRow } from '@/components/ToggleRow';
 
 interface CreateEventModalProps {
   lobbies: LobbyDto[];
@@ -286,39 +287,4 @@ function getEventErrorMessage(error: unknown, isEditMode: boolean): string {
   return isEditMode
     ? "Couldn't save changes — please try again"
     : "Couldn't create event — please try again";
-}
-
-// ─── ToggleRow ────────────────────────────────────────────────────────────────
-
-interface ToggleRowProps {
-  label: string;
-  description: string;
-  checked: boolean;
-  onChange: (v: boolean) => void;
-}
-
-function ToggleRow({ label, description, checked, onChange }: ToggleRowProps) {
-  return (
-    <div className="flex items-center justify-between border-b border-border py-3.5">
-      <div>
-        <div className="text-sm font-medium text-text-primary">{label}</div>
-        <div className="mt-0.5 text-xs text-text-secondary">{description}</div>
-      </div>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={checked}
-        onClick={() => onChange(!checked)}
-        className={`relative h-6 w-11 flex-shrink-0 rounded-full transition-colors ${
-          checked ? 'bg-brand-green' : 'bg-border'
-        }`}
-      >
-        <span
-          className={`absolute top-[3px] h-[18px] w-[18px] rounded-full bg-white shadow-sm transition-[left] ${
-            checked ? 'left-[23px]' : 'left-[3px]'
-          }`}
-        />
-      </button>
-    </div>
-  );
 }

--- a/lined-web/src/components/CreateMenu.tsx
+++ b/lined-web/src/components/CreateMenu.tsx
@@ -11,6 +11,7 @@ import { useCreateMenuStore } from '@/store/createMenu';
 export const CreateMenu = () => {
   const openCreateLobby = useCreateMenuStore((s) => s.openCreateLobby);
   const openOverlay = useCreateMenuStore((s) => s.openOverlay);
+  const openReserveSlot = useCreateMenuStore((s) => s.openReserveSlot);
 
   return (
     <DropdownMenu>
@@ -33,7 +34,7 @@ export const CreateMenu = () => {
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem
-          onClick={() => openOverlay('reserveSlot')}
+          onClick={() => openReserveSlot()}
           className="gap-2.5 bg-brand-green-light py-2 text-brand-green-dark focus:bg-brand-green-light/80 focus:text-brand-green-dark"
         >
           <Sparkles className="h-4 w-4" />

--- a/lined-web/src/components/DayAgendaPanel.tsx
+++ b/lined-web/src/components/DayAgendaPanel.tsx
@@ -1,0 +1,85 @@
+import { X } from 'lucide-react';
+import type { EventDto, LobbyDto } from '@/types';
+import { formatClockTime, formatFullDate } from '@/lib/calendarUtils';
+
+interface DayAgendaPanelProps {
+  day: Date;
+  events: EventDto[];
+  lobbies: LobbyDto[];
+  selectedEventId: number | null;
+  onEventClick: (id: number) => void;
+  onClose: () => void;
+}
+
+/**
+ * Right-docked sidebar (matches EventDetailPanel's shell) listing every event
+ * on a given day — the global calendar's overlap/overflow entry point, since
+ * that view doesn't have a single lobby to scope a modal to.
+ */
+export function DayAgendaPanel({
+  day,
+  events,
+  lobbies,
+  selectedEventId,
+  onEventClick,
+  onClose,
+}: DayAgendaPanelProps) {
+  const lobbyMap = new Map(lobbies.map((l) => [l.id, l]));
+  const sorted = [...events].sort((a, b) => a.startAt.localeCompare(b.startAt));
+
+  return (
+    <div className="m-4 ml-0 w-72 flex-shrink-0 self-start overflow-hidden rounded-xl bg-white shadow-[var(--shadow-md)]">
+      <div className="flex items-center justify-between px-5 pt-4 pb-3">
+        <h3 className="text-sm font-bold text-text-primary">{formatFullDate(day)}</h3>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="flex-shrink-0 text-text-muted hover:text-text-secondary"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="max-h-[calc(100vh-220px)] overflow-y-auto px-5 pb-4">
+        {sorted.length === 0 ? (
+          <p className="py-2 text-sm text-text-secondary">No events today.</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {sorted.map((event) => {
+              const lobby = lobbyMap.get(event.lobbyId);
+              const accentColor = lobby
+                ? `var(--color-lobby-${lobby.lobbyType.toLowerCase()})`
+                : 'var(--color-lobby-couple)';
+              return (
+                <li key={event.id}>
+                  <button
+                    type="button"
+                    onClick={() => onEventClick(event.id)}
+                    className={`w-full rounded-lg border px-3.5 py-2.5 text-left transition-colors hover:bg-gray-50 ${
+                      event.id === selectedEventId ? 'border-brand-green' : 'border-border'
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="h-2 w-2 flex-shrink-0 rounded-full"
+                        style={{ backgroundColor: accentColor }}
+                      />
+                      <span className="text-sm font-semibold text-text-primary">
+                        {formatClockTime(new Date(event.startAt))} –{' '}
+                        {formatClockTime(new Date(event.endAt))}
+                      </span>
+                    </div>
+                    <div className="mt-1 text-sm text-text-primary">{event.title}</div>
+                    {lobby && (
+                      <div className="mt-0.5 text-xs text-text-secondary">{lobby.name}</div>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lined-web/src/components/ReserveSlotModal.tsx
+++ b/lined-web/src/components/ReserveSlotModal.tsx
@@ -1,0 +1,344 @@
+import { useState } from 'react';
+import { X, Sparkles, Check } from 'lucide-react';
+import { HTTPError } from 'ky';
+import type { EventDto, LobbyDto } from '@/types';
+import { useCreateEvent } from '@/hooks/useEvents';
+import { useFreeSlotCandidates, type FreeSlotCandidate } from '@/hooks/useDashboard';
+import { useUsers } from '@/hooks/useUsers';
+import { useAuthStore } from '@/store/auth';
+import type { ReserveSlotInitial } from '@/store/createMenu';
+import { toDatetimeLocal, fromDatetimeLocal, formatFreeSlotRange } from '@/lib/calendarUtils';
+import { LOBBY_TYPE_ICONS } from '@/lib/constants';
+import { AuthAlert } from '@/components/AuthAlert';
+import { FormField } from '@/components/FormField';
+import { AssigneeAvatar } from '@/components/AssigneeAvatar';
+import { ToggleRow } from '@/components/ToggleRow';
+
+interface ReserveSlotModalProps {
+  lobbies: LobbyDto[];
+  /** null ⇒ compute candidates across the user's lobbies and let them pick (create-menu entry point). */
+  initial: ReserveSlotInitial | null;
+  onClose: () => void;
+  onReserved?: (event: EventDto) => void;
+}
+
+/** A resolved slot ready to render as a form: a concrete or picked time window, possibly missing a lobby. */
+interface ResolvedSlot {
+  lobbyId: number | null;
+  start: string;
+  end: string;
+}
+
+export function ReserveSlotModal({ lobbies, initial, onClose, onReserved }: ReserveSlotModalProps) {
+  const { candidates, isLoading: candidatesLoading } = useFreeSlotCandidates(lobbies);
+  const [pickedCandidate, setPickedCandidate] = useState<FreeSlotCandidate | null>(null);
+
+  const resolved: ResolvedSlot | null = initial
+    ? { lobbyId: initial.lobbyId ?? null, start: initial.start, end: initial.end }
+    : pickedCandidate
+      ? { lobbyId: pickedCandidate.lobby.id, start: pickedCandidate.start, end: pickedCandidate.end }
+      : null;
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/45"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="w-[520px] max-w-[90vw] overflow-hidden rounded-2xl bg-white shadow-[var(--shadow-lg)]">
+        {/* Header */}
+        <div className="flex items-start justify-between px-6 pt-5">
+          <div>
+            <h2 className="text-lg font-bold text-text-primary">Reserve Free Slot</h2>
+            {resolved && (
+              <span className="mt-1.5 inline-flex items-center gap-1.5 rounded-full bg-brand-green-light px-3 py-1 text-xs font-semibold text-brand-green-dark">
+                <Sparkles className="h-3 w-3" />
+                {formatFreeSlotRange(resolved.start, resolved.end)} · Both free
+              </span>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-text-muted hover:text-text-secondary"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="px-6 py-5">
+          {resolved ? (
+            <ReserveSlotForm
+              key={`${resolved.lobbyId}-${resolved.start}`}
+              lobbies={lobbies}
+              slot={resolved}
+              onClose={onClose}
+              onReserved={onReserved}
+            />
+          ) : (
+            <CandidatePicker
+              candidates={candidates}
+              isLoading={candidatesLoading}
+              onPick={setPickedCandidate}
+              onClose={onClose}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── ReserveSlotForm ───────────────────────────────────────────────────────────
+
+interface ReserveSlotFormProps {
+  lobbies: LobbyDto[];
+  slot: ResolvedSlot;
+  onClose: () => void;
+  onReserved?: (event: EventDto) => void;
+}
+
+function getReserveErrorMessage(error: unknown): string {
+  if (error instanceof HTTPError && error.response.status === 400) {
+    return 'Enter a valid title and time range';
+  }
+  return "Couldn't reserve this slot — please try again";
+}
+
+function ReserveSlotForm({ lobbies, slot, onClose, onReserved }: ReserveSlotFormProps) {
+  const createEvent = useCreateEvent();
+  const currentUserId = useAuthStore((s) => s.userId);
+  const sharableLobbies = lobbies.filter((l) => l.memberIds.length > 1);
+  const showLobbyPicker = slot.lobbyId == null;
+
+  const [selectedLobbyId, setSelectedLobbyId] = useState<number | undefined>(
+    slot.lobbyId ?? sharableLobbies[0]?.id,
+  );
+  const [title, setTitle] = useState('');
+  const [startAt, setStartAt] = useState(() => toDatetimeLocal(new Date(slot.start)));
+  const [endAt, setEndAt] = useState(() => toDatetimeLocal(new Date(slot.end)));
+  const [location, setLocation] = useState('');
+  const [notifyMembers, setNotifyMembers] = useState(true);
+
+  const lobby = lobbies.find((l) => l.id === selectedLobbyId) ?? null;
+  const memberQueries = useUsers(lobby?.memberIds ?? []);
+  const members = memberQueries.map((q) => q.data).filter((u): u is NonNullable<typeof u> => !!u);
+  const membersLoading = memberQueries.some((q) => q.isLoading);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim() || !lobby || !startAt || !endAt) return;
+
+    const trimmedLocation = location.trim();
+    createEvent.mutate(
+      {
+        title: title.trim(),
+        lobbyId: lobby.id,
+        shared: true,
+        startAt: fromDatetimeLocal(startAt).toISOString(),
+        endAt: fromDatetimeLocal(endAt).toISOString(),
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        notifyMembers,
+        ...(trimmedLocation ? { location: trimmedLocation } : {}),
+      },
+      { onSuccess: (event) => onReserved?.(event) },
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="space-y-5">
+        {showLobbyPicker ? (
+          <div>
+            <label
+              htmlFor="reserve-slot-lobby"
+              className="mb-1.5 block text-xs font-medium text-text-secondary"
+            >
+              Lobby
+            </label>
+            <select
+              id="reserve-slot-lobby"
+              required
+              value={selectedLobbyId ?? ''}
+              onChange={(e) => setSelectedLobbyId(Number(e.target.value))}
+              className="h-12 w-full rounded-lg border border-border bg-input-bg px-4 text-sm text-text-primary focus:border-brand-green focus:outline-none"
+            >
+              {sharableLobbies.map((l) => (
+                <option key={l.id} value={l.id}>
+                  {l.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : lobby ? (
+          <div className="flex items-center gap-2.5 rounded-lg bg-brand-green-light p-3">
+            <span className="text-xl">{LOBBY_TYPE_ICONS[lobby.lobbyType]}</span>
+            <div>
+              <div className="text-sm font-semibold text-brand-green-dark">
+                {lobby.name} are both free
+              </div>
+              <div className="mt-0.5 text-xs text-brand-green-dark">
+                {formatFreeSlotRange(slot.start, slot.end)}
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        <FormField
+          id="reserve-slot-title"
+          label="What would you like to do?"
+          value={title}
+          onChange={setTitle}
+          placeholder="e.g. Walk in the park, Cook together…"
+          required
+        />
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-text-secondary">Start time</label>
+            <input
+              type="datetime-local"
+              required
+              value={startAt}
+              onChange={(e) => setStartAt(e.target.value)}
+              className="h-12 w-full rounded-lg border border-border bg-input-bg px-4 text-sm text-text-primary focus:border-brand-green focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-text-secondary">End time</label>
+            <input
+              type="datetime-local"
+              required
+              value={endAt}
+              onChange={(e) => setEndAt(e.target.value)}
+              className="h-12 w-full rounded-lg border border-border bg-input-bg px-4 text-sm text-text-primary focus:border-brand-green focus:outline-none"
+            />
+          </div>
+        </div>
+
+        <FormField
+          id="reserve-slot-location"
+          label="Location (optional)"
+          value={location}
+          onChange={setLocation}
+          placeholder="Where will you meet?"
+        />
+
+        {lobby && (
+          <div>
+            <span className="mb-1.5 block text-xs font-medium text-text-secondary">Invite</span>
+            {membersLoading ? (
+              <div className="h-12 w-full animate-pulse rounded-lg bg-gray-100" />
+            ) : (
+              <div className="flex flex-wrap items-center gap-2.5 rounded-lg border border-border bg-input-bg px-3 py-2.5">
+                {members.map((member) => (
+                  <div key={member.id} className="flex items-center gap-1.5">
+                    <AssigneeAvatar assignee={member} size="sm" />
+                    <span className="text-sm text-text-primary">{member.username}</span>
+                    {member.id === currentUserId && (
+                      <span className="text-xs text-text-secondary">(you)</span>
+                    )}
+                  </div>
+                ))}
+                <Check
+                  className="ml-auto h-4 w-4 flex-shrink-0 text-brand-green"
+                  aria-label="Everyone auto-included"
+                />
+              </div>
+            )}
+          </div>
+        )}
+
+        <ToggleRow
+          label="Notify lobby members"
+          description="They'll get a notification about this plan"
+          checked={notifyMembers}
+          onChange={setNotifyMembers}
+        />
+
+        {createEvent.isError && <AuthAlert message={getReserveErrorMessage(createEvent.error)} />}
+      </div>
+
+      <div className="mt-5 flex items-center justify-end gap-2.5">
+        <button
+          type="button"
+          onClick={onClose}
+          className="h-10 rounded-lg border border-border bg-white px-4 text-sm text-text-secondary hover:bg-gray-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={createEvent.isPending || !lobby}
+          className="h-10 rounded-lg bg-brand-green px-6 text-sm font-semibold text-white hover:bg-brand-green-dark disabled:opacity-60 transition-colors"
+        >
+          {createEvent.isPending ? 'Reserving…' : 'Reserve Slot ✨'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ─── CandidatePicker ───────────────────────────────────────────────────────────
+
+interface CandidatePickerProps {
+  candidates: FreeSlotCandidate[];
+  isLoading: boolean;
+  onPick: (candidate: FreeSlotCandidate) => void;
+  onClose: () => void;
+}
+
+function CandidatePicker({ candidates, isLoading, onPick, onClose }: CandidatePickerProps) {
+  if (isLoading) {
+    return (
+      <div className="space-y-2" data-testid="candidate-picker-loading">
+        {[0, 1].map((i) => (
+          <div key={i} className="h-14 animate-pulse rounded-lg bg-gray-100" />
+        ))}
+      </div>
+    );
+  }
+
+  if (candidates.length === 0) {
+    return (
+      <div className="text-center">
+        <p className="py-4 text-sm text-text-secondary">
+          No shared free time found in the next 7 days.
+        </p>
+        <button
+          type="button"
+          onClick={onClose}
+          className="h-10 w-full rounded-lg border border-border bg-white text-sm text-text-secondary hover:bg-gray-50"
+        >
+          Close
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p className="mb-3 text-xs font-medium text-text-secondary">Choose a time</p>
+      <ul className="flex flex-col gap-2">
+        {candidates.map((candidate) => (
+          <li key={candidate.lobby.id}>
+            <button
+              type="button"
+              onClick={() => onPick(candidate)}
+              className="flex w-full items-center gap-2.5 rounded-lg border border-border px-4 py-3 text-left hover:border-brand-green hover:bg-brand-green-light/40"
+            >
+              <span className="text-lg">{LOBBY_TYPE_ICONS[candidate.lobby.lobbyType]}</span>
+              <div>
+                <div className="text-sm font-semibold text-text-primary">{candidate.lobby.name}</div>
+                <div className="text-xs text-text-secondary">
+                  {formatFreeSlotRange(candidate.start, candidate.end)}
+                </div>
+              </div>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/lined-web/src/components/ToggleRow.tsx
+++ b/lined-web/src/components/ToggleRow.tsx
@@ -1,0 +1,33 @@
+interface ToggleRowProps {
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+/** Labelled on/off switch row, shared by CreateEventModal, AddTaskDrawer, ReserveSlotModal. */
+export function ToggleRow({ label, description, checked, onChange }: ToggleRowProps) {
+  return (
+    <div className="flex items-center justify-between border-b border-border py-3.5">
+      <div>
+        <div className="text-sm font-medium text-text-primary">{label}</div>
+        <div className="mt-0.5 text-xs text-text-secondary">{description}</div>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={`relative h-6 w-11 flex-shrink-0 rounded-full transition-colors ${
+          checked ? 'bg-brand-green' : 'bg-border'
+        }`}
+      >
+        <span
+          className={`absolute top-[3px] h-[18px] w-[18px] rounded-full bg-white shadow-sm transition-[left] ${
+            checked ? 'left-[23px]' : 'left-[3px]'
+          }`}
+        />
+      </button>
+    </div>
+  );
+}

--- a/lined-web/src/components/WeekGrid.tsx
+++ b/lined-web/src/components/WeekGrid.tsx
@@ -168,10 +168,16 @@ function DayColumn({
     <div
       className={`relative flex-1 border-l border-border ${today ? 'bg-brand-green-light/25' : ''}`}
     >
-      {/* Hour grid lines */}
-      {GRID_HOURS.map((h) => (
-        <div key={h} className="h-20 border-b border-border" />
-      ))}
+      {/* Hour grid lines — a single tiled background instead of GRID_HOURS.length
+          separately-bordered divs, so every line renders identically regardless
+          of scroll position or fractional column widths. */}
+      <div
+        className="pointer-events-none"
+        style={{
+          height: GRID_HOURS.length * HOUR_HEIGHT,
+          backgroundImage: `repeating-linear-gradient(to bottom, transparent 0, transparent ${HOUR_HEIGHT - 1}px, var(--color-border) ${HOUR_HEIGHT - 1}px, var(--color-border) ${HOUR_HEIGHT}px)`,
+        }}
+      />
 
       {/* Free slot bands (behind events) */}
       {freeSlots.map((slot, i) => (
@@ -306,8 +312,12 @@ export function WeekGrid({
 
       {/* Scrollable time grid */}
       <div ref={gridRef} className="flex flex-1 overflow-y-auto bg-white">
-        {/* Hour labels */}
-        <div className="w-14 flex-shrink-0">
+        {/* Hour labels. self-start: without it, the flex row's default
+            align-items:stretch sizes this box to the scroll container's
+            *viewport* height rather than its own (taller) content, which
+            would anchor the absolutely-positioned "12 AM" label below to
+            the wrong, visually-clipped spot. */}
+        <div className="relative w-14 flex-shrink-0 self-start">
           {GRID_HOURS.map((h) => (
             <div
               key={h}
@@ -316,6 +326,9 @@ export function WeekGrid({
               {formatHour(h)}
             </div>
           ))}
+          {/* Closing boundary label for the last row — absolutely positioned so
+              it doesn't add flow height (would desync from the day columns). */}
+          <div className="absolute bottom-0 right-2 text-[11px] text-text-muted">12 AM</div>
         </div>
 
         {/* Day columns */}

--- a/lined-web/src/components/WeekGrid.tsx
+++ b/lined-web/src/components/WeekGrid.tsx
@@ -3,7 +3,9 @@ import type { EventDto, LobbyDto } from '@/types';
 import {
   addDays,
   assignEventLanes,
+  clipEventToDay,
   computeFreeSlots,
+  eventTouchesDay,
   formatDayLabel,
   formatHour,
   getEventHeight,
@@ -12,7 +14,6 @@ import {
   GRID_HOURS,
   GRID_START_HOUR,
   HOUR_HEIGHT,
-  isSameDay,
   isToday,
   type EventLane,
   type FreeSlot,
@@ -57,6 +58,10 @@ function NowLine() {
 
 interface CalendarEventProps {
   event: EventDto;
+  /** This day's slice of the event's start/end — differs from event.startAt/endAt
+   *  when the event spans midnight, so it renders as two clipped segments. */
+  displayStartAt: string;
+  displayEndAt: string;
   lobby?: LobbyDto;
   isSelected: boolean;
   onClick: () => void;
@@ -64,9 +69,18 @@ interface CalendarEventProps {
   laneCount?: number;
 }
 
-function CalendarEvent({ event, lobby, isSelected, onClick, lane, laneCount }: CalendarEventProps) {
-  const top = getEventTop(event.startAt);
-  const height = Math.max(getEventHeight(event.startAt, event.endAt), 24);
+function CalendarEvent({
+  event,
+  displayStartAt,
+  displayEndAt,
+  lobby,
+  isSelected,
+  onClick,
+  lane,
+  laneCount,
+}: CalendarEventProps) {
+  const top = getEventTop(displayStartAt);
+  const height = Math.max(getEventHeight(displayStartAt, displayEndAt), 24);
   const lobbyType = lobby?.lobbyType.toLowerCase() ?? 'couple';
 
   const horizontal: React.CSSProperties =
@@ -140,6 +154,7 @@ function FreeSlotBand({ startHour, endHour, onClick }: FreeSlotBandProps) {
 // ─── DayColumn ────────────────────────────────────────────────────────────────
 
 interface DayColumnProps {
+  day: Date;
   events: EventDto[];
   lobbyMap: Map<number, LobbyDto>;
   today: boolean;
@@ -153,6 +168,7 @@ interface DayColumnProps {
 }
 
 function DayColumn({
+  day,
   events,
   lobbyMap,
   today,
@@ -192,10 +208,13 @@ function DayColumn({
       {/* Events */}
       {events.map((event) => {
         const laneInfo = lanes?.get(event.id);
+        const { startAt: displayStartAt, endAt: displayEndAt } = clipEventToDay(event, day);
         return (
           <CalendarEvent
             key={event.id}
             event={event}
+            displayStartAt={displayStartAt}
+            displayEndAt={displayEndAt}
             lobby={lobbyMap.get(event.lobbyId)}
             isSelected={event.id === selectedEventId}
             onClick={() => onEventClick(event.id)}
@@ -281,7 +300,7 @@ export function WeekGrid({
       <div className="flex flex-shrink-0 border-b border-border bg-white" style={{ paddingLeft: 56 }}>
         {weekDays.map((day) => {
           const today = isToday(day);
-          const dayEvents = events.filter((e) => isSameDay(new Date(e.startAt), day));
+          const dayEvents = events.filter((e) => eventTouchesDay(e, day));
           return (
             <div
               key={day.toISOString()}
@@ -334,15 +353,14 @@ export function WeekGrid({
         {/* Day columns */}
         <div className="flex flex-1 min-w-0">
           {weekDays.map((day) => {
-            const dayEvents = events.filter((e) =>
-              isSameDay(new Date(e.startAt), day),
-            );
+            const dayEvents = events.filter((e) => eventTouchesDay(e, day));
             const freeSlots = getFreeSlotsForDay(day, dayEvents);
 
             if (!onDayClick) {
               return (
                 <DayColumn
                   key={day.toISOString()}
+                  day={day}
                   events={dayEvents}
                   lobbyMap={lobbyMap}
                   today={isToday(day)}
@@ -364,6 +382,7 @@ export function WeekGrid({
             return (
               <DayColumn
                 key={day.toISOString()}
+                day={day}
                 events={visible}
                 lobbyMap={lobbyMap}
                 today={isToday(day)}

--- a/lined-web/src/components/WeekGrid.tsx
+++ b/lined-web/src/components/WeekGrid.tsx
@@ -266,8 +266,8 @@ interface WeekGridProps {
   onFreeSlotClick?: (day: Date, slot: FreeSlot) => void;
 }
 
-const defaultGetFreeSlotsForDay = (_day: Date, dayEvents: EventDto[]): FreeSlot[] =>
-  dayEvents.length > 0 ? computeFreeSlots(dayEvents) : [];
+const defaultGetFreeSlotsForDay = (day: Date, dayEvents: EventDto[]): FreeSlot[] =>
+  dayEvents.length > 0 ? computeFreeSlots(dayEvents, day) : [];
 
 export function WeekGrid({
   weekStart,

--- a/lined-web/src/components/WeekGrid.tsx
+++ b/lined-web/src/components/WeekGrid.tsx
@@ -106,11 +106,26 @@ function CalendarEvent({ event, lobby, isSelected, onClick, lane, laneCount }: C
 interface FreeSlotBandProps {
   startHour: number;
   endHour: number;
+  onClick?: () => void;
 }
 
-function FreeSlotBand({ startHour, endHour }: FreeSlotBandProps) {
+function FreeSlotBand({ startHour, endHour, onClick }: FreeSlotBandProps) {
   const top = (startHour - GRID_START_HOUR) * HOUR_HEIGHT;
   const height = (endHour - startHour) * HOUR_HEIGHT;
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label="Reserve this free slot"
+        className="absolute left-[2px] right-[2px] flex cursor-pointer items-center justify-center rounded-[6px] text-[10px] font-semibold text-brand-green-dark hover:opacity-80"
+        style={{ top, height, backgroundColor: '#B4EBD0', opacity: 0.6 }}
+      >
+        {height >= 40 && 'Free slot'}
+      </button>
+    );
+  }
 
   return (
     <div
@@ -131,6 +146,7 @@ interface DayColumnProps {
   selectedEventId: number | null;
   onEventClick: (id: number) => void;
   freeSlots: FreeSlot[];
+  onFreeSlotClick?: (slot: FreeSlot) => void;
   lanes?: Map<number, EventLane>;
   overflowCount?: number;
   onShowMore?: () => void;
@@ -143,6 +159,7 @@ function DayColumn({
   selectedEventId,
   onEventClick,
   freeSlots,
+  onFreeSlotClick,
   lanes,
   overflowCount = 0,
   onShowMore,
@@ -158,7 +175,12 @@ function DayColumn({
 
       {/* Free slot bands (behind events) */}
       {freeSlots.map((slot, i) => (
-        <FreeSlotBand key={i} startHour={slot.startHour} endHour={slot.endHour} />
+        <FreeSlotBand
+          key={i}
+          startHour={slot.startHour}
+          endHour={slot.endHour}
+          onClick={onFreeSlotClick ? () => onFreeSlotClick(slot) : undefined}
+        />
       ))}
 
       {/* Events */}
@@ -215,6 +237,8 @@ interface WeekGridProps {
   onDayClick?: (day: Date, dayEvents: EventDto[]) => void;
   /** Only used when `onDayClick` is provided. Defaults to 4. */
   maxVisibleEvents?: number;
+  /** Opt-in: makes green free-slot bands clickable, e.g. to open ReserveSlotModal. */
+  onFreeSlotClick?: (day: Date, slot: FreeSlot) => void;
 }
 
 const defaultGetFreeSlotsForDay = (_day: Date, dayEvents: EventDto[]): FreeSlot[] =>
@@ -230,6 +254,7 @@ export function WeekGrid({
   legendItems = DEFAULT_LEGEND_ITEMS,
   onDayClick,
   maxVisibleEvents = 4,
+  onFreeSlotClick,
 }: WeekGridProps) {
   const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
   const lobbyMap = new Map(lobbies.map((l) => [l.id, l]));
@@ -311,6 +336,9 @@ export function WeekGrid({
                   selectedEventId={selectedEventId}
                   onEventClick={onEventClick}
                   freeSlots={freeSlots}
+                  onFreeSlotClick={
+                    onFreeSlotClick ? (slot) => onFreeSlotClick(day, slot) : undefined
+                  }
                 />
               );
             }
@@ -329,6 +357,9 @@ export function WeekGrid({
                 selectedEventId={selectedEventId}
                 onEventClick={onEventClick}
                 freeSlots={freeSlots}
+                onFreeSlotClick={
+                  onFreeSlotClick ? (slot) => onFreeSlotClick(day, slot) : undefined
+                }
                 lanes={lanes}
                 overflowCount={overflowCount}
                 onShowMore={() => onDayClick(day, dayEvents)}

--- a/lined-web/src/components/__tests__/AppShell.test.tsx
+++ b/lined-web/src/components/__tests__/AppShell.test.tsx
@@ -9,7 +9,7 @@ import { CREATE_MENU_TEXT } from '@/test/createMenuContent';
 describe('AppShell', () => {
   beforeEach(() => {
     useAuthStore.setState({ userId: 1, token: 'token' });
-    useCreateMenuStore.setState({ isCreateLobbyOpen: false, overlay: null });
+    useCreateMenuStore.setState({ isCreateLobbyOpen: false, overlay: null, reserveSlotInitial: null });
   });
 
   function renderShell(initialEntries: string[] = ['/']) {
@@ -70,5 +70,24 @@ describe('AppShell', () => {
 
     expect(await screen.findByRole('heading', { name: 'Add Task' })).toBeInTheDocument();
     expect(screen.queryByLabelText('Lobby')).not.toBeInTheDocument();
+  });
+
+  it('renders the reserve-slot modal when the overlay is "reserveSlot"', async () => {
+    expect.assertions(1);
+    useCreateMenuStore.setState({ overlay: 'reserveSlot', reserveSlotInitial: null });
+    renderShell();
+
+    expect(await screen.findByRole('heading', { name: 'Reserve Free Slot' })).toBeInTheDocument();
+  });
+
+  it('pre-fills the reserve-slot modal from reserveSlotInitial', async () => {
+    expect.assertions(1);
+    useCreateMenuStore.setState({
+      overlay: 'reserveSlot',
+      reserveSlotInitial: { lobbyId: 1, start: '2026-03-29T14:00:00Z', end: '2026-03-29T17:00:00Z' },
+    });
+    renderShell();
+
+    expect(await screen.findByLabelText('What would you like to do?')).toBeInTheDocument();
   });
 });

--- a/lined-web/src/components/__tests__/CalendarTopBar.test.tsx
+++ b/lined-web/src/components/__tests__/CalendarTopBar.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { LobbyDto } from '@/types';
+import { CalendarTopBar } from '../CalendarTopBar';
+
+const LOBBIES: LobbyDto[] = [
+  { id: 1, name: 'Alex & Anastasiia', lobbyType: 'COUPLE', ownerId: 1, memberIds: [1, 2] },
+  { id: 2, name: 'Weekend Crew', lobbyType: 'FRIENDS', ownerId: 1, memberIds: [1, 2] },
+];
+
+function baseProps() {
+  return {
+    title: 'July 2026',
+    viewMode: 'week' as const,
+    onPrev: vi.fn(),
+    onNext: vi.fn(),
+    onToday: vi.fn(),
+    onViewModeChange: vi.fn(),
+    onNewEvent: vi.fn(),
+  };
+}
+
+describe('CalendarTopBar — lobby filter', () => {
+  it('does not show a Filters button when no lobbies are supplied', () => {
+    expect.assertions(1);
+    render(<CalendarTopBar {...baseProps()} />);
+
+    expect(screen.queryByRole('button', { name: /filters/i })).not.toBeInTheDocument();
+  });
+
+  it('does not show a Filters button for a single lobby (nothing to filter)', () => {
+    expect.assertions(1);
+    render(
+      <CalendarTopBar
+        {...baseProps()}
+        lobbies={[LOBBIES[0]!]}
+        hiddenLobbyIds={[]}
+        onToggleLobby={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /filters/i })).not.toBeInTheDocument();
+  });
+
+  it('shows a Filters button listing every lobby when there is more than one', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    render(
+      <CalendarTopBar {...baseProps()} lobbies={LOBBIES} hiddenLobbyIds={[]} onToggleLobby={vi.fn()} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /filters/i }));
+
+    expect(await screen.findByText('Alex & Anastasiia')).toBeInTheDocument();
+    expect(screen.getByText('Weekend Crew')).toBeInTheDocument();
+  });
+
+  it('checks lobbies that are not hidden and unchecks hidden ones', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    render(
+      <CalendarTopBar
+        {...baseProps()}
+        lobbies={LOBBIES}
+        hiddenLobbyIds={[2]}
+        onToggleLobby={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /filters/i }));
+
+    expect(await screen.findByRole('menuitemcheckbox', { name: /Alex & Anastasiia/ })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+    expect(screen.getByRole('menuitemcheckbox', { name: /Weekend Crew/ })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+  });
+
+  it('calls onToggleLobby with the clicked lobby id', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onToggleLobby = vi.fn();
+    render(
+      <CalendarTopBar
+        {...baseProps()}
+        lobbies={LOBBIES}
+        hiddenLobbyIds={[]}
+        onToggleLobby={onToggleLobby}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /filters/i }));
+    await user.click(await screen.findByRole('menuitemcheckbox', { name: /Weekend Crew/ }));
+
+    expect(onToggleLobby).toHaveBeenCalledWith(2);
+  });
+
+  it('shows a badge with the count of hidden lobbies', () => {
+    expect.assertions(1);
+    render(
+      <CalendarTopBar
+        {...baseProps()}
+        lobbies={LOBBIES}
+        hiddenLobbyIds={[2]}
+        onToggleLobby={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /filters/i })).toHaveTextContent('1');
+  });
+});

--- a/lined-web/src/components/__tests__/DayAgendaPanel.test.tsx
+++ b/lined-web/src/components/__tests__/DayAgendaPanel.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { EventDto, LobbyDto } from '@/types';
+import { DayAgendaPanel } from '../DayAgendaPanel';
+
+const LOBBY: LobbyDto = {
+  id: 1,
+  name: 'Alex & Anastasiia',
+  lobbyType: 'COUPLE',
+  ownerId: 1,
+  memberIds: [1, 2],
+};
+
+const OTHER_LOBBY: LobbyDto = {
+  id: 2,
+  name: 'Weekend Crew',
+  lobbyType: 'FRIENDS',
+  ownerId: 1,
+  memberIds: [1, 2],
+};
+
+const DAY = new Date('2026-03-28T00:00:00');
+
+const makeEvent = (id: number, startHour: number, lobbyId = LOBBY.id): EventDto => ({
+  id,
+  title: `Event ${id}`,
+  location: null,
+  shared: true,
+  startAt: `2026-03-28T${String(startHour).padStart(2, '0')}:00:00`,
+  endAt: `2026-03-28T${String(startHour + 1).padStart(2, '0')}:00:00`,
+  timezone: 'UTC',
+  lobbyId,
+  ownerId: 1,
+  createdAt: '2026-01-01T00:00:00Z',
+});
+
+describe('DayAgendaPanel', () => {
+  it('shows an empty state when there are no events', () => {
+    expect.assertions(1);
+    render(
+      <DayAgendaPanel
+        day={DAY}
+        events={[]}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('No events today.')).toBeInTheDocument();
+  });
+
+  it('renders events sorted chronologically with time, title, and lobby name', () => {
+    expect.assertions(2);
+    const later = makeEvent(1, 16);
+    const earlier = makeEvent(2, 9);
+    render(
+      <DayAgendaPanel
+        day={DAY}
+        events={[later, earlier]}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const titles = screen.getAllByText(/Event \d/).map((el) => el.textContent);
+    expect(titles).toEqual(['Event 2', 'Event 1']);
+    expect(screen.getAllByText('Alex & Anastasiia').length).toBe(2);
+  });
+
+  it('labels each event with its own lobby when events span multiple lobbies', () => {
+    expect.assertions(2);
+    render(
+      <DayAgendaPanel
+        day={DAY}
+        events={[makeEvent(1, 9, LOBBY.id), makeEvent(2, 11, OTHER_LOBBY.id)]}
+        lobbies={[LOBBY, OTHER_LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Alex & Anastasiia')).toBeInTheDocument();
+    expect(screen.getByText('Weekend Crew')).toBeInTheDocument();
+  });
+
+  it('calls onEventClick with the clicked event id', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onEventClick = vi.fn();
+    render(
+      <DayAgendaPanel
+        day={DAY}
+        events={[makeEvent(1, 9)]}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={onEventClick}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByText('Event 1'));
+
+    expect(onEventClick).toHaveBeenCalledWith(1);
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <DayAgendaPanel
+        day={DAY}
+        events={[]}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lined-web/src/components/__tests__/ReserveSlotModal.test.tsx
+++ b/lined-web/src/components/__tests__/ReserveSlotModal.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders, screen, userEvent, waitFor } from '@/test/utils';
+import { server } from '@/test/server';
+import { MOCK_LOBBIES, MOCK_FREE_SLOT } from '@/test/data';
+import { useAuthStore } from '@/store/auth';
+import { ReserveSlotModal } from '../ReserveSlotModal';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+const LOBBY = MOCK_LOBBIES[0]!; // id 1, members [1, 2]
+const OTHER_LOBBY = MOCK_LOBBIES[1]!; // id 2, members [1, 2]
+
+beforeEach(() => {
+  useAuthStore.setState({ userId: 1, token: 'token' });
+});
+
+describe('ReserveSlotModal — mode A (full slot, lobby known)', () => {
+  it('pre-fills the title-less form from the given slot and shows the lobby, read-only', async () => {
+    expect.assertions(3);
+    renderWithProviders(
+      <ReserveSlotModal
+        lobbies={MOCK_LOBBIES}
+        initial={{ lobbyId: LOBBY.id, start: MOCK_FREE_SLOT.start, end: MOCK_FREE_SLOT.end }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText(`${LOBBY.name} are both free`)).toBeInTheDocument();
+    expect(screen.queryByLabelText('Lobby')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('What would you like to do?')).toHaveValue('');
+  });
+
+  it('lists lobby members in the attendee row, tagging the current user', async () => {
+    expect.assertions(2);
+    renderWithProviders(
+      <ReserveSlotModal
+        lobbies={MOCK_LOBBIES}
+        initial={{ lobbyId: LOBBY.id, start: MOCK_FREE_SLOT.start, end: MOCK_FREE_SLOT.end }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText('alex_johnson')).toBeInTheDocument();
+    expect(screen.getByText('(you)')).toBeInTheDocument();
+  });
+
+  it('does not submit when the title is blank', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onReserved = vi.fn();
+    renderWithProviders(
+      <ReserveSlotModal
+        lobbies={MOCK_LOBBIES}
+        initial={{ lobbyId: LOBBY.id, start: MOCK_FREE_SLOT.start, end: MOCK_FREE_SLOT.end }}
+        onClose={vi.fn()}
+        onReserved={onReserved}
+      />,
+    );
+
+    await user.click(await screen.findByRole('button', { name: /reserve slot/i }));
+
+    expect(onReserved).not.toHaveBeenCalled();
+  });
+
+  it('submits a shared event with the lobby, title, and pre-filled times, calling onReserved', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onReserved = vi.fn();
+    renderWithProviders(
+      <ReserveSlotModal
+        lobbies={MOCK_LOBBIES}
+        initial={{ lobbyId: LOBBY.id, start: MOCK_FREE_SLOT.start, end: MOCK_FREE_SLOT.end }}
+        onClose={vi.fn()}
+        onReserved={onReserved}
+      />,
+    );
+
+    await user.type(
+      await screen.findByLabelText('What would you like to do?'),
+      'Walk in the park',
+    );
+    await user.click(screen.getByRole('button', { name: /reserve slot/i }));
+
+    await waitFor(() => expect(onReserved).toHaveBeenCalledTimes(1));
+  });
+
+  it('shows an inline error when the API rejects the request', async () => {
+    expect.assertions(1);
+    server.use(
+      http.post(`${BASE}/calendar/events`, () =>
+        HttpResponse.json({ code: 'VALIDATION_ERROR', message: 'title must not be blank' }, { status: 400 }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ReserveSlotModal
+        lobbies={MOCK_LOBBIES}
+        initial={{ lobbyId: LOBBY.id, start: MOCK_FREE_SLOT.start, end: MOCK_FREE_SLOT.end }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await user.type(await screen.findByLabelText('What would you like to do?'), 'Movie night');
+    await user.click(screen.getByRole('button', { name: /reserve slot/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/valid title and time range/i);
+  });
+});
+
+describe('ReserveSlotModal — mode B (time only, no lobby)', () => {
+  it('shows an editable lobby select pre-filled with the clicked time', async () => {
+    expect.assertions(2);
+    renderWithProviders(
+      <ReserveSlotModal
+        lobbies={MOCK_LOBBIES}
+        initial={{ start: MOCK_FREE_SLOT.start, end: MOCK_FREE_SLOT.end }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const select = await screen.findByLabelText('Lobby');
+    expect(select).toBeInTheDocument();
+    expect(select).toBeEnabled();
+  });
+
+  it('submits with the lobby chosen from the select', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onReserved = vi.fn();
+    renderWithProviders(
+      <ReserveSlotModal
+        lobbies={MOCK_LOBBIES}
+        initial={{ start: MOCK_FREE_SLOT.start, end: MOCK_FREE_SLOT.end }}
+        onClose={vi.fn()}
+        onReserved={onReserved}
+      />,
+    );
+
+    await user.selectOptions(await screen.findByLabelText('Lobby'), String(OTHER_LOBBY.id));
+    await user.type(screen.getByLabelText('What would you like to do?'), 'Family game night');
+    await user.click(screen.getByRole('button', { name: /reserve slot/i }));
+
+    await waitFor(() => expect(onReserved).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe('ReserveSlotModal — mode C (no slot, candidate picker)', () => {
+  it('shows an empty state when no lobby has a qualifying free slot', async () => {
+    expect.assertions(1);
+    server.use(http.get(`${BASE}/lobbies/:id/free-slots`, () => HttpResponse.json([])));
+    renderWithProviders(<ReserveSlotModal lobbies={MOCK_LOBBIES} initial={null} onClose={vi.fn()} />);
+
+    expect(
+      await screen.findByText(/no shared free time found in the next 7 days/i),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onClose from the empty state', async () => {
+    expect.assertions(1);
+    server.use(http.get(`${BASE}/lobbies/:id/free-slots`, () => HttpResponse.json([])));
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderWithProviders(<ReserveSlotModal lobbies={MOCK_LOBBIES} initial={null} onClose={onClose} />);
+
+    await user.click(await screen.findByRole('button', { name: 'Close' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('lists one candidate per multi-member lobby that has a qualifying slot', async () => {
+    expect.assertions(3);
+    renderWithProviders(<ReserveSlotModal lobbies={MOCK_LOBBIES} initial={null} onClose={vi.fn()} />);
+
+    expect(await screen.findByText('Choose a time')).toBeInTheDocument();
+    expect(screen.getByText(LOBBY.name)).toBeInTheDocument();
+    expect(screen.getByText(OTHER_LOBBY.name)).toBeInTheDocument();
+  });
+
+  it('picking a candidate opens the pre-filled form for that lobby', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderWithProviders(<ReserveSlotModal lobbies={MOCK_LOBBIES} initial={null} onClose={vi.fn()} />);
+
+    await screen.findByText('Choose a time');
+    await user.click(screen.getByText(LOBBY.name));
+
+    expect(await screen.findByText(`${LOBBY.name} are both free`)).toBeInTheDocument();
+  });
+});

--- a/lined-web/src/components/__tests__/ToggleRow.test.tsx
+++ b/lined-web/src/components/__tests__/ToggleRow.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ToggleRow } from '../ToggleRow';
+
+describe('ToggleRow', () => {
+  it('renders the label and description', () => {
+    expect.assertions(2);
+    render(
+      <ToggleRow label="Notify assignee" description="Send a notification" checked={false} onChange={vi.fn()} />,
+    );
+
+    expect(screen.getByText('Notify assignee')).toBeInTheDocument();
+    expect(screen.getByText('Send a notification')).toBeInTheDocument();
+  });
+
+  it('reflects checked=true via aria-checked', () => {
+    expect.assertions(1);
+    render(<ToggleRow label="Shared" description="Visible to all" checked={true} onChange={vi.fn()} />);
+
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('reflects checked=false via aria-checked', () => {
+    expect.assertions(1);
+    render(<ToggleRow label="Shared" description="Visible to all" checked={false} onChange={vi.fn()} />);
+
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('calls onChange with the flipped value when clicked', async () => {
+    expect.assertions(1);
+    const onChange = vi.fn();
+    render(<ToggleRow label="Shared" description="Visible to all" checked={false} onChange={onChange} />);
+
+    await userEvent.click(screen.getByRole('switch'));
+
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/lined-web/src/components/__tests__/WeekGrid.test.tsx
+++ b/lined-web/src/components/__tests__/WeekGrid.test.tsx
@@ -116,6 +116,47 @@ describe('WeekGrid — getFreeSlotsForDay override', () => {
   });
 });
 
+describe('WeekGrid — onFreeSlotClick opt-in', () => {
+  it('renders free-slot bands as non-interactive divs when the prop is omitted', () => {
+    expect.assertions(1);
+    render(
+      <WeekGrid
+        weekStart={WEEK_START}
+        events={[]}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        getFreeSlotsForDay={() => [{ startHour: 9, endHour: 10 }]}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /reserve this free slot/i })).not.toBeInTheDocument();
+  });
+
+  it('calls onFreeSlotClick with the day and slot when a band is clicked', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    const onFreeSlotClick = vi.fn();
+    render(
+      <WeekGrid
+        weekStart={WEEK_START}
+        events={[]}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        getFreeSlotsForDay={() => [{ startHour: 9, endHour: 10 }]}
+        onFreeSlotClick={onFreeSlotClick}
+      />,
+    );
+
+    const [band] = screen.getAllByRole('button', { name: /reserve this free slot/i });
+    await user.click(band!);
+
+    expect(onFreeSlotClick).toHaveBeenCalledTimes(1);
+    expect(onFreeSlotClick).toHaveBeenCalledWith(expect.any(Date), { startHour: 9, endHour: 10 });
+  });
+});
+
 describe('WeekGrid — onDayClick opt-in (lobby calendar behavior)', () => {
   it('caps visible events and shows a "+N more" pill', () => {
     expect.assertions(2);

--- a/lined-web/src/components/__tests__/WeekGrid.test.tsx
+++ b/lined-web/src/components/__tests__/WeekGrid.test.tsx
@@ -257,3 +257,71 @@ describe('WeekGrid — hour labels', () => {
     expect(screen.getByText('12 AM')).toBeInTheDocument();
   });
 });
+
+describe('WeekGrid — midnight-spanning events', () => {
+  const midnightSpanning: EventDto = {
+    id: 20,
+    title: 'Movie Night',
+    location: null,
+    shared: true,
+    startAt: dayAt(0, 23).toISOString(), // Monday 11 PM
+    endAt: new Date(dayAt(1, 2).getTime()).toISOString(), // Tuesday 2 AM
+    timezone: 'UTC',
+    lobbyId: LOBBY.id,
+    ownerId: 1,
+    createdAt: '2026-01-01T00:00:00Z',
+  };
+
+  it('renders a clipped block on both the start day and the end day', () => {
+    expect.assertions(1);
+    render(
+      <WeekGrid
+        weekStart={WEEK_START}
+        events={[midnightSpanning]}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText('Movie Night')).toHaveLength(2);
+  });
+
+  it("clips the start-day segment's height to midnight, not the full duration", () => {
+    expect.assertions(1);
+    render(
+      <WeekGrid
+        weekStart={WEEK_START}
+        events={[midnightSpanning]}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+      />,
+    );
+
+    const [mondayBlock] = screen.getAllByText('Movie Night').map((el) => el.closest('button'));
+    // 11 PM -> midnight is 1h = 80px, well under the event's real 3h duration (240px).
+    expect(mondayBlock?.style.height).toBe('80px');
+  });
+
+  it('does not double-count the event when the end day is clicked (onDayClick opt-in)', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onDayClick = vi.fn();
+    render(
+      <WeekGrid
+        weekStart={WEEK_START}
+        events={[midnightSpanning]}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+        onDayClick={onDayClick}
+      />,
+    );
+
+    await user.click(screen.getByText('Tue 31'));
+
+    const [, dayEvents] = onDayClick.mock.calls[0] as [Date, EventDto[]];
+    expect(dayEvents).toHaveLength(1);
+  });
+});

--- a/lined-web/src/components/__tests__/WeekGrid.test.tsx
+++ b/lined-web/src/components/__tests__/WeekGrid.test.tsx
@@ -239,3 +239,21 @@ describe('WeekGrid — onDayClick opt-in (lobby calendar behavior)', () => {
     expect(second?.style.width).toBe('calc(50% - 4px)');
   });
 });
+
+describe('WeekGrid — hour labels', () => {
+  it('shows the grid start hour and a closing "12 AM" label at the end', () => {
+    expect.assertions(2);
+    render(
+      <WeekGrid
+        weekStart={WEEK_START}
+        events={[]}
+        lobbies={[LOBBY]}
+        selectedEventId={null}
+        onEventClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('1 AM')).toBeInTheDocument();
+    expect(screen.getByText('12 AM')).toBeInTheDocument();
+  });
+});

--- a/lined-web/src/components/dashboard/FreeSlotBanner.tsx
+++ b/lined-web/src/components/dashboard/FreeSlotBanner.tsx
@@ -5,9 +5,10 @@ import { formatFreeSlotRange } from '@/lib/calendarUtils';
 interface FreeSlotBannerProps {
   slot: FreeSlotBannerData | null;
   isLoading: boolean;
+  onPlan?: (slot: FreeSlotBannerData) => void;
 }
 
-export function FreeSlotBanner({ slot, isLoading }: FreeSlotBannerProps) {
+export function FreeSlotBanner({ slot, isLoading, onPlan }: FreeSlotBannerProps) {
   if (isLoading || !slot) return null;
 
   return (
@@ -20,9 +21,13 @@ export function FreeSlotBanner({ slot, isLoading }: FreeSlotBannerProps) {
           {formatFreeSlotRange(slot.start, slot.end)}
         </p>
       </div>
-      <span className="flex-shrink-0 text-xs font-semibold text-brand-green-dark">
+      <button
+        type="button"
+        onClick={() => onPlan?.(slot)}
+        className="flex-shrink-0 text-xs font-semibold text-brand-green-dark hover:underline"
+      >
         Plan something →
-      </span>
+      </button>
     </div>
   );
 }

--- a/lined-web/src/components/dashboard/__tests__/FreeSlotBanner.test.tsx
+++ b/lined-web/src/components/dashboard/__tests__/FreeSlotBanner.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { FreeSlotBanner } from '../FreeSlotBanner';
 
 describe('FreeSlotBanner', () => {
@@ -22,6 +23,7 @@ describe('FreeSlotBanner', () => {
     render(
       <FreeSlotBanner
         slot={{
+          lobbyId: 1,
           start: '2026-03-29T14:00:00Z',
           end: '2026-03-29T17:00:00Z',
           lobbyName: 'Alex & Anastasiia',
@@ -40,6 +42,7 @@ describe('FreeSlotBanner', () => {
     render(
       <FreeSlotBanner
         slot={{
+          lobbyId: 1,
           start: '2026-03-29T14:00:00Z',
           end: '2026-03-29T17:00:00Z',
           lobbyName: 'Alex & Anastasiia',
@@ -50,5 +53,22 @@ describe('FreeSlotBanner', () => {
     );
 
     expect(screen.getByText(/Alex & Anastasiia are both free/i)).toBeInTheDocument();
+  });
+
+  it('calls onPlan with the slot when "Plan something" is clicked', async () => {
+    expect.assertions(1);
+    const onPlan = vi.fn();
+    const slot = {
+      lobbyId: 1,
+      start: '2026-03-29T14:00:00Z',
+      end: '2026-03-29T17:00:00Z',
+      lobbyName: 'Alex & Anastasiia',
+      otherUsername: 'nastia_k',
+    };
+    render(<FreeSlotBanner slot={slot} isLoading={false} onPlan={onPlan} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /plan something/i }));
+
+    expect(onPlan).toHaveBeenCalledWith(slot);
   });
 });

--- a/lined-web/src/components/dashboard/__tests__/LobbyCardGrid.test.tsx
+++ b/lined-web/src/components/dashboard/__tests__/LobbyCardGrid.test.tsx
@@ -24,7 +24,7 @@ describe('LobbyCardGrid', () => {
     expect(screen.getByText('Alex & Anastasiia')).toBeInTheDocument();
     expect(screen.getByText('Johnson Family')).toBeInTheDocument();
     expect(screen.getByText('Weekend Crew')).toBeInTheDocument();
-    // Lobby 1 has 2 members, 2 events (ids 1,4), and 2 tasks (ids 1,2) in the fixtures.
+    // Lobby 1 has 2 members in the fixtures, so its "2 members" stat renders.
     expect(screen.getAllByText('2').length).toBeGreaterThan(0);
   });
 

--- a/lined-web/src/components/lobby/LobbyCalendarView.tsx
+++ b/lined-web/src/components/lobby/LobbyCalendarView.tsx
@@ -7,8 +7,16 @@ import { WeekGrid, type LegendItem } from '@/components/WeekGrid';
 import { DayAgendaModal } from '@/components/lobby/DayAgendaModal';
 import { useLobbyWeekEvents, useDeleteEvent } from '@/hooks/useEvents';
 import { useLobbyFreeSlots } from '@/hooks/useDashboard';
-import { addDays, formatMonthYear, getWeekStart, isSameDay } from '@/lib/calendarUtils';
+import {
+  addDays,
+  formatMonthYear,
+  getWeekStart,
+  isSameDay,
+  hourRangeToIso,
+  type FreeSlot,
+} from '@/lib/calendarUtils';
 import { freeSlotsForDay } from '@/lib/freeSlots';
+import { useCreateMenuStore } from '@/store/createMenu';
 import type { ViewMode } from '@/store/calendar';
 import type { EventDto } from '@/types';
 
@@ -27,6 +35,12 @@ export function LobbyCalendarView({ lobby }: LobbyCalendarViewProps) {
   const { data: events, isLoading, isError } = useLobbyWeekEvents(lobby.id, weekStart);
   const { data: freeSlots } = useLobbyFreeSlots(lobby.id, weekStart);
   const deleteEvent = useDeleteEvent();
+  const openReserveSlot = useCreateMenuStore((s) => s.openReserveSlot);
+
+  function handleFreeSlotClick(day: Date, slot: FreeSlot) {
+    const { start, end } = hourRangeToIso(day, slot.startHour, slot.endHour);
+    openReserveSlot({ lobbyId: lobby.id, start, end });
+  }
 
   const selectedEvent =
     selectedEventId != null ? (events?.find((e) => e.id === selectedEventId) ?? null) : null;
@@ -75,6 +89,7 @@ export function LobbyCalendarView({ lobby }: LobbyCalendarViewProps) {
             legendItems={legendItems}
             onDayClick={(day) => setAgendaDay(day)}
             maxVisibleEvents={4}
+            onFreeSlotClick={handleFreeSlotClick}
           />
 
           {selectedEvent && (

--- a/lined-web/src/components/lobby/__tests__/LobbyCalendarView.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/LobbyCalendarView.test.tsx
@@ -4,6 +4,7 @@ import { renderWithProviders, screen, userEvent, waitFor } from '@/test/utils';
 import { server } from '@/test/server';
 import { MOCK_LOBBIES } from '@/test/data';
 import type { EventDto } from '@/types';
+import { useCreateMenuStore } from '@/store/createMenu';
 import { LobbyCalendarView } from '../LobbyCalendarView';
 
 const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
@@ -139,5 +140,26 @@ describe('LobbyCalendarView', () => {
       if (screen.queryByRole('button', { name: 'Edit event' })) throw new Error('still open');
     });
     expect(screen.queryByRole('button', { name: 'Edit event' })).not.toBeInTheDocument();
+  });
+
+  it('clicking a free-slot band opens the reserve-slot overlay locked to this lobby', async () => {
+    expect.assertions(2);
+    const today = new Date();
+    today.setUTCHours(14, 0, 0, 0);
+    const start = today.toISOString();
+    today.setUTCHours(17);
+    const end = today.toISOString();
+    server.use(
+      http.get(`${BASE}/calendar/events`, () => HttpResponse.json([])),
+      http.get(`${BASE}/lobbies/:id/free-slots`, () => HttpResponse.json([{ start, end }])),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyCalendarView lobby={LOBBY} />);
+
+    const [band] = await screen.findAllByRole('button', { name: /reserve this free slot/i });
+    await user.click(band!);
+
+    expect(useCreateMenuStore.getState().overlay).toBe('reserveSlot');
+    expect(useCreateMenuStore.getState().reserveSlotInitial?.lobbyId).toBe(LOBBY.id);
   });
 });

--- a/lined-web/src/components/lobby/__tests__/LobbyTaskList.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/LobbyTaskList.test.tsx
@@ -21,7 +21,9 @@ describe('LobbyTaskList', () => {
 
     expect(await screen.findByText('Plan dinner for Saturday')).toBeInTheDocument();
     expect(screen.getByText('Book restaurant reservation')).toBeInTheDocument();
-    expect(screen.getByText('All (2)')).toBeInTheDocument();
+    // Lobby 1 has 3 tasks in the fixtures: "Plan dinner..." (TODO), "Book
+    // restaurant..." (IN_PROGRESS), and "Water the plants" (DONE).
+    expect(screen.getByText('All (3)')).toBeInTheDocument();
     expect(screen.getByText('To Do (1)')).toBeInTheDocument();
   });
 

--- a/lined-web/src/components/tasks/__tests__/KanbanBoard.test.tsx
+++ b/lined-web/src/components/tasks/__tests__/KanbanBoard.test.tsx
@@ -39,9 +39,10 @@ describe('KanbanBoard', () => {
     renderWithProviders(<KanbanBoard />);
 
     expect(await screen.findByText('Plan dinner for Saturday')).toBeInTheDocument();
-    expect(screen.getByTestId(KANBAN_TEST_IDS.column('TODO'))).toHaveTextContent('3');
-    expect(screen.getByTestId(KANBAN_TEST_IDS.column('IN_PROGRESS'))).toHaveTextContent('2');
-    expect(screen.getByTestId(KANBAN_TEST_IDS.column('DONE'))).toHaveTextContent('1');
+    // Fixture totals across all lobbies: 6 TODO, 3 IN_PROGRESS, 2 DONE.
+    expect(screen.getByTestId(KANBAN_TEST_IDS.column('TODO'))).toHaveTextContent('6');
+    expect(screen.getByTestId(KANBAN_TEST_IDS.column('IN_PROGRESS'))).toHaveTextContent('3');
+    expect(screen.getByTestId(KANBAN_TEST_IDS.column('DONE'))).toHaveTextContent('2');
   });
 
   it('shows an error message when the tasks request fails', async () => {
@@ -177,7 +178,7 @@ describe('KanbanBoard', () => {
     expect(screen.getByTestId(KANBAN_TEST_IDS.column('TODO'))).not.toHaveTextContent(
       'Plan dinner for Saturday',
     );
-    expect(doneColumn).toHaveTextContent('2');
+    expect(doneColumn).toHaveTextContent('3'); // 2 fixture DONE tasks + the one just moved
   });
 
   it('dropping a card back onto its own column leaves the board unchanged', async () => {
@@ -195,6 +196,6 @@ describe('KanbanBoard', () => {
     fireEvent.drop(todoColumn, { dataTransfer });
 
     expect(todoColumn).toHaveTextContent('Plan dinner for Saturday');
-    expect(todoColumn).toHaveTextContent('3');
+    expect(todoColumn).toHaveTextContent('6');
   });
 });

--- a/lined-web/src/hooks/useDashboard.ts
+++ b/lined-web/src/hooks/useDashboard.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-import type { FreeSlotDto } from '@/types';
+import { useQuery, useQueries } from '@tanstack/react-query';
+import type { FreeSlotDto, LobbyDto } from '@/types';
 import { getFreeSlots } from '@/api/lobbies';
 import { QUERY_KEYS } from '@/lib/constants';
 import { addDays } from '@/lib/calendarUtils';
@@ -11,6 +11,7 @@ const FREE_SLOT_WINDOW_DAYS = 7;
 const MIN_SLOT_MS = 60 * 60 * 1000; // 1 hour
 
 export interface FreeSlotBannerData {
+  lobbyId: number;
   start: string;
   end: string;
   lobbyName: string;
@@ -57,12 +58,56 @@ export function useFreeSlotBanner(): {
   return {
     isLoading: freeSlotsQuery.isLoading,
     slot: {
+      lobbyId: targetLobby.id,
       start: slot.start,
       end: slot.end,
       lobbyName: targetLobby.name,
       otherUsername: otherUserQuery.data?.username ?? null,
     },
   };
+}
+
+export interface FreeSlotCandidate {
+  lobby: LobbyDto;
+  start: string;
+  end: string;
+}
+
+const CANDIDATE_WINDOW_DAYS = 7;
+const MIN_CANDIDATE_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Earliest ≥1h mutual free slot per multi-member lobby (next 7 days), sorted
+ * soonest-first. Used by ReserveSlotModal when opened with no specific slot
+ * (the "+ Create → Reserve Free Slot" entry point) to offer a picker.
+ */
+export function useFreeSlotCandidates(lobbies: LobbyDto[]): {
+  candidates: FreeSlotCandidate[];
+  isLoading: boolean;
+} {
+  const multiMemberLobbies = lobbies.filter((l) => l.memberIds.length > 1);
+  const from = new Date();
+  const to = addDays(from, CANDIDATE_WINDOW_DAYS);
+  const fromKey = from.toISOString().slice(0, 10);
+
+  const queries = useQueries({
+    queries: multiMemberLobbies.map((lobby) => ({
+      queryKey: [...QUERY_KEYS.lobbyFreeSlots(lobby.id), fromKey],
+      queryFn: () => getFreeSlots(lobby.id, from.toISOString(), to.toISOString()),
+    })),
+  });
+
+  const candidates: FreeSlotCandidate[] = multiMemberLobbies
+    .map((lobby, i) => {
+      const slot = queries[i]?.data?.find(
+        (s) => new Date(s.end).getTime() - new Date(s.start).getTime() >= MIN_CANDIDATE_MS,
+      );
+      return slot ? { lobby, start: slot.start, end: slot.end } : null;
+    })
+    .filter((c): c is FreeSlotCandidate => c != null)
+    .sort((a, b) => a.start.localeCompare(b.start));
+
+  return { candidates, isLoading: queries.some((q) => q.isLoading) };
 }
 
 const LOBBY_FREE_SLOTS_WINDOW_DAYS = 7;

--- a/lined-web/src/lib/__tests__/calendarUtils.test.ts
+++ b/lined-web/src/lib/__tests__/calendarUtils.test.ts
@@ -7,6 +7,7 @@ import {
   formatFreeSlotRange,
   formatTaskDueDate,
   formatHourRange,
+  hourRangeToIso,
   assignEventLanes,
   getMonthGridDays,
   isSameMonth,
@@ -168,6 +169,39 @@ describe('formatHourRange', () => {
   it('includes minutes for a half-hour boundary', () => {
     expect.assertions(1);
     expect(formatHourRange(9.5, 11)).toBe('9:30–11 AM');
+  });
+});
+
+describe('hourRangeToIso', () => {
+  it('converts a whole-hour range on a given day to ISO timestamps', () => {
+    expect.assertions(2);
+    const day = new Date(2026, 2, 29); // local midnight, 29 Mar 2026
+    const { start, end } = hourRangeToIso(day, 14, 17);
+    expect(new Date(start).getHours()).toBe(14);
+    expect(new Date(end).getHours()).toBe(17);
+  });
+
+  it('converts a half-hour fraction to minutes', () => {
+    expect.assertions(2);
+    const day = new Date(2026, 2, 29);
+    const { start } = hourRangeToIso(day, 9.5, 11);
+    expect(new Date(start).getHours()).toBe(9);
+    expect(new Date(start).getMinutes()).toBe(30);
+  });
+
+  it('handles the midnight edge (hour 0)', () => {
+    expect.assertions(2);
+    const day = new Date(2026, 2, 29);
+    const { start, end } = hourRangeToIso(day, 0, 1);
+    expect(new Date(start).getHours()).toBe(0);
+    expect(new Date(end).getHours()).toBe(1);
+  });
+
+  it('does not mutate the day passed in', () => {
+    expect.assertions(1);
+    const day = new Date(2026, 2, 29, 6, 0, 0, 0);
+    hourRangeToIso(day, 14, 17);
+    expect(day.getHours()).toBe(6);
   });
 });
 

--- a/lined-web/src/lib/__tests__/calendarUtils.test.ts
+++ b/lined-web/src/lib/__tests__/calendarUtils.test.ts
@@ -13,6 +13,7 @@ import {
   isSameMonth,
   eventTouchesDay,
   clipEventToDay,
+  computeFreeSlots,
 } from '../calendarUtils';
 
 afterEach(() => {
@@ -282,6 +283,56 @@ describe('clipEventToDay', () => {
     const clipped = clipEventToDay(event, new Date('2026-07-19T00:00:00'));
     expect(new Date(clipped.startAt).getHours()).toBe(0);
     expect(new Date(clipped.endAt).toISOString()).toBe(new Date('2026-07-19T02:00:00').toISOString());
+  });
+});
+
+describe('computeFreeSlots', () => {
+  const makeEvent = (id: number, startAt: string, endAt: string): EventDto => ({
+    id,
+    title: `Event ${id}`,
+    location: null,
+    shared: true,
+    startAt,
+    endAt,
+    timezone: 'UTC',
+    lobbyId: 1,
+    ownerId: 1,
+    createdAt: '2026-01-01T00:00:00Z',
+  });
+
+  it('caps the free slot before a midnight-spanning event at its real start, not GRID_END_HOUR', () => {
+    expect.assertions(1);
+    // A gap from early evening up to 11:30 PM, when Movie Night starts and
+    // runs past midnight — the bug this guards: raw .getHours() on the 2 AM
+    // end reads smaller than 23.5, so cursor never advances past the event's
+    // start and the loop wrongly reports the day free all the way to 12 AM.
+    const events = [
+      makeEvent(1, '2026-07-18T20:00:00', '2026-07-18T21:00:00'),
+      makeEvent(2, '2026-07-18T23:30:00', '2026-07-19T02:00:00'),
+    ];
+    const slots = computeFreeSlots(events, new Date('2026-07-18T00:00:00'));
+
+    const trailingSlot = slots[slots.length - 1]!;
+    expect(trailingSlot).toEqual({ startHour: 21, endHour: 23.5 });
+  });
+
+  it('reports no free time after a midnight-spanning event that runs to the end of the day', () => {
+    expect.assertions(1);
+    const events = [makeEvent(1, '2026-07-18T23:30:00', '2026-07-19T02:00:00')];
+    const slots = computeFreeSlots(events, new Date('2026-07-18T00:00:00'));
+
+    expect(slots.some((s) => s.endHour === 24)).toBe(false);
+  });
+
+  it('still computes ordinary same-day gaps correctly', () => {
+    expect.assertions(1);
+    const events = [makeEvent(1, '2026-07-18T09:00:00', '2026-07-18T10:00:00')];
+    const slots = computeFreeSlots(events, new Date('2026-07-18T00:00:00'));
+
+    expect(slots).toEqual([
+      { startHour: 1, endHour: 9 },
+      { startHour: 10, endHour: 24 },
+    ]);
   });
 });
 

--- a/lined-web/src/lib/__tests__/calendarUtils.test.ts
+++ b/lined-web/src/lib/__tests__/calendarUtils.test.ts
@@ -11,6 +11,8 @@ import {
   assignEventLanes,
   getMonthGridDays,
   isSameMonth,
+  eventTouchesDay,
+  clipEventToDay,
 } from '../calendarUtils';
 
 afterEach(() => {
@@ -202,6 +204,84 @@ describe('hourRangeToIso', () => {
     const day = new Date(2026, 2, 29, 6, 0, 0, 0);
     hourRangeToIso(day, 14, 17);
     expect(day.getHours()).toBe(6);
+  });
+});
+
+describe('eventTouchesDay', () => {
+  const makeEvent = (startAt: string, endAt: string): EventDto => ({
+    id: 1,
+    title: 'Movie Night',
+    location: null,
+    shared: true,
+    startAt,
+    endAt,
+    timezone: 'UTC',
+    lobbyId: 1,
+    ownerId: 1,
+    createdAt: '2026-01-01T00:00:00Z',
+  });
+
+  it('is true when the event starts and ends on the same given day', () => {
+    expect.assertions(1);
+    const event = makeEvent('2026-07-18T09:00:00', '2026-07-18T10:00:00');
+    expect(eventTouchesDay(event, new Date('2026-07-18T00:00:00'))).toBe(true);
+  });
+
+  it('is true for the start day of a midnight-spanning event', () => {
+    expect.assertions(1);
+    const event = makeEvent('2026-07-18T23:30:00', '2026-07-19T02:00:00');
+    expect(eventTouchesDay(event, new Date('2026-07-18T00:00:00'))).toBe(true);
+  });
+
+  it('is true for the end day of a midnight-spanning event', () => {
+    expect.assertions(1);
+    const event = makeEvent('2026-07-18T23:30:00', '2026-07-19T02:00:00');
+    expect(eventTouchesDay(event, new Date('2026-07-19T00:00:00'))).toBe(true);
+  });
+
+  it('is false for a day the event does not touch at all', () => {
+    expect.assertions(1);
+    const event = makeEvent('2026-07-18T23:30:00', '2026-07-19T02:00:00');
+    expect(eventTouchesDay(event, new Date('2026-07-20T00:00:00'))).toBe(false);
+  });
+});
+
+describe('clipEventToDay', () => {
+  const makeEvent = (startAt: string, endAt: string): EventDto => ({
+    id: 1,
+    title: 'Movie Night',
+    location: null,
+    shared: true,
+    startAt,
+    endAt,
+    timezone: 'UTC',
+    lobbyId: 1,
+    ownerId: 1,
+    createdAt: '2026-01-01T00:00:00Z',
+  });
+
+  it('leaves a same-day event untouched', () => {
+    expect.assertions(2);
+    const event = makeEvent('2026-07-18T09:00:00', '2026-07-18T10:00:00');
+    const clipped = clipEventToDay(event, new Date('2026-07-18T00:00:00'));
+    expect(new Date(clipped.startAt).toISOString()).toBe(new Date('2026-07-18T09:00:00').toISOString());
+    expect(new Date(clipped.endAt).toISOString()).toBe(new Date('2026-07-18T10:00:00').toISOString());
+  });
+
+  it('clips the end to midnight on the start day of a midnight-spanning event', () => {
+    expect.assertions(2);
+    const event = makeEvent('2026-07-18T23:30:00', '2026-07-19T02:00:00');
+    const clipped = clipEventToDay(event, new Date('2026-07-18T00:00:00'));
+    expect(new Date(clipped.startAt).toISOString()).toBe(new Date('2026-07-18T23:30:00').toISOString());
+    expect(new Date(clipped.endAt).getHours()).toBe(0);
+  });
+
+  it('clips the start to midnight on the end day of a midnight-spanning event', () => {
+    expect.assertions(2);
+    const event = makeEvent('2026-07-18T23:30:00', '2026-07-19T02:00:00');
+    const clipped = clipEventToDay(event, new Date('2026-07-19T00:00:00'));
+    expect(new Date(clipped.startAt).getHours()).toBe(0);
+    expect(new Date(clipped.endAt).toISOString()).toBe(new Date('2026-07-19T02:00:00').toISOString());
   });
 });
 

--- a/lined-web/src/lib/__tests__/freeSlots.test.ts
+++ b/lined-web/src/lib/__tests__/freeSlots.test.ts
@@ -29,10 +29,12 @@ describe('freeSlotsForDay', () => {
 
   it('clips a slot to the grid start/end bounds', () => {
     expect.assertions(1);
+    // Starts just after midnight (before GRID_START_HOUR) and spills into the
+    // next day (past GRID_END_HOUR, which same-day hours can never exceed).
     const slots: FreeSlotDto[] = [
-      { start: '2026-03-28T06:00:00', end: '2026-03-28T23:00:00' },
+      { start: '2026-03-28T00:30:00', end: '2026-03-29T02:00:00' },
     ];
-    expect(freeSlotsForDay(slots, DAY)).toEqual([{ startHour: 8, endHour: 22 }]);
+    expect(freeSlotsForDay(slots, DAY)).toEqual([{ startHour: 1, endHour: 24 }]);
   });
 
   it('handles multiple slots in the same day', () => {

--- a/lined-web/src/lib/calendarUtils.ts
+++ b/lined-web/src/lib/calendarUtils.ts
@@ -1,13 +1,13 @@
 import type { EventDto, TaskStatus } from '@/types';
 
-export const GRID_START_HOUR = 8; // 8 AM
-export const GRID_END_HOUR = 22; // 10 PM
+export const GRID_START_HOUR = 1; // 1 AM
+export const GRID_END_HOUR = 24; // 12 AM (midnight)
 export const HOUR_HEIGHT = 80; // px per hour
 
 export const GRID_HOURS = Array.from(
   { length: GRID_END_HOUR - GRID_START_HOUR },
   (_, i) => i + GRID_START_HOUR,
-); // [8, 9, 10, ..., 21]
+); // [1, 2, 3, ..., 23]
 
 /** Returns the Monday of the week containing `date`. */
 export function getWeekStart(date: Date = new Date()): Date {

--- a/lined-web/src/lib/calendarUtils.ts
+++ b/lined-web/src/lib/calendarUtils.ts
@@ -265,6 +265,23 @@ export function formatHourRange(startHour: number, endHour: number): string {
     : `${start.value} ${start.ampm}–${end.value} ${end.ampm}`;
 }
 
+/** Converts a grid-relative hour range on a given day into real ISO timestamps. */
+export function hourRangeToIso(
+  day: Date,
+  startHour: number,
+  endHour: number,
+): { start: string; end: string } {
+  const toDate = (hour: number): Date => {
+    const d = new Date(day);
+    const wholeHour = Math.floor(hour);
+    const minutes = Math.round((hour - wholeHour) * 60);
+    d.setHours(wholeHour, minutes, 0, 0);
+    return d;
+  };
+
+  return { start: toDate(startHour).toISOString(), end: toDate(endHour).toISOString() };
+}
+
 export interface EventLane {
   lane: number;
   laneCount: number;

--- a/lined-web/src/lib/calendarUtils.ts
+++ b/lined-web/src/lib/calendarUtils.ts
@@ -209,6 +209,37 @@ export function getEventHeight(startAt: string, endAt: string): number {
   return durationHours * HOUR_HEIGHT;
 }
 
+/** True if an event starts, ends, or spans across the given day. */
+export function eventTouchesDay(event: EventDto, day: Date): boolean {
+  return (
+    isSameDay(new Date(event.startAt), day) || isSameDay(new Date(event.endAt), day)
+  );
+}
+
+/**
+ * Clips an event's start/end to `day`'s midnight-to-midnight bounds, so a
+ * multi-day event (e.g. 11:30 PM–2 AM) renders as two separate segments: a
+ * short block at the bottom of the day it starts, and a continuation at the
+ * top of the day it ends. The portion before GRID_START_HOUR on the
+ * continuation day is clipped by the grid itself, same as free slots.
+ */
+export function clipEventToDay(
+  event: EventDto,
+  day: Date,
+): { startAt: string; endAt: string } {
+  const dayStart = new Date(day);
+  dayStart.setHours(0, 0, 0, 0);
+  const dayEnd = addDays(dayStart, 1);
+
+  const eventStart = new Date(event.startAt);
+  const eventEnd = new Date(event.endAt);
+
+  const start = eventStart < dayStart ? dayStart : eventStart;
+  const end = eventEnd > dayEnd ? dayEnd : eventEnd;
+
+  return { startAt: start.toISOString(), endAt: end.toISOString() };
+}
+
 export interface FreeSlot {
   startHour: number;
   endHour: number;

--- a/lined-web/src/lib/calendarUtils.ts
+++ b/lined-web/src/lib/calendarUtils.ts
@@ -245,18 +245,30 @@ export interface FreeSlot {
   endHour: number;
 }
 
-/** Compute gaps between events within the visible grid range (≥ 30 min). */
-export function computeFreeSlots(events: EventDto[]): FreeSlot[] {
+/**
+ * Compute gaps between events within the visible grid range (>= 30 min), for
+ * one specific day. Events are clipped to that day first — a plain
+ * `.getHours()` read on a midnight-spanning event's real endAt (e.g. 2 AM the
+ * next day) would come back smaller than its own start hour, making the gap
+ * logic below think the day was free again right after the event started.
+ */
+export function computeFreeSlots(events: EventDto[], day: Date): FreeSlot[] {
   if (events.length === 0) return [];
 
   const MIN_SLOT_HOURS = 0.5;
 
+  const dayStart = new Date(day);
+  dayStart.setHours(0, 0, 0, 0);
+  // Hours elapsed since this day's midnight, rather than getHours(), so a
+  // clipped end exactly at the next day's midnight reads as 24, not 0.
+  const hoursSinceMidnight = (d: Date): number =>
+    (d.getTime() - dayStart.getTime()) / (1000 * 60 * 60);
+
   const ranges = events
-    .map((e) => ({
-      start:
-        new Date(e.startAt).getHours() + new Date(e.startAt).getMinutes() / 60,
-      end:
-        new Date(e.endAt).getHours() + new Date(e.endAt).getMinutes() / 60,
+    .map((e) => clipEventToDay(e, day))
+    .map(({ startAt, endAt }) => ({
+      start: hoursSinceMidnight(new Date(startAt)),
+      end: hoursSinceMidnight(new Date(endAt)),
     }))
     .sort((a, b) => a.start - b.start);
 

--- a/lined-web/src/pages/CalendarPage.tsx
+++ b/lined-web/src/pages/CalendarPage.tsx
@@ -19,6 +19,7 @@ export function CalendarPage() {
     viewMode,
     selectedEventId,
     isCreateModalOpen,
+    hiddenLobbyIds,
     goToPrevWeek,
     goToNextWeek,
     goToPrevMonth,
@@ -29,13 +30,19 @@ export function CalendarPage() {
     setSelectedEventId,
     openCreateModal,
     closeCreateModal,
+    toggleLobbyVisibility,
   } = useCalendarStore();
 
   const [editingEvent, setEditingEvent] = useState<EventDto | null>(null);
   const [agendaDay, setAgendaDay] = useState<Date | null>(null);
 
-  const { data: weekEvents = [] } = useWeekEvents(weekStart);
-  const { data: monthEvents = [] } = useMonthEvents(monthAnchor);
+  const { data: allWeekEvents = [] } = useWeekEvents(weekStart);
+  const { data: allMonthEvents = [] } = useMonthEvents(monthAnchor);
+  // Lobby-filter dropdown decluttering: same intent as Google/Outlook's
+  // per-calendar checkboxes — hidden lobbies vanish from the grid entirely,
+  // including free-slot detection (a hidden lobby's time isn't "free").
+  const weekEvents = allWeekEvents.filter((e) => !hiddenLobbyIds.includes(e.lobbyId));
+  const monthEvents = allMonthEvents.filter((e) => !hiddenLobbyIds.includes(e.lobbyId));
   const events = viewMode === 'month' ? monthEvents : weekEvents;
   const { data: lobbies = [] } = useMyLobbies();
   const deleteEvent = useDeleteEvent();
@@ -83,6 +90,9 @@ export function CalendarPage() {
         onToday={goToToday}
         onViewModeChange={setViewMode}
         onNewEvent={openCreateModal}
+        lobbies={lobbies}
+        hiddenLobbyIds={hiddenLobbyIds}
+        onToggleLobby={toggleLobbyVisibility}
       />
 
       <div className="flex flex-1 min-h-0 overflow-hidden">

--- a/lined-web/src/pages/CalendarPage.tsx
+++ b/lined-web/src/pages/CalendarPage.tsx
@@ -2,13 +2,14 @@ import { useState } from 'react';
 import { CalendarTopBar } from '@/components/CalendarTopBar';
 import { CreateEventModal } from '@/components/CreateEventModal';
 import { EventDetailPanel } from '@/components/EventDetailPanel';
+import { DayAgendaPanel } from '@/components/DayAgendaPanel';
 import { WeekGrid } from '@/components/WeekGrid';
 import { MonthGrid } from '@/components/MonthGrid';
 import { useWeekEvents, useMonthEvents, useDeleteEvent } from '@/hooks/useEvents';
 import { useMyLobbies } from '@/hooks/useLobbies';
 import { useCalendarStore } from '@/store/calendar';
 import { useCreateMenuStore } from '@/store/createMenu';
-import { formatMonthYear, hourRangeToIso, type FreeSlot } from '@/lib/calendarUtils';
+import { formatMonthYear, hourRangeToIso, isSameDay, type FreeSlot } from '@/lib/calendarUtils';
 import type { EventDto } from '@/types';
 
 export function CalendarPage() {
@@ -31,6 +32,7 @@ export function CalendarPage() {
   } = useCalendarStore();
 
   const [editingEvent, setEditingEvent] = useState<EventDto | null>(null);
+  const [agendaDay, setAgendaDay] = useState<Date | null>(null);
 
   const { data: weekEvents = [] } = useWeekEvents(weekStart);
   const { data: monthEvents = [] } = useMonthEvents(monthAnchor);
@@ -42,6 +44,16 @@ export function CalendarPage() {
   function handleFreeSlotClick(day: Date, slot: FreeSlot) {
     const { start, end } = hourRangeToIso(day, slot.startHour, slot.endHour);
     openReserveSlot({ start, end });
+  }
+
+  function handleEventClick(id: number) {
+    setAgendaDay(null);
+    setSelectedEventId(id);
+  }
+
+  function handleDayClick(day: Date) {
+    setSelectedEventId(null);
+    setAgendaDay(day);
   }
 
   const lobbyMap = new Map(lobbies.map((l) => [l.id, l]));
@@ -87,19 +99,34 @@ export function CalendarPage() {
             events={weekEvents}
             lobbies={lobbies}
             selectedEventId={selectedEventId}
-            onEventClick={setSelectedEventId}
+            onEventClick={handleEventClick}
             onFreeSlotClick={handleFreeSlotClick}
+            onDayClick={handleDayClick}
+            maxVisibleEvents={4}
           />
         )}
 
-        {selectedEvent && selectedLobby && viewMode === 'week' && (
-          <EventDetailPanel
-            event={selectedEvent}
-            lobby={selectedLobby}
-            onClose={() => setSelectedEventId(null)}
-            onEdit={() => setEditingEvent(selectedEvent)}
-            onDelete={handleDelete}
+        {agendaDay && viewMode === 'week' ? (
+          <DayAgendaPanel
+            day={agendaDay}
+            events={weekEvents.filter((e) => isSameDay(new Date(e.startAt), agendaDay))}
+            lobbies={lobbies}
+            selectedEventId={selectedEventId}
+            onEventClick={handleEventClick}
+            onClose={() => setAgendaDay(null)}
           />
+        ) : (
+          selectedEvent &&
+          selectedLobby &&
+          viewMode === 'week' && (
+            <EventDetailPanel
+              event={selectedEvent}
+              lobby={selectedLobby}
+              onClose={() => setSelectedEventId(null)}
+              onEdit={() => setEditingEvent(selectedEvent)}
+              onDelete={handleDelete}
+            />
+          )
         )}
       </div>
 

--- a/lined-web/src/pages/CalendarPage.tsx
+++ b/lined-web/src/pages/CalendarPage.tsx
@@ -7,7 +7,8 @@ import { MonthGrid } from '@/components/MonthGrid';
 import { useWeekEvents, useMonthEvents, useDeleteEvent } from '@/hooks/useEvents';
 import { useMyLobbies } from '@/hooks/useLobbies';
 import { useCalendarStore } from '@/store/calendar';
-import { formatMonthYear } from '@/lib/calendarUtils';
+import { useCreateMenuStore } from '@/store/createMenu';
+import { formatMonthYear, hourRangeToIso, type FreeSlot } from '@/lib/calendarUtils';
 import type { EventDto } from '@/types';
 
 export function CalendarPage() {
@@ -36,6 +37,12 @@ export function CalendarPage() {
   const events = viewMode === 'month' ? monthEvents : weekEvents;
   const { data: lobbies = [] } = useMyLobbies();
   const deleteEvent = useDeleteEvent();
+  const openReserveSlot = useCreateMenuStore((s) => s.openReserveSlot);
+
+  function handleFreeSlotClick(day: Date, slot: FreeSlot) {
+    const { start, end } = hourRangeToIso(day, slot.startHour, slot.endHour);
+    openReserveSlot({ start, end });
+  }
 
   const lobbyMap = new Map(lobbies.map((l) => [l.id, l]));
   const selectedEvent =
@@ -81,6 +88,7 @@ export function CalendarPage() {
             lobbies={lobbies}
             selectedEventId={selectedEventId}
             onEventClick={setSelectedEventId}
+            onFreeSlotClick={handleFreeSlotClick}
           />
         )}
 

--- a/lined-web/src/pages/DashboardPage.tsx
+++ b/lined-web/src/pages/DashboardPage.tsx
@@ -10,6 +10,7 @@ import { UpcomingEventsList } from '@/components/dashboard/UpcomingEventsList';
 import { MyTasksList } from '@/components/dashboard/MyTasksList';
 import { FreeSlotBanner } from '@/components/dashboard/FreeSlotBanner';
 import { CreateMenu } from '@/components/CreateMenu';
+import { useCreateMenuStore } from '@/store/createMenu';
 
 export function DashboardPage() {
   const { data: user } = useCurrentUser();
@@ -17,6 +18,7 @@ export function DashboardPage() {
   const { data: events, isLoading: eventsLoading, isError: eventsError } = useUpcomingEvents();
   const { data: tasks, isLoading: tasksLoading, isError: tasksError } = useMyTasks();
   const { slot, isLoading: slotLoading } = useFreeSlotBanner();
+  const openReserveSlot = useCreateMenuStore((s) => s.openReserveSlot);
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -60,7 +62,11 @@ export function DashboardPage() {
 
           <div>
             <MyTasksList tasks={tasks} isLoading={tasksLoading} isError={tasksError} />
-            <FreeSlotBanner slot={slot} isLoading={slotLoading} />
+            <FreeSlotBanner
+              slot={slot}
+              isLoading={slotLoading}
+              onPlan={(s) => openReserveSlot({ lobbyId: s.lobbyId, start: s.start, end: s.end })}
+            />
           </div>
         </div>
       </div>

--- a/lined-web/src/pages/__tests__/CalendarPage.test.tsx
+++ b/lined-web/src/pages/__tests__/CalendarPage.test.tsx
@@ -3,6 +3,7 @@ import { renderWithProviders, screen, userEvent, waitFor } from '@/test/utils';
 import { CalendarPage } from '../CalendarPage';
 import { useAuthStore } from '@/store/auth';
 import { useCalendarStore } from '@/store/calendar';
+import { useCreateMenuStore } from '@/store/createMenu';
 
 describe('CalendarPage', () => {
   beforeEach(() => {
@@ -60,5 +61,17 @@ describe('CalendarPage', () => {
     await waitFor(() =>
       expect(screen.getByRole('button', { name: 'Week' })).toHaveClass('bg-brand-green'),
     );
+  });
+
+  it('opens the reserve-slot overlay without a lobbyId when a free-slot band is clicked', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    renderWithProviders(<CalendarPage />);
+
+    const [band] = await screen.findAllByRole('button', { name: /reserve this free slot/i });
+    await user.click(band!);
+
+    expect(useCreateMenuStore.getState().overlay).toBe('reserveSlot');
+    expect(useCreateMenuStore.getState().reserveSlotInitial?.lobbyId).toBeUndefined();
   });
 });

--- a/lined-web/src/pages/__tests__/CalendarPage.test.tsx
+++ b/lined-web/src/pages/__tests__/CalendarPage.test.tsx
@@ -14,6 +14,7 @@ describe('CalendarPage', () => {
       viewMode: 'week',
       selectedEventId: null,
       isCreateModalOpen: false,
+      hiddenLobbyIds: [],
     });
   });
 
@@ -100,5 +101,32 @@ describe('CalendarPage', () => {
     await user.click(agendaRow!);
 
     expect(await screen.findByRole('button', { name: 'Edit event' })).toBeInTheDocument();
+  });
+
+  it('hides a lobby\'s events from the grid when it is unchecked in the Filters dropdown', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    renderWithProviders(<CalendarPage />);
+    await screen.findByText('Morning Coffee'); // lobby 1 (Alex & Anastasiia)
+
+    await user.click(screen.getByRole('button', { name: /filters/i }));
+    await user.click(await screen.findByRole('menuitemcheckbox', { name: /Alex & Anastasiia/ }));
+
+    await waitFor(() => expect(screen.queryByText('Morning Coffee')).not.toBeInTheDocument());
+    expect(screen.getByText('Team Lunch')).toBeInTheDocument(); // a different lobby, still visible
+  });
+
+  it('reflects a hidden lobby as unchecked and re-shows its events once re-checked', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    useCalendarStore.setState({ hiddenLobbyIds: [1] });
+    renderWithProviders(<CalendarPage />);
+
+    await waitFor(() => expect(screen.queryByText('Morning Coffee')).not.toBeInTheDocument());
+
+    await user.click(await screen.findByRole('button', { name: /filters/i }));
+    await user.click(await screen.findByRole('menuitemcheckbox', { name: /Alex & Anastasiia/ }));
+
+    expect(await screen.findByText('Morning Coffee')).toBeInTheDocument();
   });
 });

--- a/lined-web/src/pages/__tests__/CalendarPage.test.tsx
+++ b/lined-web/src/pages/__tests__/CalendarPage.test.tsx
@@ -74,4 +74,31 @@ describe('CalendarPage', () => {
     expect(useCreateMenuStore.getState().overlay).toBe('reserveSlot');
     expect(useCreateMenuStore.getState().reserveSlotInitial?.lobbyId).toBeUndefined();
   });
+
+  it('opens the day agenda panel listing that day\'s events when a day header is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderWithProviders(<CalendarPage />);
+    await screen.findByText('Morning Coffee');
+
+    const todayLabel = `${new Date().toLocaleDateString('en-US', { weekday: 'short' })} ${new Date().getDate()}`;
+    await user.click(screen.getByRole('button', { name: todayLabel }));
+
+    expect(await screen.findAllByText('Morning Coffee')).toHaveLength(2); // grid event + agenda row
+  });
+
+  it('selects the event and shows its detail panel when an agenda row is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderWithProviders(<CalendarPage />);
+    await screen.findByText('Morning Coffee');
+
+    const todayLabel = `${new Date().toLocaleDateString('en-US', { weekday: 'short' })} ${new Date().getDate()}`;
+    await user.click(screen.getByRole('button', { name: todayLabel }));
+
+    const [, agendaRow] = await screen.findAllByText('Morning Coffee');
+    await user.click(agendaRow!);
+
+    expect(await screen.findByRole('button', { name: 'Edit event' })).toBeInTheDocument();
+  });
 });

--- a/lined-web/src/pages/__tests__/DashboardPage.test.tsx
+++ b/lined-web/src/pages/__tests__/DashboardPage.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { renderWithProviders, screen } from '@/test/utils';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
 import { server } from '@/test/server';
 import { DashboardPage } from '../DashboardPage';
 import { useAuthStore } from '@/store/auth';
+import { useCreateMenuStore } from '@/store/createMenu';
 
 const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
 
@@ -28,6 +29,16 @@ describe('DashboardPage', () => {
     renderWithProviders(<DashboardPage />);
 
     expect(await screen.findByText('Free time found!')).toBeInTheDocument();
+  });
+
+  it('opens the reserve-slot overlay pre-filled with the banner slot when "Plan something" is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderWithProviders(<DashboardPage />);
+
+    await user.click(await screen.findByRole('button', { name: /plan something/i }));
+
+    expect(useCreateMenuStore.getState().reserveSlotInitial).toMatchObject({ lobbyId: 1 });
   });
 
   it('hides the free-slot banner when the lobby has no free slots', async () => {

--- a/lined-web/src/store/calendar.ts
+++ b/lined-web/src/store/calendar.ts
@@ -9,6 +9,9 @@ interface CalendarState {
   viewMode: ViewMode;
   selectedEventId: number | null;
   isCreateModalOpen: boolean;
+  /** Lobby ids excluded from the global calendar grid — mirrors Google/Outlook's
+   *  per-calendar visibility checkboxes, so a busy user can declutter overlap. */
+  hiddenLobbyIds: number[];
   goToPrevWeek: () => void;
   goToNextWeek: () => void;
   goToPrevMonth: () => void;
@@ -19,6 +22,7 @@ interface CalendarState {
   setSelectedEventId: (id: number | null) => void;
   openCreateModal: () => void;
   closeCreateModal: () => void;
+  toggleLobbyVisibility: (lobbyId: number) => void;
 }
 
 export const useCalendarStore = create<CalendarState>()((set) => ({
@@ -27,6 +31,7 @@ export const useCalendarStore = create<CalendarState>()((set) => ({
   viewMode: 'week',
   selectedEventId: null,
   isCreateModalOpen: false,
+  hiddenLobbyIds: [],
 
   goToPrevWeek: () => set((s) => ({ weekStart: addDays(s.weekStart, -7) })),
   goToNextWeek: () => set((s) => ({ weekStart: addDays(s.weekStart, 7) })),
@@ -40,4 +45,10 @@ export const useCalendarStore = create<CalendarState>()((set) => ({
   setSelectedEventId: (id) => set({ selectedEventId: id }),
   openCreateModal: () => set({ isCreateModalOpen: true }),
   closeCreateModal: () => set({ isCreateModalOpen: false }),
+  toggleLobbyVisibility: (lobbyId) =>
+    set((s) => ({
+      hiddenLobbyIds: s.hiddenLobbyIds.includes(lobbyId)
+        ? s.hiddenLobbyIds.filter((id) => id !== lobbyId)
+        : [...s.hiddenLobbyIds, lobbyId],
+    })),
 }));

--- a/lined-web/src/store/createMenu.ts
+++ b/lined-web/src/store/createMenu.ts
@@ -3,6 +3,14 @@ import type { TaskStatus } from '@/types';
 
 export type CreateOverlay = 'event' | 'task' | 'reserveSlot' | null;
 
+/** A concrete or partial slot to seed ReserveSlotModal from. */
+export interface ReserveSlotInitial {
+  /** Omitted when the click site doesn't know which lobby (global calendar free-band). */
+  lobbyId?: number;
+  start: string;
+  end: string;
+}
+
 interface CreateMenuState {
   isCreateLobbyOpen: boolean;
   openCreateLobby: () => void;
@@ -10,7 +18,10 @@ interface CreateMenuState {
   overlay: CreateOverlay;
   /** Preselected status for the 'task' overlay, e.g. when opened from a kanban column. */
   taskInitialStatus: TaskStatus | null;
+  /** Preselected slot for the 'reserveSlot' overlay, e.g. from the dashboard banner or a free-band click. */
+  reserveSlotInitial: ReserveSlotInitial | null;
   openOverlay: (overlay: Exclude<CreateOverlay, null>, taskInitialStatus?: TaskStatus) => void;
+  openReserveSlot: (initial?: ReserveSlotInitial) => void;
   closeOverlay: () => void;
 }
 
@@ -20,6 +31,8 @@ export const useCreateMenuStore = create<CreateMenuState>()((set) => ({
   closeCreateLobby: () => set({ isCreateLobbyOpen: false }),
   overlay: null,
   taskInitialStatus: null,
+  reserveSlotInitial: null,
   openOverlay: (overlay, taskInitialStatus) => set({ overlay, taskInitialStatus: taskInitialStatus ?? null }),
-  closeOverlay: () => set({ overlay: null, taskInitialStatus: null }),
+  openReserveSlot: (initial) => set({ overlay: 'reserveSlot', reserveSlotInitial: initial ?? null }),
+  closeOverlay: () => set({ overlay: null, taskInitialStatus: null, reserveSlotInitial: null }),
 }));

--- a/lined-web/src/test/data.ts
+++ b/lined-web/src/test/data.ts
@@ -45,6 +45,42 @@ export const MOCK_USERS: UserDto[] = [
     activePlan: null,
     activeUntil: null,
   },
+  {
+    id: 5,
+    username: 'maria_garcia',
+    email: 'maria@lined.app',
+    createdAt: '2025-09-03T10:00:00Z',
+    roles: ['ROLE_USER'],
+    activePlan: 'PRO_MONTHLY',
+    activeUntil: '2026-06-03T10:00:00Z',
+  },
+  {
+    id: 6,
+    username: 'james_lee',
+    email: 'james@lined.app',
+    createdAt: '2025-09-15T14:00:00Z',
+    roles: ['ROLE_USER'],
+    activePlan: null,
+    activeUntil: null,
+  },
+  {
+    id: 7,
+    username: 'sophia_chen',
+    email: 'sophia@lined.app',
+    createdAt: '2025-10-01T09:00:00Z',
+    roles: ['ROLE_USER'],
+    activePlan: null,
+    activeUntil: null,
+  },
+  {
+    id: 8,
+    username: 'ryan_patel',
+    email: 'ryan@lined.app',
+    createdAt: '2025-10-20T11:00:00Z',
+    roles: ['ROLE_USER'],
+    activePlan: 'PRO_MONTHLY',
+    activeUntil: '2026-07-20T11:00:00Z',
+  },
 ];
 
 export const MOCK_LOBBIES: LobbyDto[] = [
@@ -69,6 +105,13 @@ export const MOCK_LOBBIES: LobbyDto[] = [
     ownerId: 1,
     memberIds: [1, 2],
   },
+  {
+    id: 4,
+    name: 'Design Team',
+    lobbyType: 'WORK',
+    ownerId: 1,
+    memberIds: [1, 5, 6, 7],
+  },
 ];
 
 const today = new Date();
@@ -80,6 +123,18 @@ const dayAfter = new Date(today);
 dayAfter.setDate(dayAfter.getDate() + 2);
 const dayAfterStr = dayAfter.toISOString().slice(0, 10);
 const inThreeDaysStr = new Date(today.getTime() + 3 * 24 * 60 * 60 * 1000)
+  .toISOString()
+  .slice(0, 10);
+const inFourDaysStr = new Date(today.getTime() + 4 * 24 * 60 * 60 * 1000)
+  .toISOString()
+  .slice(0, 10);
+const inTenDaysStr = new Date(today.getTime() + 10 * 24 * 60 * 60 * 1000)
+  .toISOString()
+  .slice(0, 10);
+const yesterdayStr = new Date(today.getTime() - 24 * 60 * 60 * 1000)
+  .toISOString()
+  .slice(0, 10);
+const dayAfterPlusOneStr = new Date(dayAfter.getTime() + 24 * 60 * 60 * 1000)
   .toISOString()
   .slice(0, 10);
 
@@ -162,6 +217,66 @@ export const MOCK_TASKS: TaskDto[] = [
     dueDate: null,
     createdAt: '2026-04-10T11:00:00Z',
   },
+  {
+    id: 7,
+    title: 'Finalize onboarding flow mockups',
+    description: 'Incorporate feedback from the last design review',
+    priority: 'HIGH',
+    status: 'IN_PROGRESS',
+    lobbyId: 4,
+    creatorId: 1,
+    assigneeId: 5,
+    dueDate: tomorrowStr,
+    createdAt: '2026-04-11T09:00:00Z',
+  },
+  {
+    id: 8,
+    title: 'Review pull requests',
+    description: null,
+    priority: 'MEDIUM',
+    status: 'TODO',
+    lobbyId: 4,
+    creatorId: 1,
+    assigneeId: 6,
+    dueDate: todayStr,
+    createdAt: '2026-04-11T10:00:00Z',
+  },
+  {
+    id: 9,
+    title: 'Submit expense report',
+    description: 'Overdue since last week',
+    priority: 'MEDIUM',
+    status: 'TODO',
+    lobbyId: 4,
+    creatorId: 7,
+    assigneeId: 7,
+    dueDate: yesterdayStr,
+    createdAt: '2026-04-05T08:00:00Z',
+  },
+  {
+    id: 10,
+    title: 'Prepare quarterly roadmap deck',
+    description: null,
+    priority: 'HIGH',
+    status: 'TODO',
+    lobbyId: 4,
+    creatorId: 1,
+    assigneeId: 1,
+    dueDate: inTenDaysStr,
+    createdAt: '2026-04-11T12:00:00Z',
+  },
+  {
+    id: 11,
+    title: 'Water the plants',
+    description: null,
+    priority: 'LOW',
+    status: 'DONE',
+    lobbyId: 1,
+    creatorId: 2,
+    assigneeId: 2,
+    dueDate: yesterdayStr,
+    createdAt: '2026-04-06T08:00:00Z',
+  },
 ];
 
 export const MOCK_EVENTS: EventDto[] = [
@@ -225,6 +340,107 @@ export const MOCK_EVENTS: EventDto[] = [
     ownerId: 1,
     createdAt: '2026-04-10T07:00:00Z',
   },
+  {
+    id: 6,
+    title: 'Morning Run',
+    location: 'Riverside Park',
+    shared: true,
+    startAt: `${todayStr}T06:00:00Z`,
+    endAt: `${todayStr}T07:00:00Z`,
+    timezone: 'UTC',
+    lobbyId: 1,
+    ownerId: 1,
+    createdAt: '2026-04-11T06:00:00Z',
+  },
+  {
+    id: 7,
+    title: 'Design Standup',
+    location: null,
+    shared: true,
+    startAt: `${todayStr}T15:00:00Z`,
+    endAt: `${todayStr}T15:30:00Z`,
+    timezone: 'UTC',
+    lobbyId: 4,
+    ownerId: 1,
+    createdAt: '2026-04-11T07:00:00Z',
+  },
+  {
+    id: 8,
+    // Deliberately overlaps "Team Lunch" (lobby 3, same day, 12:00-13:00) by
+    // 30 minutes across two different lobbies -- exercises side-by-side lane
+    // layout and the lobby-visibility filter on the global calendar.
+    title: 'Design Sync',
+    location: null,
+    shared: true,
+    startAt: `${todayStr}T12:30:00Z`,
+    endAt: `${todayStr}T13:30:00Z`,
+    timezone: 'UTC',
+    lobbyId: 4,
+    ownerId: 1,
+    createdAt: '2026-04-11T07:15:00Z',
+  },
+  {
+    id: 9,
+    title: '1:1 with Manager',
+    location: null,
+    shared: true,
+    startAt: `${tomorrowStr}T14:00:00Z`,
+    endAt: `${tomorrowStr}T14:30:00Z`,
+    timezone: 'UTC',
+    lobbyId: 4,
+    ownerId: 1,
+    createdAt: '2026-04-11T07:30:00Z',
+  },
+  {
+    id: 10,
+    // A second midnight-spanning event (different lobby than "Movie Night")
+    // -- regression coverage for the day-column clipping/split rendering.
+    title: 'Family Game Night',
+    location: 'Home',
+    shared: true,
+    startAt: `${dayAfterStr}T22:00:00Z`,
+    endAt: `${dayAfterPlusOneStr}T01:00:00Z`,
+    timezone: 'UTC',
+    lobbyId: 2,
+    ownerId: 1,
+    createdAt: '2026-04-10T08:00:00Z',
+  },
+  {
+    id: 11,
+    title: 'Design Team Offsite',
+    location: 'Lakeside Retreat Center',
+    shared: true,
+    startAt: `${dayAfterStr}T08:00:00Z`,
+    endAt: `${dayAfterStr}T20:00:00Z`,
+    timezone: 'UTC',
+    lobbyId: 4,
+    ownerId: 1,
+    createdAt: '2026-04-10T09:00:00Z',
+  },
+  {
+    id: 12,
+    title: 'Quarterly Roadmap Review',
+    location: null,
+    shared: true,
+    startAt: `${inTenDaysStr}T16:00:00Z`,
+    endAt: `${inTenDaysStr}T17:30:00Z`,
+    timezone: 'UTC',
+    lobbyId: 4,
+    ownerId: 1,
+    createdAt: '2026-04-11T08:00:00Z',
+  },
+  {
+    id: 13,
+    title: 'Anniversary Dinner',
+    location: 'Le Petit Bistro',
+    shared: true,
+    startAt: `${inFourDaysStr}T19:00:00Z`,
+    endAt: `${inFourDaysStr}T21:00:00Z`,
+    timezone: 'UTC',
+    lobbyId: 1,
+    ownerId: 2,
+    createdAt: '2026-04-10T10:00:00Z',
+  },
 ];
 
 export const MOCK_LOBBY_INVITES: LobbyInviteDto[] = [
@@ -247,6 +463,16 @@ export const MOCK_LOBBY_INVITES: LobbyInviteDto[] = [
     sentAt: '2026-03-27T10:00:00Z',
     createdAt: '2026-03-27T10:00:00Z',
     updatedAt: '2026-03-27T10:00:00Z',
+  },
+  {
+    id: 3,
+    lobbyId: 4,
+    inviterId: 1,
+    inviteeId: 8,
+    status: 'PENDING',
+    sentAt: '2026-07-16T09:00:00Z',
+    createdAt: '2026-07-16T09:00:00Z',
+    updatedAt: '2026-07-16T09:00:00Z',
   },
 ];
 
@@ -292,6 +518,25 @@ export const MOCK_NOTIFICATIONS: NotificationDto[] = [
         status: 'DELIVERED',
         queuedAt: '2026-07-15T11:00:00Z',
         deliveredAt: '2026-07-15T11:00:00Z',
+      },
+    ],
+  },
+  {
+    id: 3,
+    type: 'TASK_ASSIGNED',
+    title: 'New task assigned',
+    message: 'You were assigned "Prepare quarterly roadmap deck"',
+    lobbyId: 4,
+    taskId: 10,
+    eventId: null,
+    readAt: null,
+    createdAt: '2026-07-16T08:00:00Z',
+    deliveries: [
+      {
+        channel: 'IN_APP',
+        status: 'DELIVERED',
+        queuedAt: '2026-07-16T08:00:00Z',
+        deliveredAt: '2026-07-16T08:00:00Z',
       },
     ],
   },

--- a/lined-web/src/test/smoke.test.ts
+++ b/lined-web/src/test/smoke.test.ts
@@ -3,17 +3,18 @@ import { MOCK_USERS, MOCK_LOBBIES, MOCK_TASKS, MOCK_EVENTS } from './data';
 
 describe('Mock data', () => {
   it('has users matching mockup personas, including invitable non-members', () => {
-    expect(MOCK_USERS).toHaveLength(4);
+    expect(MOCK_USERS).toHaveLength(8);
     expect(MOCK_USERS[0]?.username).toBe('alex_johnson');
     expect(MOCK_USERS[1]?.username).toBe('nastia_k');
   });
 
-  it('has three lobbies covering each type', () => {
-    expect(MOCK_LOBBIES).toHaveLength(3);
+  it('has lobbies covering each type', () => {
+    expect(MOCK_LOBBIES).toHaveLength(4);
     const types = MOCK_LOBBIES.map((l) => l.lobbyType);
     expect(types).toContain('COUPLE');
     expect(types).toContain('FAMILY');
     expect(types).toContain('FRIENDS');
+    expect(types).toContain('WORK');
   });
 
   it('has tasks with valid statuses', () => {


### PR DESCRIPTION
## Summary

Implements [Task 11](lined-web/docs/tasks/UI-11-reserve-slot.md) — the "detect mutual free time → one click → reserve it" flow.

- **`ReserveSlotModal`** resolves three modes from an optional `ReserveSlotInitial { lobbyId?, start, end }`:
  - **full slot** (lobbyId known): dashboard banner / lobby free-band click — read-only lobby/member card, editable times.
  - **time only** (no lobbyId): global-calendar free-band click — same form with an editable lobby select.
  - **no slot**: "+ Create → Reserve Free Slot" — computes one candidate per multi-member lobby via `useFreeSlotCandidates` (earliest ≥1h mutual slot, next 7 days) and lets the user pick.
- Submits a shared event (`POST /api/calendar/events`, `shared: true`, `notifyMembers` wired to the toggle), closes, selects the new event, and navigates to `/calendar`.
- Wired all three entry points: `FreeSlotBanner` → `DashboardPage`, `CreateMenu`, and a new opt-in `onFreeSlotClick` on `WeekGrid` (used by both `CalendarPage` and `LobbyCalendarView`).
- New pure helper `hourRangeToIso` converts a clicked grid band into ISO timestamps.
- Extracted a shared `ToggleRow` (was duplicated between `CreateEventModal` and `AddTaskDrawer`).
- `docs/UI_TASKS.md` row 11 updated to `DONE`.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm run test:run` (321 tests / 46 files), `npm run build` all pass
- [x] New/changed components have unit tests (MSW v2), covering positive, negative (blank title, 400/API error, empty candidate list), and loading states
- [x] Manually exercised all three entry points against the dev server + MSW mocks:
  - Dashboard banner "Plan something →" → pre-filled, submits, navigates to `/calendar`
  - "+ Create → Reserve Free Slot" with no context → candidate picker → picks a lobby → pre-filled form
  - Clicking a free-slot band on the global calendar → editable lobby select, pre-filled times
  - Clicking a free-slot band on a lobby calendar → locked to that lobby
- [x] Visually verified against `mockups/index.html#reserve-slot` — header, slot tag, member card, form fields, invite row, notify toggle, and footer all match