### PR TITLE
refactor(web): fix code smells found in code-review/simplify audit

### DIFF
--- a/lined-web/src/api/client.ts
+++ b/lined-web/src/api/client.ts
@@ -14,3 +14,26 @@ export const api = ky.create({
     ],
   },
 });
+
+/**
+ * Drops `undefined`/`null` entries before handing params to ky's
+ * `searchParams`, which otherwise serializes them as the literal string
+ * "undefined"/"null" in the query string.
+ */
+export function toSearchParams(
+  params: Record<string, string | number | boolean | undefined | null>,
+): Record<string, string | number | boolean> {
+  const result: Record<string, string | number | boolean> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null) result[key] = value;
+  }
+  return result;
+}
+
+/** DELETE (or other void-response request) that discards the empty body. */
+export function requestVoid(
+  method: 'delete' | 'post',
+  url: string,
+): Promise<void> {
+  return api[method](url).then(() => undefined);
+}

--- a/lined-web/src/api/events.ts
+++ b/lined-web/src/api/events.ts
@@ -1,4 +1,4 @@
-import { api } from './client';
+import { api, requestVoid, toSearchParams } from './client';
 import type {
   EventDto,
   EventCreateDto,
@@ -13,7 +13,7 @@ export function listEvents(params: {
   to: string;
 }): Promise<EventDto[]> {
   return api
-    .get('calendar/events', { searchParams: params as Record<string, string | number> })
+    .get('calendar/events', { searchParams: toSearchParams(params) })
     .json<EventDto[]>();
 }
 
@@ -26,7 +26,7 @@ export function updateEvent(id: number, data: EventUpdateDto): Promise<EventDto>
 }
 
 export function deleteEvent(id: number): Promise<void> {
-  return api.delete(`calendar/events/${id}`).then(() => undefined);
+  return requestVoid('delete', `calendar/events/${id}`);
 }
 
 export function findConflicts(params: {
@@ -36,7 +36,7 @@ export function findConflicts(params: {
   requesterId: number;
 }): Promise<EventConflictDto[]> {
   return api
-    .get('calendar/conflicts', { searchParams: params as Record<string, string | number> })
+    .get('calendar/conflicts', { searchParams: toSearchParams(params) })
     .json<EventConflictDto[]>();
 }
 
@@ -47,8 +47,6 @@ export function checkUserConflict(params: {
   requesterId: number;
 }): Promise<UserConflictDto> {
   return api
-    .get('calendar/user-conflict', {
-      searchParams: params as Record<string, string | number>,
-    })
+    .get('calendar/user-conflict', { searchParams: toSearchParams(params) })
     .json<UserConflictDto>();
 }

--- a/lined-web/src/api/invites.ts
+++ b/lined-web/src/api/invites.ts
@@ -1,4 +1,4 @@
-import { api } from './client';
+import { api, requestVoid, toSearchParams } from './client';
 import type { LobbyInviteDto } from '@/types';
 
 export type InviteTarget = { userId: number } | { userEmail: string };
@@ -8,9 +8,7 @@ export function createInvite(
   target: InviteTarget,
 ): Promise<LobbyInviteDto> {
   return api
-    .post(`lobbies/${lobbyId}/invites`, {
-      searchParams: target as Record<string, string | number>,
-    })
+    .post(`lobbies/${lobbyId}/invites`, { searchParams: toSearchParams(target) })
     .json<LobbyInviteDto>();
 }
 
@@ -28,7 +26,7 @@ export function resendInvite(
 }
 
 export function cancelInvite(lobbyId: number, inviteId: number): Promise<void> {
-  return api.delete(`lobbies/${lobbyId}/invites/${inviteId}`).then(() => undefined);
+  return requestVoid('delete', `lobbies/${lobbyId}/invites/${inviteId}`);
 }
 
 export function myInvites(): Promise<LobbyInviteDto[]> {

--- a/lined-web/src/api/lobbies.ts
+++ b/lined-web/src/api/lobbies.ts
@@ -1,4 +1,4 @@
-import { api } from './client';
+import { api, requestVoid } from './client';
 import type { LobbyDto, LobbyCreateDto, LobbyUpdateDto, FreeSlotDto } from '@/types';
 
 export function getMyLobbies(): Promise<LobbyDto[]> {
@@ -32,5 +32,5 @@ export function removeMember(lobbyId: number, userId: number): Promise<LobbyDto>
 }
 
 export function deleteLobby(id: number): Promise<void> {
-  return api.delete(`lobbies/${id}`).then(() => undefined);
+  return requestVoid('delete', `lobbies/${id}`);
 }

--- a/lined-web/src/api/subscriptions.ts
+++ b/lined-web/src/api/subscriptions.ts
@@ -1,4 +1,4 @@
-import { api } from './client';
+import { api, requestVoid } from './client';
 import type { SubscriptionDto } from '@/types';
 
 export function getActiveSubscription(userId: number): Promise<SubscriptionDto> {
@@ -17,5 +17,5 @@ export function startSubscription(data: {
 }
 
 export function cancelSubscription(userId: number): Promise<void> {
-  return api.post(`subscriptions/${userId}/cancel-active`).then(() => undefined);
+  return requestVoid('post', `subscriptions/${userId}/cancel-active`);
 }

--- a/lined-web/src/api/subscriptions.ts
+++ b/lined-web/src/api/subscriptions.ts
@@ -1,5 +1,5 @@
 import { api, requestVoid } from './client';
-import type { SubscriptionDto } from '@/types';
+import type { SubscriptionDto, SubscriptionCreateDto } from '@/types';
 
 export function getActiveSubscription(userId: number): Promise<SubscriptionDto> {
   return api.get(`subscriptions/${userId}/active`).json<SubscriptionDto>();
@@ -9,10 +9,7 @@ export function getSubscriptionHistory(userId: number): Promise<SubscriptionDto[
   return api.get(`subscriptions/${userId}/history`).json<SubscriptionDto[]>();
 }
 
-export function startSubscription(data: {
-  userId: number;
-  planId: number;
-}): Promise<SubscriptionDto> {
+export function startSubscription(data: SubscriptionCreateDto): Promise<SubscriptionDto> {
   return api.post('subscriptions', { json: data }).json<SubscriptionDto>();
 }
 

--- a/lined-web/src/api/tasks.ts
+++ b/lined-web/src/api/tasks.ts
@@ -1,4 +1,4 @@
-import { api } from './client';
+import { api, requestVoid, toSearchParams } from './client';
 import type { TaskDto, TaskCreateDto, TaskUpdateDto } from '@/types';
 
 export function listTasks(params?: {
@@ -7,7 +7,7 @@ export function listTasks(params?: {
   status?: string;
 }): Promise<TaskDto[]> {
   return api
-    .get('tasks', { searchParams: params as Record<string, string | number> })
+    .get('tasks', { searchParams: toSearchParams(params ?? {}) })
     .json<TaskDto[]>();
 }
 
@@ -20,7 +20,7 @@ export function updateTask(id: number, data: TaskUpdateDto): Promise<TaskDto> {
 }
 
 export function deleteTask(id: number): Promise<void> {
-  return api.delete(`tasks/${id}`).then(() => undefined);
+  return requestVoid('delete', `tasks/${id}`);
 }
 
 export function listMyTasks(): Promise<TaskDto[]> {

--- a/lined-web/src/api/users.ts
+++ b/lined-web/src/api/users.ts
@@ -1,4 +1,4 @@
-import { api } from './client';
+import { api, requestVoid } from './client';
 import type { UserDto, UserCreateDto, UserUpdateDto, UserPageDto } from '@/types';
 
 export function getUser(id: number): Promise<UserDto> {
@@ -20,5 +20,5 @@ export function searchUsers(q: string, page = 0, size = 20): Promise<UserPageDto
 }
 
 export function deleteUser(id: number): Promise<void> {
-  return api.delete(`users/${id}`).then(() => undefined);
+  return requestVoid('delete', `users/${id}`);
 }

--- a/lined-web/src/components/AddTaskDrawer.tsx
+++ b/lined-web/src/components/AddTaskDrawer.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import { HTTPError } from 'ky';
 import type { LobbyDto, TaskDto, TaskStatus } from '@/types';
 import { useCreateTask } from '@/hooks/useTasks';
 import { useUsers } from '@/hooks/useUsers';
 import { TASK_STATUS_LABELS } from '@/lib/constants';
+import { getApiErrorMessage } from '@/lib/apiErrors';
 import { AuthAlert } from '@/components/AuthAlert';
 import { FormField } from '@/components/FormField';
 import { ToggleRow } from '@/components/ToggleRow';
@@ -27,10 +27,7 @@ function todayStr(): string {
 }
 
 function getCreateTaskErrorMessage(error: unknown): string {
-  if (error instanceof HTTPError && error.response.status === 400) {
-    return 'Enter a valid title';
-  }
-  return "Couldn't create task — please try again";
+  return getApiErrorMessage(error, { 400: 'Enter a valid title' }, "Couldn't create task — please try again");
 }
 
 export function AddTaskDrawer({

--- a/lined-web/src/components/CalendarTopBar.tsx
+++ b/lined-web/src/components/CalendarTopBar.tsx
@@ -1,7 +1,7 @@
 import { ChevronLeft, ChevronRight, ListFilter, Plus } from 'lucide-react';
 import type { ViewMode } from '@/store/calendar';
 import type { LobbyDto } from '@/types';
-import { LOBBY_TYPE_LABELS } from '@/lib/constants';
+import { LOBBY_TYPE_LABELS, lobbyAccentColor } from '@/lib/constants';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -113,7 +113,7 @@ export function CalendarTopBar({
                 >
                   <span
                     className="h-2.5 w-2.5 flex-shrink-0 rounded-full"
-                    style={{ backgroundColor: `var(--color-lobby-${lobby.lobbyType.toLowerCase()})` }}
+                    style={{ backgroundColor: lobbyAccentColor(lobby.lobbyType) }}
                   />
                   <span className="truncate">{lobby.name}</span>
                   <span className="ml-auto flex-shrink-0 text-xs text-text-muted">

--- a/lined-web/src/components/CreateEventModal.tsx
+++ b/lined-web/src/components/CreateEventModal.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import { X } from 'lucide-react';
-import { HTTPError } from 'ky';
 import type { EventDto, LobbyDto } from '@/types';
 import { useCreateEvent, useUpdateEvent } from '@/hooks/useEvents';
 import { toDatetimeLocal, fromDatetimeLocal } from '@/lib/calendarUtils';
+import { getApiErrorMessage } from '@/lib/apiErrors';
 import { AuthAlert } from '@/components/AuthAlert';
 import { ToggleRow } from '@/components/ToggleRow';
 
@@ -281,10 +281,9 @@ export function CreateEventModal({
 }
 
 function getEventErrorMessage(error: unknown, isEditMode: boolean): string {
-  if (error instanceof HTTPError && error.response.status === 400) {
-    return 'Enter a valid title and time range';
-  }
-  return isEditMode
-    ? "Couldn't save changes — please try again"
-    : "Couldn't create event — please try again";
+  return getApiErrorMessage(
+    error,
+    { 400: 'Enter a valid title and time range' },
+    isEditMode ? "Couldn't save changes — please try again" : "Couldn't create event — please try again",
+  );
 }

--- a/lined-web/src/components/CreateLobbyModal.tsx
+++ b/lined-web/src/components/CreateLobbyModal.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { X } from 'lucide-react';
-import { HTTPError } from 'ky';
 import type { LobbyType } from '@/types';
 import { useCreateLobby } from '@/hooks/useLobbies';
 import { LobbyTypePicker } from '@/components/LobbyTypePicker';
 import { FormField } from '@/components/FormField';
 import { AuthAlert } from '@/components/AuthAlert';
+import { getApiErrorMessage } from '@/lib/apiErrors';
 
 interface CreateLobbyModalProps {
   onClose: () => void;
@@ -112,8 +112,9 @@ export const CreateLobbyModal = ({ onClose }: CreateLobbyModalProps) => {
 };
 
 function getCreateLobbyErrorMessage(error: unknown): string {
-  if (error instanceof HTTPError && error.response.status === 400) {
-    return 'Enter a valid lobby name';
-  }
-  return 'Something went wrong — please try again';
+  return getApiErrorMessage(
+    error,
+    { 400: 'Enter a valid lobby name' },
+    'Something went wrong — please try again',
+  );
 }

--- a/lined-web/src/components/DayAgendaPanel.tsx
+++ b/lined-web/src/components/DayAgendaPanel.tsx
@@ -1,6 +1,7 @@
 import { X } from 'lucide-react';
 import type { EventDto, LobbyDto } from '@/types';
 import { formatClockTime, formatFullDate } from '@/lib/calendarUtils';
+import { lobbyAccentColor } from '@/lib/constants';
 
 interface DayAgendaPanelProps {
   day: Date;
@@ -47,9 +48,7 @@ export function DayAgendaPanel({
           <ul className="flex flex-col gap-2">
             {sorted.map((event) => {
               const lobby = lobbyMap.get(event.lobbyId);
-              const accentColor = lobby
-                ? `var(--color-lobby-${lobby.lobbyType.toLowerCase()})`
-                : 'var(--color-lobby-couple)';
+              const accentColor = lobby ? lobbyAccentColor(lobby.lobbyType) : 'var(--color-lobby-couple)';
               return (
                 <li key={event.id}>
                   <button

--- a/lined-web/src/components/EventDetailPanel.tsx
+++ b/lined-web/src/components/EventDetailPanel.tsx
@@ -1,6 +1,7 @@
 import { Clock, Link, MapPin, X } from 'lucide-react';
 import type { EventDto, LobbyDto } from '@/types';
 import { formatEventTime } from '@/lib/calendarUtils';
+import { lobbyAccentColor } from '@/lib/constants';
 
 interface EventDetailPanelProps {
   event: EventDto;
@@ -19,8 +20,7 @@ export function EventDetailPanel({
   onDelete,
   deleteError,
 }: EventDetailPanelProps) {
-  const lobbyType = lobby.lobbyType.toLowerCase();
-  const accentColor = `var(--color-lobby-${lobbyType})`;
+  const accentColor = lobbyAccentColor(lobby.lobbyType);
 
   return (
     <div className="m-4 ml-0 w-72 flex-shrink-0 self-start overflow-hidden rounded-xl bg-white shadow-[var(--shadow-md)]">

--- a/lined-web/src/components/EventDetailPanel.tsx
+++ b/lined-web/src/components/EventDetailPanel.tsx
@@ -8,6 +8,7 @@ interface EventDetailPanelProps {
   onClose: () => void;
   onEdit: () => void;
   onDelete: () => void;
+  deleteError?: string | null;
 }
 
 export function EventDetailPanel({
@@ -16,6 +17,7 @@ export function EventDetailPanel({
   onClose,
   onEdit,
   onDelete,
+  deleteError,
 }: EventDetailPanelProps) {
   const lobbyType = lobby.lobbyType.toLowerCase();
   const accentColor = `var(--color-lobby-${lobbyType})`;
@@ -76,6 +78,10 @@ export function EventDetailPanel({
 
         {/* Divider */}
         <div className="my-3 h-px bg-border" />
+
+        {deleteError && (
+          <p className="mb-2 text-xs font-medium text-red-500">{deleteError}</p>
+        )}
 
         {/* Actions */}
         <div className="flex gap-2">

--- a/lined-web/src/components/MonthGrid.tsx
+++ b/lined-web/src/components/MonthGrid.tsx
@@ -1,6 +1,7 @@
 import type { EventDto, LobbyDto } from '@/types';
 import { CalendarLegend } from '@/components/CalendarLegend';
 import { getMonthGridDays, isSameDay, isSameMonth, isToday } from '@/lib/calendarUtils';
+import { lobbyAccentColor } from '@/lib/constants';
 
 const DOW_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const MAX_VISIBLE_CHIPS = 3;
@@ -42,12 +43,12 @@ function MonthDayCell({ day, monthAnchor, events, lobbyMap, onDayClick }: MonthD
       <div className="flex w-full flex-col gap-0.5">
         {visible.map((event) => {
           const lobby = lobbyMap.get(event.lobbyId);
-          const lobbyType = lobby?.lobbyType.toLowerCase() ?? 'couple';
+          const accentColor = lobby ? lobbyAccentColor(lobby.lobbyType) : 'var(--color-lobby-couple)';
           return (
             <span
               key={event.id}
               className="truncate rounded px-1.5 py-0.5 text-[10px] font-medium text-white"
-              style={{ backgroundColor: `var(--color-lobby-${lobbyType})` }}
+              style={{ backgroundColor: accentColor }}
             >
               {event.title}
             </span>

--- a/lined-web/src/components/ReserveSlotModal.tsx
+++ b/lined-web/src/components/ReserveSlotModal.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { X, Sparkles, Check } from 'lucide-react';
-import { HTTPError } from 'ky';
 import type { EventDto, LobbyDto } from '@/types';
 import { useCreateEvent } from '@/hooks/useEvents';
 import { useFreeSlotCandidates, type FreeSlotCandidate } from '@/hooks/useDashboard';
@@ -9,6 +8,7 @@ import { useAuthStore } from '@/store/auth';
 import type { ReserveSlotInitial } from '@/store/createMenu';
 import { toDatetimeLocal, fromDatetimeLocal, formatFreeSlotRange } from '@/lib/calendarUtils';
 import { LOBBY_TYPE_ICONS } from '@/lib/constants';
+import { getApiErrorMessage } from '@/lib/apiErrors';
 import { AuthAlert } from '@/components/AuthAlert';
 import { FormField } from '@/components/FormField';
 import { AssigneeAvatar } from '@/components/AssigneeAvatar';
@@ -100,10 +100,11 @@ interface ReserveSlotFormProps {
 }
 
 function getReserveErrorMessage(error: unknown): string {
-  if (error instanceof HTTPError && error.response.status === 400) {
-    return 'Enter a valid title and time range';
-  }
-  return "Couldn't reserve this slot — please try again";
+  return getApiErrorMessage(
+    error,
+    { 400: 'Enter a valid title and time range' },
+    "Couldn't reserve this slot — please try again",
+  );
 }
 
 function ReserveSlotForm({ lobbies, slot, onClose, onReserved }: ReserveSlotFormProps) {

--- a/lined-web/src/components/Sidebar.tsx
+++ b/lined-web/src/components/Sidebar.tsx
@@ -20,11 +20,9 @@ export function Sidebar() {
   const { data: user, isLoading: userLoading } = useCurrentUser();
   const openCreateLobby = useCreateMenuStore((s) => s.openCreateLobby);
   const setUserId = useAuthStore((s) => s.setUserId);
-  const setToken = useAuthStore((s) => s.setToken);
 
   function handleSignOut() {
     setUserId(null);
-    setToken(null);
     navigate('/sign-in');
   }
 

--- a/lined-web/src/components/WeekGrid.tsx
+++ b/lined-web/src/components/WeekGrid.tsx
@@ -134,7 +134,7 @@ function FreeSlotBand({ startHour, endHour, onClick }: FreeSlotBandProps) {
         onClick={onClick}
         aria-label="Reserve this free slot"
         className="absolute left-[2px] right-[2px] flex cursor-pointer items-center justify-center rounded-[6px] text-[10px] font-semibold text-brand-green-dark hover:opacity-80"
-        style={{ top, height, backgroundColor: '#B4EBD0', opacity: 0.6 }}
+        style={{ top, height, backgroundColor: 'var(--color-free-slot)', opacity: 0.6 }}
       >
         {height >= 40 && 'Free slot'}
       </button>
@@ -144,7 +144,7 @@ function FreeSlotBand({ startHour, endHour, onClick }: FreeSlotBandProps) {
   return (
     <div
       className="pointer-events-none absolute left-[2px] right-[2px] rounded-[6px] flex items-center justify-center text-[10px] font-semibold text-brand-green-dark"
-      style={{ top, height, backgroundColor: '#B4EBD0', opacity: 0.6 }}
+      style={{ top, height, backgroundColor: 'var(--color-free-slot)', opacity: 0.6 }}
     >
       {height >= 40 && 'Free slot'}
     </div>

--- a/lined-web/src/components/WeekGrid.tsx
+++ b/lined-web/src/components/WeekGrid.tsx
@@ -19,7 +19,7 @@ import {
   type FreeSlot,
 } from '@/lib/calendarUtils';
 import { CalendarLegend } from '@/components/CalendarLegend';
-import { DEFAULT_LEGEND_ITEMS, type LegendItem } from '@/lib/constants';
+import { DEFAULT_LEGEND_ITEMS, lobbyAccentColor, type LegendItem } from '@/lib/constants';
 
 export type { LegendItem };
 
@@ -81,7 +81,7 @@ function CalendarEvent({
 }: CalendarEventProps) {
   const top = getEventTop(displayStartAt);
   const height = Math.max(getEventHeight(displayStartAt, displayEndAt), 24);
-  const lobbyType = lobby?.lobbyType.toLowerCase() ?? 'couple';
+  const accentColor = lobby ? lobbyAccentColor(lobby.lobbyType) : 'var(--color-lobby-couple)';
 
   const horizontal: React.CSSProperties =
     laneCount != null && laneCount > 1
@@ -99,7 +99,7 @@ function CalendarEvent({
         top,
         height,
         ...horizontal,
-        backgroundColor: `var(--color-lobby-${lobbyType})`,
+        backgroundColor: accentColor,
         opacity: isSelected ? 1 : 0.92,
         outline: isSelected ? '2px solid white' : 'none',
         outlineOffset: '-2px',

--- a/lined-web/src/components/WeekGrid.tsx
+++ b/lined-web/src/components/WeekGrid.tsx
@@ -153,18 +153,22 @@ function FreeSlotBand({ startHour, endHour, onClick }: FreeSlotBandProps) {
 
 // ─── DayColumn ────────────────────────────────────────────────────────────────
 
+interface DayColumnActions {
+  onEventClick: (id: number) => void;
+  onFreeSlotClick?: (slot: FreeSlot) => void;
+  onShowMore?: () => void;
+}
+
 interface DayColumnProps {
   day: Date;
   events: EventDto[];
   lobbyMap: Map<number, LobbyDto>;
   today: boolean;
   selectedEventId: number | null;
-  onEventClick: (id: number) => void;
   freeSlots: FreeSlot[];
-  onFreeSlotClick?: (slot: FreeSlot) => void;
   lanes?: Map<number, EventLane>;
   overflowCount?: number;
-  onShowMore?: () => void;
+  actions: DayColumnActions;
 }
 
 function DayColumn({
@@ -173,12 +177,10 @@ function DayColumn({
   lobbyMap,
   today,
   selectedEventId,
-  onEventClick,
   freeSlots,
-  onFreeSlotClick,
   lanes,
   overflowCount = 0,
-  onShowMore,
+  actions,
 }: DayColumnProps) {
   return (
     <div
@@ -201,7 +203,7 @@ function DayColumn({
           key={i}
           startHour={slot.startHour}
           endHour={slot.endHour}
-          onClick={onFreeSlotClick ? () => onFreeSlotClick(slot) : undefined}
+          onClick={actions.onFreeSlotClick ? () => actions.onFreeSlotClick!(slot) : undefined}
         />
       ))}
 
@@ -217,7 +219,7 @@ function DayColumn({
             displayEndAt={displayEndAt}
             lobby={lobbyMap.get(event.lobbyId)}
             isSelected={event.id === selectedEventId}
-            onClick={() => onEventClick(event.id)}
+            onClick={() => actions.onEventClick(event.id)}
             lane={laneInfo?.lane}
             laneCount={laneInfo?.laneCount}
           />
@@ -225,10 +227,10 @@ function DayColumn({
       })}
 
       {/* Overflow pill — opens the day agenda view for the remaining events */}
-      {overflowCount > 0 && onShowMore && (
+      {overflowCount > 0 && actions.onShowMore && (
         <button
           type="button"
-          onClick={onShowMore}
+          onClick={actions.onShowMore}
           className="absolute right-1 top-1 z-20 rounded-full bg-text-primary/80 px-2 py-0.5 text-[10px] font-semibold text-white hover:bg-text-primary"
         >
           +{overflowCount} more
@@ -365,11 +367,13 @@ export function WeekGrid({
                   lobbyMap={lobbyMap}
                   today={isToday(day)}
                   selectedEventId={selectedEventId}
-                  onEventClick={onEventClick}
                   freeSlots={freeSlots}
-                  onFreeSlotClick={
-                    onFreeSlotClick ? (slot) => onFreeSlotClick(day, slot) : undefined
-                  }
+                  actions={{
+                    onEventClick,
+                    onFreeSlotClick: onFreeSlotClick
+                      ? (slot) => onFreeSlotClick(day, slot)
+                      : undefined,
+                  }}
                 />
               );
             }
@@ -387,14 +391,16 @@ export function WeekGrid({
                 lobbyMap={lobbyMap}
                 today={isToday(day)}
                 selectedEventId={selectedEventId}
-                onEventClick={onEventClick}
                 freeSlots={freeSlots}
-                onFreeSlotClick={
-                  onFreeSlotClick ? (slot) => onFreeSlotClick(day, slot) : undefined
-                }
                 lanes={lanes}
                 overflowCount={overflowCount}
-                onShowMore={() => onDayClick(day, dayEvents)}
+                actions={{
+                  onEventClick,
+                  onFreeSlotClick: onFreeSlotClick
+                    ? (slot) => onFreeSlotClick(day, slot)
+                    : undefined,
+                  onShowMore: () => onDayClick(day, dayEvents),
+                }}
               />
             );
           })}

--- a/lined-web/src/components/__tests__/AppShell.test.tsx
+++ b/lined-web/src/components/__tests__/AppShell.test.tsx
@@ -8,7 +8,7 @@ import { CREATE_MENU_TEXT } from '@/test/createMenuContent';
 
 describe('AppShell', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: 1, token: 'token' });
+    useAuthStore.setState({ userId: 1 });
     useCreateMenuStore.setState({ isCreateLobbyOpen: false, overlay: null, reserveSlotInitial: null });
   });
 

--- a/lined-web/src/components/__tests__/CreateLobbyModal.test.tsx
+++ b/lined-web/src/components/__tests__/CreateLobbyModal.test.tsx
@@ -24,7 +24,7 @@ function renderModal(onClose = vi.fn()) {
 
 describe('CreateLobbyModal', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: 1, token: 'token' });
+    useAuthStore.setState({ userId: 1 });
   });
 
   it('renders the name field, type picker, and hint text', () => {

--- a/lined-web/src/components/__tests__/EventDetailPanel.test.tsx
+++ b/lined-web/src/components/__tests__/EventDetailPanel.test.tsx
@@ -94,4 +94,22 @@ describe('EventDetailPanel', () => {
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it('shows a delete error message when deleteError is set', () => {
+    expect.assertions(1);
+    render(
+      <EventDetailPanel
+        event={BASE_EVENT}
+        lobby={LOBBY}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        deleteError="Could not delete this event — please try again"
+      />,
+    );
+
+    expect(
+      screen.getByText('Could not delete this event — please try again'),
+    ).toBeInTheDocument();
+  });
 });

--- a/lined-web/src/components/__tests__/RequireAuth.test.tsx
+++ b/lined-web/src/components/__tests__/RequireAuth.test.tsx
@@ -6,7 +6,7 @@ import { useAuthStore } from '@/store/auth';
 
 describe('RequireAuth', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: null, token: null });
+    useAuthStore.setState({ userId: null });
   });
 
   it('redirects to /sign-in when signed out', () => {
@@ -26,7 +26,7 @@ describe('RequireAuth', () => {
 
   it('renders the protected route when signed in', () => {
     expect.assertions(1);
-    useAuthStore.setState({ userId: 1, token: 'token' });
+    useAuthStore.setState({ userId: 1 });
     renderWithProviders(
       <Routes>
         <Route element={<RequireAuth />}>
@@ -43,12 +43,12 @@ describe('RequireAuth', () => {
 
 describe('RedirectIfAuthed', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: null, token: null });
+    useAuthStore.setState({ userId: null });
   });
 
   it('redirects home when already signed in', () => {
     expect.assertions(1);
-    useAuthStore.setState({ userId: 1, token: 'token' });
+    useAuthStore.setState({ userId: 1 });
     renderWithProviders(
       <Routes>
         <Route

--- a/lined-web/src/components/__tests__/ReserveSlotModal.test.tsx
+++ b/lined-web/src/components/__tests__/ReserveSlotModal.test.tsx
@@ -11,7 +11,7 @@ const LOBBY = MOCK_LOBBIES[0]!; // id 1, members [1, 2]
 const OTHER_LOBBY = MOCK_LOBBIES[1]!; // id 2, members [1, 2]
 
 beforeEach(() => {
-  useAuthStore.setState({ userId: 1, token: 'token' });
+  useAuthStore.setState({ userId: 1 });
 });
 
 describe('ReserveSlotModal — mode A (full slot, lobby known)', () => {

--- a/lined-web/src/components/__tests__/Sidebar.test.tsx
+++ b/lined-web/src/components/__tests__/Sidebar.test.tsx
@@ -22,7 +22,7 @@ function renderSidebar() {
 
 describe('Sidebar', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: 1, token: 'token' });
+    useAuthStore.setState({ userId: 1 });
     useCreateMenuStore.setState({ isCreateLobbyOpen: false });
   });
 
@@ -94,7 +94,7 @@ describe('Sidebar', () => {
   });
 
   it('signs out and redirects to /sign-in when the sign-out button is clicked', async () => {
-    expect.assertions(3);
+    expect.assertions(2);
     const user = userEvent.setup();
     renderSidebar();
     await screen.findByText('alex_johnson');
@@ -103,6 +103,5 @@ describe('Sidebar', () => {
 
     expect(await screen.findByText('Sign In Page')).toBeInTheDocument();
     expect(useAuthStore.getState().userId).toBeNull();
-    expect(useAuthStore.getState().token).toBeNull();
   });
 });

--- a/lined-web/src/components/dashboard/MyTasksList.tsx
+++ b/lined-web/src/components/dashboard/MyTasksList.tsx
@@ -2,22 +2,13 @@ import { Link } from 'react-router-dom';
 import type { TaskDto } from '@/types';
 import { TASK_STATUS_COLORS } from '@/lib/constants';
 import { formatTaskDueDate } from '@/lib/calendarUtils';
+import { sortTasksByDueDate } from '@/lib/taskUtils';
 import { StatusBadge } from './StatusBadge';
 
 const MAX_TASKS_SHOWN = 5;
 
 function sortTasks(tasks: TaskDto[]): TaskDto[] {
-  return [...tasks]
-    .sort((a, b) => {
-      if ((a.status === 'DONE') !== (b.status === 'DONE')) {
-        return a.status === 'DONE' ? 1 : -1;
-      }
-      if (a.dueDate == null && b.dueDate == null) return 0;
-      if (a.dueDate == null) return 1;
-      if (b.dueDate == null) return -1;
-      return a.dueDate.localeCompare(b.dueDate);
-    })
-    .slice(0, MAX_TASKS_SHOWN);
+  return sortTasksByDueDate(tasks).slice(0, MAX_TASKS_SHOWN);
 }
 
 interface MyTasksListProps {

--- a/lined-web/src/components/lobby/AddMemberModal.tsx
+++ b/lined-web/src/components/lobby/AddMemberModal.tsx
@@ -5,6 +5,7 @@ import type { LobbyDto } from '@/types';
 import { useUserSearch } from '@/hooks/useUsers';
 import { useCreateInvite } from '@/hooks/useInvites';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { useRowMutationState } from '@/hooks/useRowMutationState';
 import { SearchResultsList } from './SearchResultsList';
 
 interface AddMemberModalProps {
@@ -19,17 +20,10 @@ export const AddMemberModal = ({ lobby, onClose }: AddMemberModalProps) => {
   const createInvite = useCreateInvite(lobby.id);
 
   const [invitedIds, setInvitedIds] = useState<Set<number>>(new Set());
-  const [sendingId, setSendingId] = useState<number | null>(null);
-  const [rowErrors, setRowErrors] = useState<Record<number, string>>({});
+  const { busyId: sendingId, errors: rowErrors, start, finish, setError } = useRowMutationState();
 
   const handleInvite = (userId: number) => {
-    setSendingId(userId);
-    setRowErrors((prev) => {
-      if (!(userId in prev)) return prev;
-      const next = { ...prev };
-      delete next[userId];
-      return next;
-    });
+    start(userId);
 
     createInvite.mutate(
       { userId },
@@ -42,9 +36,9 @@ export const AddMemberModal = ({ lobby, onClose }: AddMemberModalProps) => {
             error instanceof HTTPError && error.response.status === 409
               ? 'Already a member or already invited'
               : "Couldn't send invite — try again";
-          setRowErrors((prev) => ({ ...prev, [userId]: message }));
+          setError(userId, message);
         },
-        onSettled: () => setSendingId(null),
+        onSettled: finish,
       },
     );
   };

--- a/lined-web/src/components/lobby/DayAgendaModal.tsx
+++ b/lined-web/src/components/lobby/DayAgendaModal.tsx
@@ -94,7 +94,7 @@ export function DayAgendaModal({
                   <li
                     key={i}
                     className="flex items-center gap-1.5 rounded-lg px-3.5 py-2 text-sm text-brand-green-dark"
-                    style={{ backgroundColor: '#B4EBD0', opacity: 0.6 }}
+                    style={{ backgroundColor: 'var(--color-free-slot)', opacity: 0.6 }}
                   >
                     <Sparkles className="h-3.5 w-3.5 flex-shrink-0" />
                     {formatHourRange(slot.startHour, slot.endHour)}

--- a/lined-web/src/components/lobby/DayAgendaModal.tsx
+++ b/lined-web/src/components/lobby/DayAgendaModal.tsx
@@ -1,6 +1,7 @@
 import { X, MapPin, Sparkles } from 'lucide-react';
 import type { EventDto, LobbyDto } from '@/types';
 import { formatClockTime, formatFullDate, formatHourRange, type FreeSlot } from '@/lib/calendarUtils';
+import { lobbyAccentColor } from '@/lib/constants';
 
 interface DayAgendaModalProps {
   day: Date;
@@ -22,7 +23,7 @@ export function DayAgendaModal({
   onClose,
 }: DayAgendaModalProps) {
   const sorted = [...events].sort((a, b) => a.startAt.localeCompare(b.startAt));
-  const accentColor = `var(--color-lobby-${lobby.lobbyType.toLowerCase()})`;
+  const accentColor = lobbyAccentColor(lobby.lobbyType);
 
   return (
     /* Backdrop */

--- a/lined-web/src/components/lobby/LobbyCalendarView.tsx
+++ b/lined-web/src/components/lobby/LobbyCalendarView.tsx
@@ -57,7 +57,7 @@ export function LobbyCalendarView({ lobby }: LobbyCalendarViewProps) {
 
   const legendItems: LegendItem[] = [
     { label: 'Shared event', color: lobbyAccentColor(lobby.lobbyType) },
-    { label: 'Free slot (both available)', color: '#B4EBD0' },
+    { label: 'Free slot (both available)', color: 'var(--color-free-slot)' },
   ];
 
   function handleDelete() {

--- a/lined-web/src/components/lobby/LobbyCalendarView.tsx
+++ b/lined-web/src/components/lobby/LobbyCalendarView.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { HTTPError } from 'ky';
 import type { LobbyDto } from '@/types';
 import { CalendarTopBar } from '@/components/CalendarTopBar';
 import { CreateEventModal } from '@/components/CreateEventModal';
@@ -24,6 +25,13 @@ interface LobbyCalendarViewProps {
   lobby: LobbyDto;
 }
 
+function getDeleteEventErrorMessage(error: unknown): string {
+  if (error instanceof HTTPError && error.response.status === 404) {
+    return 'This event was already deleted';
+  }
+  return 'Could not delete this event — please try again';
+}
+
 export function LobbyCalendarView({ lobby }: LobbyCalendarViewProps) {
   const [weekStart, setWeekStart] = useState(() => getWeekStart());
   const [viewMode, setViewMode] = useState<ViewMode>('week');
@@ -31,6 +39,7 @@ export function LobbyCalendarView({ lobby }: LobbyCalendarViewProps) {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [editingEvent, setEditingEvent] = useState<EventDto | null>(null);
   const [agendaDay, setAgendaDay] = useState<Date | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const { data: events, isLoading, isError } = useLobbyWeekEvents(lobby.id, weekStart);
   const { data: freeSlots } = useLobbyFreeSlots(lobby.id, weekStart);
@@ -52,8 +61,10 @@ export function LobbyCalendarView({ lobby }: LobbyCalendarViewProps) {
 
   function handleDelete() {
     if (selectedEventId == null) return;
+    setDeleteError(null);
     deleteEvent.mutate(selectedEventId, {
       onSuccess: () => setSelectedEventId(null),
+      onError: (error) => setDeleteError(getDeleteEventErrorMessage(error)),
     });
   }
 
@@ -84,7 +95,10 @@ export function LobbyCalendarView({ lobby }: LobbyCalendarViewProps) {
             events={events ?? []}
             lobbies={[lobby]}
             selectedEventId={selectedEventId}
-            onEventClick={setSelectedEventId}
+            onEventClick={(id) => {
+              setDeleteError(null);
+              setSelectedEventId(id);
+            }}
             getFreeSlotsForDay={(day) => freeSlotsForDay(freeSlots ?? [], day)}
             legendItems={legendItems}
             onDayClick={(day) => setAgendaDay(day)}
@@ -96,9 +110,13 @@ export function LobbyCalendarView({ lobby }: LobbyCalendarViewProps) {
             <EventDetailPanel
               event={selectedEvent}
               lobby={lobby}
-              onClose={() => setSelectedEventId(null)}
+              onClose={() => {
+                setDeleteError(null);
+                setSelectedEventId(null);
+              }}
               onEdit={() => setEditingEvent(selectedEvent)}
               onDelete={handleDelete}
+              deleteError={deleteError}
             />
           )}
         </div>

--- a/lined-web/src/components/lobby/LobbyCalendarView.tsx
+++ b/lined-web/src/components/lobby/LobbyCalendarView.tsx
@@ -17,6 +17,7 @@ import {
   type FreeSlot,
 } from '@/lib/calendarUtils';
 import { freeSlotsForDay } from '@/lib/freeSlots';
+import { lobbyAccentColor } from '@/lib/constants';
 import { useCreateMenuStore } from '@/store/createMenu';
 import type { ViewMode } from '@/store/calendar';
 import type { EventDto } from '@/types';
@@ -55,7 +56,7 @@ export function LobbyCalendarView({ lobby }: LobbyCalendarViewProps) {
     selectedEventId != null ? (events?.find((e) => e.id === selectedEventId) ?? null) : null;
 
   const legendItems: LegendItem[] = [
-    { label: 'Shared event', color: `var(--color-lobby-${lobby.lobbyType.toLowerCase()})` },
+    { label: 'Shared event', color: lobbyAccentColor(lobby.lobbyType) },
     { label: 'Free slot (both available)', color: '#B4EBD0' },
   ];
 

--- a/lined-web/src/components/lobby/LobbyDangerZoneCard.tsx
+++ b/lined-web/src/components/lobby/LobbyDangerZoneCard.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { HTTPError } from 'ky';
 import type { LobbyDto } from '@/types';
 import { useRemoveMember, useDeleteLobby } from '@/hooks/useLobbies';
+import { getApiErrorMessage } from '@/lib/apiErrors';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 
 interface LobbyDangerZoneCardProps {
@@ -13,10 +13,8 @@ interface LobbyDangerZoneCardProps {
 type PendingAction = 'leave' | 'delete' | null;
 
 function getLeaveErrorMessage(error: unknown): string {
-  if (error instanceof HTTPError && (error.response.status === 400 || error.response.status === 409)) {
-    return "You're the lobby owner — transfer ownership or delete the lobby instead of leaving";
-  }
-  return 'Could not leave this lobby — please try again';
+  const message = "You're the lobby owner — transfer ownership or delete the lobby instead of leaving";
+  return getApiErrorMessage(error, { 400: message, 409: message }, 'Could not leave this lobby — please try again');
 }
 
 export const LobbyDangerZoneCard = ({ lobby, currentUserId }: LobbyDangerZoneCardProps) => {

--- a/lined-web/src/components/lobby/LobbyGeneralCard.tsx
+++ b/lined-web/src/components/lobby/LobbyGeneralCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { HTTPError } from 'ky';
 import type { LobbyDto, LobbyType } from '@/types';
 import { useUpdateLobby } from '@/hooks/useLobbies';
+import { getApiErrorMessage } from '@/lib/apiErrors';
 import { LobbyTypePicker } from '@/components/LobbyTypePicker';
 import { SettingsCard } from '@/components/settings/SettingsCard';
 import { SettingsRow, SETTINGS_INPUT_CLASS } from '@/components/settings/SettingsRow';
@@ -12,13 +12,14 @@ interface LobbyGeneralCardProps {
 }
 
 function getLobbyUpdateErrorMessage(error: unknown): string {
-  if (error instanceof HTTPError && error.response.status === 403) {
-    return 'Only the lobby owner can update lobby settings';
-  }
-  if (error instanceof HTTPError && error.response.status === 400) {
-    return 'Enter a valid lobby name';
-  }
-  return 'Something went wrong — please try again';
+  return getApiErrorMessage(
+    error,
+    {
+      403: 'Only the lobby owner can update lobby settings',
+      400: 'Enter a valid lobby name',
+    },
+    'Something went wrong — please try again',
+  );
 }
 
 export const LobbyGeneralCard = ({ lobby, isOwner }: LobbyGeneralCardProps) => {

--- a/lined-web/src/components/lobby/LobbyLoadStates.tsx
+++ b/lined-web/src/components/lobby/LobbyLoadStates.tsx
@@ -1,0 +1,22 @@
+interface LobbyLoadStatesProps {
+  loadingTestId: string;
+}
+
+export function LobbyLoadingState({ loadingTestId }: LobbyLoadStatesProps) {
+  return (
+    <div className="flex-1 overflow-y-auto p-6">
+      <div className="h-24 animate-pulse rounded-xl bg-white" data-testid={loadingTestId} />
+      <div className="mt-4 h-10 w-64 animate-pulse rounded-lg bg-white" />
+    </div>
+  );
+}
+
+export function LobbyNotFoundState() {
+  return (
+    <div className="flex-1 overflow-y-auto p-6">
+      <p className="text-sm text-text-secondary">
+        Lobby not found. It may have been deleted, or you may not have access to it.
+      </p>
+    </div>
+  );
+}

--- a/lined-web/src/components/lobby/LobbyLoadStates.tsx
+++ b/lined-web/src/components/lobby/LobbyLoadStates.tsx
@@ -2,6 +2,7 @@ interface LobbyLoadStatesProps {
   loadingTestId: string;
 }
 
+/** Skeleton shown while a lobby is loading, shared by LobbyPage and LobbySettingsPage. */
 export function LobbyLoadingState({ loadingTestId }: LobbyLoadStatesProps) {
   return (
     <div className="flex-1 overflow-y-auto p-6">
@@ -11,6 +12,7 @@ export function LobbyLoadingState({ loadingTestId }: LobbyLoadStatesProps) {
   );
 }
 
+/** "Not found" message shown when a lobby is missing or inaccessible, shared by LobbyPage and LobbySettingsPage. */
 export function LobbyNotFoundState() {
   return (
     <div className="flex-1 overflow-y-auto p-6">

--- a/lined-web/src/components/lobby/LobbyTaskList.tsx
+++ b/lined-web/src/components/lobby/LobbyTaskList.tsx
@@ -5,6 +5,7 @@ import { useUsers } from '@/hooks/useUsers';
 import { useRowMutationState } from '@/hooks/useRowMutationState';
 import { useCreateMenuStore } from '@/store/createMenu';
 import { TASK_STATUS_LABELS } from '@/lib/constants';
+import { sortTasksByDueDate } from '@/lib/taskUtils';
 import { TaskRow } from './TaskRow';
 
 type FilterId = 'ALL' | TaskStatus;
@@ -15,17 +16,6 @@ const FILTERS: { id: FilterId; label: string }[] = [
   { id: 'IN_PROGRESS', label: TASK_STATUS_LABELS.IN_PROGRESS },
   { id: 'DONE', label: TASK_STATUS_LABELS.DONE },
 ];
-
-const sortByDueDate = (tasks: TaskDto[]): TaskDto[] =>
-  [...tasks].sort((a, b) => {
-    if ((a.status === 'DONE') !== (b.status === 'DONE')) {
-      return a.status === 'DONE' ? 1 : -1;
-    }
-    if (a.dueDate == null && b.dueDate == null) return 0;
-    if (a.dueDate == null) return 1;
-    if (b.dueDate == null) return -1;
-    return a.dueDate.localeCompare(b.dueDate);
-  });
 
 interface TaskListContentProps {
   isLoading: boolean;
@@ -113,7 +103,7 @@ export const LobbyTaskList = ({ lobbyId }: LobbyTaskListProps) => {
   };
 
   const filtered = (tasks ?? []).filter((t) => filter === 'ALL' || t.status === filter);
-  const sorted = sortByDueDate(filtered);
+  const sorted = sortTasksByDueDate(filtered);
 
   const handleToggle = (task: TaskDto) => {
     const nextStatus: TaskStatus = task.status === 'DONE' ? 'TODO' : 'DONE';

--- a/lined-web/src/components/lobby/LobbyTaskList.tsx
+++ b/lined-web/src/components/lobby/LobbyTaskList.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { TaskDto, TaskStatus, UserDto } from '@/types';
 import { useLobbyTasks, useUpdateTask } from '@/hooks/useTasks';
 import { useUsers } from '@/hooks/useUsers';
+import { useRowMutationState } from '@/hooks/useRowMutationState';
 import { useCreateMenuStore } from '@/store/createMenu';
 import { TASK_STATUS_LABELS } from '@/lib/constants';
 import { TaskRow } from './TaskRow';
@@ -96,8 +97,7 @@ export const LobbyTaskList = ({ lobbyId }: LobbyTaskListProps) => {
   const updateTask = useUpdateTask(lobbyId);
   const openOverlay = useCreateMenuStore((s) => s.openOverlay);
   const [filter, setFilter] = useState<FilterId>('ALL');
-  const [updatingTaskId, setUpdatingTaskId] = useState<number | null>(null);
-  const [rowErrors, setRowErrors] = useState<Record<number, string>>({});
+  const { busyId: updatingTaskId, errors: rowErrors, start, finish, setError } = useRowMutationState();
 
   const assigneeIds = Array.from(
     new Set((tasks ?? []).map((t) => t.assigneeId).filter((id): id is number => id != null)),
@@ -117,19 +117,12 @@ export const LobbyTaskList = ({ lobbyId }: LobbyTaskListProps) => {
 
   const handleToggle = (task: TaskDto) => {
     const nextStatus: TaskStatus = task.status === 'DONE' ? 'TODO' : 'DONE';
-    setUpdatingTaskId(task.id);
-    setRowErrors((prev) => {
-      if (!(task.id in prev)) return prev;
-      const next = { ...prev };
-      delete next[task.id];
-      return next;
-    });
+    start(task.id);
     updateTask.mutate(
       { id: task.id, data: { status: nextStatus } },
       {
-        onSettled: () => setUpdatingTaskId(null),
-        onError: () =>
-          setRowErrors((prev) => ({ ...prev, [task.id]: "Couldn't update — try again" })),
+        onSettled: finish,
+        onError: () => setError(task.id, "Couldn't update — try again"),
       },
     );
   };

--- a/lined-web/src/components/lobby/PendingInvitesSection.tsx
+++ b/lined-web/src/components/lobby/PendingInvitesSection.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
 import type { LobbyInviteDto } from '@/types';
 import { useResendInvite, useCancelInvite } from '@/hooks/useInvites';
+import { useRowMutationState } from '@/hooks/useRowMutationState';
 import { PendingInviteRow } from './PendingInviteRow';
 
 interface PendingInvitesSectionProps {
@@ -18,34 +18,21 @@ export const PendingInvitesSection = ({
 }: PendingInvitesSectionProps) => {
   const resendInvite = useResendInvite(lobbyId);
   const cancelInvite = useCancelInvite(lobbyId);
-  const [busyId, setBusyId] = useState<number | null>(null);
-  const [rowErrors, setRowErrors] = useState<Record<number, string>>({});
-
-  const clearRowError = (inviteId: number) =>
-    setRowErrors((prev) => {
-      if (!(inviteId in prev)) return prev;
-      const next = { ...prev };
-      delete next[inviteId];
-      return next;
-    });
+  const { busyId, errors: rowErrors, start, finish, setError } = useRowMutationState();
 
   const handleResend = (inviteId: number) => {
-    setBusyId(inviteId);
-    clearRowError(inviteId);
+    start(inviteId);
     resendInvite.mutate(inviteId, {
-      onSettled: () => setBusyId(null),
-      onError: () =>
-        setRowErrors((prev) => ({ ...prev, [inviteId]: "Couldn't resend — try again" })),
+      onSettled: finish,
+      onError: () => setError(inviteId, "Couldn't resend — try again"),
     });
   };
 
   const handleCancel = (inviteId: number) => {
-    setBusyId(inviteId);
-    clearRowError(inviteId);
+    start(inviteId);
     cancelInvite.mutate(inviteId, {
-      onSettled: () => setBusyId(null),
-      onError: () =>
-        setRowErrors((prev) => ({ ...prev, [inviteId]: "Couldn't cancel — try again" })),
+      onSettled: finish,
+      onError: () => setError(inviteId, "Couldn't cancel — try again"),
     });
   };
 

--- a/lined-web/src/components/lobby/__tests__/LobbyCalendarView.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/LobbyCalendarView.test.tsx
@@ -142,6 +142,25 @@ describe('LobbyCalendarView', () => {
     expect(screen.queryByRole('button', { name: 'Edit event' })).not.toBeInTheDocument();
   });
 
+  it('shows an inline error and keeps the panel open when the delete request fails', async () => {
+    expect.assertions(1);
+    server.use(
+      http.get(`${BASE}/calendar/events`, () =>
+        HttpResponse.json([makeEvent(1, LOBBY.id, 9, 'Morning Coffee')]),
+      ),
+      http.delete(`${BASE}/calendar/events/:id`, () => new HttpResponse(null, { status: 500 })),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<LobbyCalendarView lobby={LOBBY} />);
+    await user.click(await screen.findByText('Morning Coffee'));
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(
+      await screen.findByText('Could not delete this event — please try again'),
+    ).toBeInTheDocument();
+  });
+
   it('clicking a free-slot band opens the reserve-slot overlay locked to this lobby', async () => {
     expect.assertions(2);
     const today = new Date();

--- a/lined-web/src/components/lobby/__tests__/LobbyMemberList.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/LobbyMemberList.test.tsx
@@ -19,7 +19,7 @@ const lobby = MOCK_LOBBIES[0]!; // id 1, ownerId 1, memberIds [1, 2] (Alex owner
 
 describe('LobbyMemberList', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: 1, token: 'token' });
+    useAuthStore.setState({ userId: 1 });
   });
 
   it('shows a loading state while members are being fetched', () => {
@@ -67,7 +67,7 @@ describe('LobbyMemberList', () => {
 
   it('hides management actions and the Pending Invites section for a non-owner viewer', async () => {
     expect.assertions(3);
-    useAuthStore.setState({ userId: 2, token: 'token' });
+    useAuthStore.setState({ userId: 2 });
     renderWithProviders(<LobbyMemberList lobby={lobby} />);
 
     expect(await screen.findByText(MEMBER_CARD_TEXT.thatsYou)).toBeInTheDocument();

--- a/lined-web/src/components/settings/DangerZoneCard.tsx
+++ b/lined-web/src/components/settings/DangerZoneCard.tsx
@@ -19,7 +19,6 @@ function getDeleteErrorMessage(error: unknown): string {
 export const DangerZoneCard = ({ userId }: DangerZoneCardProps) => {
   const navigate = useNavigate();
   const setUserId = useAuthStore((s) => s.setUserId);
-  const setToken = useAuthStore((s) => s.setToken);
   const deleteAccount = useDeleteAccount(userId ?? 0);
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
 
@@ -27,7 +26,6 @@ export const DangerZoneCard = ({ userId }: DangerZoneCardProps) => {
     deleteAccount.mutate(undefined, {
       onSuccess: () => {
         setUserId(null);
-        setToken(null);
         navigate('/sign-in');
       },
     });

--- a/lined-web/src/components/settings/DangerZoneCard.tsx
+++ b/lined-web/src/components/settings/DangerZoneCard.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { HTTPError } from 'ky';
 import { useDeleteAccount } from '@/hooks/useUserSettings';
 import { useAuthStore } from '@/store/auth';
+import { getApiErrorMessage } from '@/lib/apiErrors';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 
 interface DangerZoneCardProps {
@@ -10,10 +10,11 @@ interface DangerZoneCardProps {
 }
 
 function getDeleteErrorMessage(error: unknown): string {
-  if (error instanceof HTTPError && error.response.status === 409) {
-    return 'You still own one or more lobbies — transfer ownership or delete them first';
-  }
-  return 'Could not delete your account — please try again';
+  return getApiErrorMessage(
+    error,
+    { 409: 'You still own one or more lobbies — transfer ownership or delete them first' },
+    'Could not delete your account — please try again',
+  );
 }
 
 export const DangerZoneCard = ({ userId }: DangerZoneCardProps) => {

--- a/lined-web/src/components/settings/PasswordCard.tsx
+++ b/lined-web/src/components/settings/PasswordCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { HTTPError } from 'ky';
 import { useUpdateUser } from '@/hooks/useUserSettings';
+import { getApiErrorMessage } from '@/lib/apiErrors';
 import { SettingsCard } from './SettingsCard';
 import { SettingsRow, SETTINGS_INPUT_CLASS } from './SettingsRow';
 
@@ -11,10 +11,11 @@ interface PasswordCardProps {
 }
 
 function getPasswordErrorMessage(error: unknown): string {
-  if (error instanceof HTTPError && error.response.status === 400) {
-    return 'Enter a valid password';
-  }
-  return 'Something went wrong — please try again';
+  return getApiErrorMessage(
+    error,
+    { 400: 'Enter a valid password' },
+    'Something went wrong — please try again',
+  );
 }
 
 export const PasswordCard = ({ userId }: PasswordCardProps) => {

--- a/lined-web/src/components/settings/ProfileCard.tsx
+++ b/lined-web/src/components/settings/ProfileCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { HTTPError } from 'ky';
 import type { UserDto } from '@/types';
 import { useUpdateUser } from '@/hooks/useUserSettings';
+import { getApiErrorMessage } from '@/lib/apiErrors';
 import { SettingsCard } from './SettingsCard';
 import { SettingsRow, SETTINGS_INPUT_CLASS } from './SettingsRow';
 
@@ -11,13 +11,14 @@ interface ProfileCardProps {
 }
 
 function getProfileErrorMessage(error: unknown): string {
-  if (error instanceof HTTPError && error.response.status === 409) {
-    return 'That username or email is already taken';
-  }
-  if (error instanceof HTTPError && error.response.status === 400) {
-    return 'Enter a valid username and email';
-  }
-  return 'Something went wrong — please try again';
+  return getApiErrorMessage(
+    error,
+    {
+      409: 'That username or email is already taken',
+      400: 'Enter a valid username and email',
+    },
+    'Something went wrong — please try again',
+  );
 }
 
 export const ProfileCard = ({ user, isLoading }: ProfileCardProps) => {

--- a/lined-web/src/components/settings/__tests__/DangerZoneCard.test.tsx
+++ b/lined-web/src/components/settings/__tests__/DangerZoneCard.test.tsx
@@ -23,7 +23,7 @@ function renderCard(userId: number | undefined) {
 
 describe('DangerZoneCard', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: lobbyOwner.id, token: 'token' });
+    useAuthStore.setState({ userId: lobbyOwner.id });
   });
 
   it('renders the Delete account button disabled when there is no user yet', () => {
@@ -74,7 +74,7 @@ describe('DangerZoneCard', () => {
 
   it('signs out and navigates to sign-in on success', async () => {
     expect.assertions(2);
-    useAuthStore.setState({ userId: noLobbyUser.id, token: 'token' });
+    useAuthStore.setState({ userId: noLobbyUser.id });
     const user = userEvent.setup();
     renderCard(noLobbyUser.id);
 

--- a/lined-web/src/components/settings/__tests__/NotificationsCard.test.tsx
+++ b/lined-web/src/components/settings/__tests__/NotificationsCard.test.tsx
@@ -9,7 +9,7 @@ const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
 
 describe('NotificationsCard', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: 1, token: 'token' });
+    useAuthStore.setState({ userId: 1 });
   });
 
   it('shows a loading skeleton before preferences load', () => {

--- a/lined-web/src/components/settings/__tests__/PasswordCard.test.tsx
+++ b/lined-web/src/components/settings/__tests__/PasswordCard.test.tsx
@@ -11,7 +11,7 @@ const user = MOCK_USERS[0]!;
 
 describe('PasswordCard', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: user.id, token: 'token' });
+    useAuthStore.setState({ userId: user.id });
   });
 
   it('keeps Change password disabled until both fields are filled in', async () => {

--- a/lined-web/src/components/settings/__tests__/ProfileCard.test.tsx
+++ b/lined-web/src/components/settings/__tests__/ProfileCard.test.tsx
@@ -11,7 +11,7 @@ const user = MOCK_USERS[0]!;
 
 describe('ProfileCard', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: user.id, token: 'token' });
+    useAuthStore.setState({ userId: user.id });
   });
 
   it('shows a loading skeleton while the user is loading', () => {

--- a/lined-web/src/components/tasks/KanbanBoard.tsx
+++ b/lined-web/src/components/tasks/KanbanBoard.tsx
@@ -7,7 +7,7 @@ import { useRowMutationState } from '@/hooks/useRowMutationState';
 import { useCreateMenuStore } from '@/store/createMenu';
 import { STATUS_ORDER, filterTasks, groupTasksByStatus, type TaskDateFilter } from '@/lib/taskUtils';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
-import { KanbanColumn } from './KanbanColumn';
+import { KanbanColumn, type KanbanActions, type KanbanMoveState } from './KanbanColumn';
 import { KanbanFilters } from './KanbanFilters';
 import { KANBAN_TEST_IDS, KANBAN_TEXT } from './kanbanConstants';
 
@@ -34,12 +34,8 @@ interface KanbanBoardContentProps {
   grouped: Record<TaskStatus, TaskDto[]>;
   lobbiesById: Map<number, LobbyDto>;
   assigneesById: Map<number, UserDto | undefined>;
-  movingTaskId: number | null;
-  moveErrors: Record<number, string>;
-  onMove: (task: TaskDto, direction: 'prev' | 'next') => void;
-  onDelete: (task: TaskDto) => void;
-  onQuickAdd: (status: TaskStatus) => void;
-  onDropTask: (taskId: number, status: TaskStatus) => void;
+  moveState: KanbanMoveState;
+  actions: KanbanActions;
 }
 
 /** Loading skeleton, error message, or the 3-column board — whichever applies. */
@@ -49,12 +45,8 @@ const KanbanBoardContent = ({
   grouped,
   lobbiesById,
   assigneesById,
-  movingTaskId,
-  moveErrors,
-  onMove,
-  onDelete,
-  onQuickAdd,
-  onDropTask,
+  moveState,
+  actions,
 }: KanbanBoardContentProps) => {
   if (isLoading) return <KanbanBoardSkeleton />;
 
@@ -71,12 +63,8 @@ const KanbanBoardContent = ({
           tasks={grouped[status]}
           lobbiesById={lobbiesById}
           assigneesById={assigneesById}
-          movingTaskId={movingTaskId}
-          moveErrors={moveErrors}
-          onMove={onMove}
-          onDelete={onDelete}
-          onQuickAdd={onQuickAdd}
-          onDropTask={onDropTask}
+          moveState={moveState}
+          actions={actions}
         />
       ))}
     </div>
@@ -185,12 +173,13 @@ export const KanbanBoard = () => {
         grouped={grouped}
         lobbiesById={lobbiesById}
         assigneesById={assigneesById}
-        movingTaskId={movingTaskId}
-        moveErrors={moveErrors}
-        onMove={handleMove}
-        onDelete={handleDelete}
-        onQuickAdd={handleQuickAdd}
-        onDropTask={handleDropTask}
+        moveState={{ movingTaskId, moveErrors }}
+        actions={{
+          onMove: handleMove,
+          onDelete: handleDelete,
+          onQuickAdd: handleQuickAdd,
+          onDropTask: handleDropTask,
+        }}
       />
 
       {pendingDelete && (

--- a/lined-web/src/components/tasks/KanbanBoard.tsx
+++ b/lined-web/src/components/tasks/KanbanBoard.tsx
@@ -3,6 +3,7 @@ import type { LobbyDto, TaskDto, TaskStatus, UserDto } from '@/types';
 import { useMyTasks, useUpdateTaskStatus, useDeleteTask } from '@/hooks/useTasks';
 import { useMyLobbies } from '@/hooks/useLobbies';
 import { useUsers } from '@/hooks/useUsers';
+import { useRowMutationState } from '@/hooks/useRowMutationState';
 import { useCreateMenuStore } from '@/store/createMenu';
 import { STATUS_ORDER, filterTasks, groupTasksByStatus, type TaskDateFilter } from '@/lib/taskUtils';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
@@ -97,8 +98,7 @@ export const KanbanBoard = () => {
   const [memberId, setMemberId] = useState<number | undefined>(undefined);
   const [dateFilter, setDateFilter] = useState<TaskDateFilter>('ALL');
 
-  const [movingTaskId, setMovingTaskId] = useState<number | null>(null);
-  const [moveErrors, setMoveErrors] = useState<Record<number, string>>({});
+  const { busyId: movingTaskId, errors: moveErrors, start, finish, setError } = useRowMutationState();
   const [pendingDelete, setPendingDelete] = useState<TaskDto | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
@@ -111,19 +111,13 @@ export const KanbanBoard = () => {
   const moveTaskToStatus = (task: TaskDto, nextStatus: TaskStatus) => {
     if (nextStatus === task.status) return;
 
-    setMovingTaskId(task.id);
-    setMoveErrors((prev) => {
-      if (!(task.id in prev)) return prev;
-      const next = { ...prev };
-      delete next[task.id];
-      return next;
-    });
+    start(task.id);
 
     updateTaskStatus.mutate(
       { id: task.id, status: nextStatus },
       {
-        onSettled: () => setMovingTaskId(null),
-        onError: () => setMoveErrors((prev) => ({ ...prev, [task.id]: KANBAN_TEXT.moveError })),
+        onSettled: finish,
+        onError: () => setError(task.id, KANBAN_TEXT.moveError),
       },
     );
   };

--- a/lined-web/src/components/tasks/KanbanColumn.tsx
+++ b/lined-web/src/components/tasks/KanbanColumn.tsx
@@ -5,17 +5,25 @@ import { TASK_STATUS_BADGE_CLASSES, TASK_STATUS_COLORS, TASK_STATUS_LABELS } fro
 import { KanbanCard, TASK_DRAG_DATA_FORMAT } from './KanbanCard';
 import { KANBAN_LABELS, KANBAN_TEST_IDS, KANBAN_TEXT } from './kanbanConstants';
 
+export interface KanbanMoveState {
+  movingTaskId: number | null;
+  moveErrors: Record<number, string>;
+}
+
+export interface KanbanActions {
+  onMove: (task: TaskDto, direction: 'prev' | 'next') => void;
+  onDelete: (task: TaskDto) => void;
+  onQuickAdd: (status: TaskStatus) => void;
+  onDropTask: (taskId: number, status: TaskStatus) => void;
+}
+
 interface KanbanColumnProps {
   status: TaskStatus;
   tasks: TaskDto[];
   lobbiesById: Map<number, LobbyDto>;
   assigneesById: Map<number, UserDto | undefined>;
-  movingTaskId: number | null;
-  moveErrors: Record<number, string>;
-  onMove: (task: TaskDto, direction: 'prev' | 'next') => void;
-  onDelete: (task: TaskDto) => void;
-  onQuickAdd: (status: TaskStatus) => void;
-  onDropTask: (taskId: number, status: TaskStatus) => void;
+  moveState: KanbanMoveState;
+  actions: KanbanActions;
 }
 
 interface KanbanCardListProps {
@@ -23,10 +31,8 @@ interface KanbanCardListProps {
   tasks: TaskDto[];
   lobbiesById: Map<number, LobbyDto>;
   assigneesById: Map<number, UserDto | undefined>;
-  movingTaskId: number | null;
-  moveErrors: Record<number, string>;
-  onMove: KanbanColumnProps['onMove'];
-  onDelete: KanbanColumnProps['onDelete'];
+  moveState: KanbanMoveState;
+  actions: Pick<KanbanActions, 'onMove' | 'onDelete'>;
 }
 
 /** The column's card stack, or an empty-state message when it has no tasks. */
@@ -35,10 +41,8 @@ const KanbanCardList = ({
   tasks,
   lobbiesById,
   assigneesById,
-  movingTaskId,
-  moveErrors,
-  onMove,
-  onDelete,
+  moveState,
+  actions,
 }: KanbanCardListProps) => {
   if (tasks.length === 0) {
     return <p className="text-xs text-text-secondary">No tasks in {TASK_STATUS_LABELS[status]}.</p>;
@@ -52,10 +56,10 @@ const KanbanCardList = ({
           task={task}
           lobby={lobbiesById.get(task.lobbyId)}
           assignee={task.assigneeId != null ? assigneesById.get(task.assigneeId) : undefined}
-          isMoving={movingTaskId === task.id}
-          moveError={moveErrors[task.id]}
-          onMove={onMove}
-          onDelete={onDelete}
+          isMoving={moveState.movingTaskId === task.id}
+          moveError={moveState.moveErrors[task.id]}
+          onMove={actions.onMove}
+          onDelete={actions.onDelete}
         />
       ))}
     </>
@@ -67,12 +71,8 @@ export const KanbanColumn = ({
   tasks,
   lobbiesById,
   assigneesById,
-  movingTaskId,
-  moveErrors,
-  onMove,
-  onDelete,
-  onQuickAdd,
-  onDropTask,
+  moveState,
+  actions,
 }: KanbanColumnProps) => {
   const [isDragOver, setIsDragOver] = useState(false);
 
@@ -87,7 +87,7 @@ export const KanbanColumn = ({
     e.preventDefault();
     setIsDragOver(false);
     const taskId = Number(e.dataTransfer.getData(TASK_DRAG_DATA_FORMAT));
-    if (taskId) onDropTask(taskId, status);
+    if (taskId) actions.onDropTask(taskId, status);
   };
 
   return (
@@ -111,7 +111,7 @@ export const KanbanColumn = ({
         <button
           type="button"
           aria-label={KANBAN_LABELS.addTaskToColumn(TASK_STATUS_LABELS[status])}
-          onClick={() => onQuickAdd(status)}
+          onClick={() => actions.onQuickAdd(status)}
           className="ml-auto text-lg leading-none text-text-secondary hover:text-brand-green"
         >
           +
@@ -124,16 +124,14 @@ export const KanbanColumn = ({
           tasks={tasks}
           lobbiesById={lobbiesById}
           assigneesById={assigneesById}
-          movingTaskId={movingTaskId}
-          moveErrors={moveErrors}
-          onMove={onMove}
-          onDelete={onDelete}
+          moveState={moveState}
+          actions={actions}
         />
       </div>
 
       <button
         type="button"
-        onClick={() => onQuickAdd(status)}
+        onClick={() => actions.onQuickAdd(status)}
         className="mt-2.5 w-full rounded-lg border-2 border-dashed border-border py-2 text-xs font-medium text-text-secondary hover:border-brand-green hover:text-brand-green"
       >
         {KANBAN_TEXT.addTask}

--- a/lined-web/src/hooks/__tests__/useFormState.test.ts
+++ b/lined-web/src/hooks/__tests__/useFormState.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useFormState } from '../useFormState';
+
+interface Values {
+  name: string;
+  age: string;
+}
+
+function validate(values: Values): Partial<Record<keyof Values, string>> {
+  const errors: Partial<Record<keyof Values, string>> = {};
+  if (!values.name.trim()) errors.name = 'Name is required';
+  return errors;
+}
+
+describe('useFormState', () => {
+  it('updates a single field via set without touching the others', () => {
+    expect.assertions(2);
+    const { result } = renderHook(() => useFormState<Values>({ name: '', age: '' }, validate));
+
+    act(() => result.current.set('name', 'Alex'));
+
+    expect(result.current.values.name).toBe('Alex');
+    expect(result.current.values.age).toBe('');
+  });
+
+  it('tracks hasErrors and per-field touched state', () => {
+    expect.assertions(3);
+    const { result } = renderHook(() => useFormState<Values>({ name: '', age: '' }, validate));
+
+    expect(result.current.hasErrors).toBe(true);
+
+    act(() => result.current.markTouched('name'));
+    expect(result.current.touched.name).toBe(true);
+    expect(result.current.touched.age).toBeUndefined();
+  });
+
+  it('markAllTouched marks every field as touched', () => {
+    expect.assertions(2);
+    const { result } = renderHook(() => useFormState<Values>({ name: '', age: '' }, validate));
+
+    act(() => result.current.markAllTouched());
+
+    expect(result.current.touched.name).toBe(true);
+    expect(result.current.touched.age).toBe(true);
+  });
+});

--- a/lined-web/src/hooks/__tests__/useRowMutationState.test.ts
+++ b/lined-web/src/hooks/__tests__/useRowMutationState.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useRowMutationState } from '../useRowMutationState';
+
+describe('useRowMutationState', () => {
+  it('start marks a row busy and clears any stale error for it', () => {
+    expect.assertions(2);
+    const { result } = renderHook(() => useRowMutationState());
+
+    act(() => result.current.setError(1, 'failed'));
+    act(() => result.current.start(1));
+
+    expect(result.current.busyId).toBe(1);
+    expect(result.current.errors[1]).toBeUndefined();
+  });
+
+  it('finish clears the busy row without touching errors', () => {
+    expect.assertions(2);
+    const { result } = renderHook(() => useRowMutationState());
+
+    act(() => result.current.start(2));
+    act(() => result.current.setError(2, 'failed'));
+    act(() => result.current.finish());
+
+    expect(result.current.busyId).toBeNull();
+    expect(result.current.errors[2]).toBe('failed');
+  });
+});

--- a/lined-web/src/hooks/__tests__/useTasks.test.tsx
+++ b/lined-web/src/hooks/__tests__/useTasks.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { server } from '@/test/server';
+import { QUERY_KEYS } from '@/lib/constants';
+import type { TaskDto } from '@/types';
+import { useDeleteTask, useUpdateTaskStatus } from '../useTasks';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+
+const makeTask = (overrides: Partial<TaskDto>): TaskDto => ({
+  id: 1,
+  title: 'Task',
+  description: null,
+  priority: 'MEDIUM',
+  status: 'TODO',
+  lobbyId: 1,
+  creatorId: 1,
+  assigneeId: null,
+  dueDate: null,
+  createdAt: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
+function makeWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useUpdateTaskStatus', () => {
+  it('patches both the myTasks cache and any cached lobbyTasks list', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const task = makeTask({ id: 1, lobbyId: 1, status: 'TODO' });
+    queryClient.setQueryData(QUERY_KEYS.myTasks, [task]);
+    queryClient.setQueryData(QUERY_KEYS.lobbyTasks(1), [task]);
+    server.use(
+      http.patch(`${BASE}/tasks/:id`, async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ ...task, ...body });
+      }),
+    );
+
+    const { result } = renderHook(() => useUpdateTaskStatus(), {
+      wrapper: makeWrapper(queryClient),
+    });
+    result.current.mutate({ id: 1, status: 'IN_PROGRESS' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryClient.getQueryData<TaskDto[]>(QUERY_KEYS.myTasks)?.[0]?.status).toBe(
+      'IN_PROGRESS',
+    );
+    expect(queryClient.getQueryData<TaskDto[]>(QUERY_KEYS.lobbyTasks(1))?.[0]?.status).toBe(
+      'IN_PROGRESS',
+    );
+  });
+});
+
+describe('useDeleteTask', () => {
+  it('removes the task from both the myTasks cache and any cached lobbyTasks list', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const task = makeTask({ id: 1, lobbyId: 1 });
+    queryClient.setQueryData(QUERY_KEYS.myTasks, [task]);
+    queryClient.setQueryData(QUERY_KEYS.lobbyTasks(1), [task]);
+    server.use(http.delete(`${BASE}/tasks/:id`, () => new HttpResponse(null, { status: 204 })));
+
+    const { result } = renderHook(() => useDeleteTask(), { wrapper: makeWrapper(queryClient) });
+    result.current.mutate(1);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryClient.getQueryData<TaskDto[]>(QUERY_KEYS.myTasks)).toEqual([]);
+    expect(queryClient.getQueryData<TaskDto[]>(QUERY_KEYS.lobbyTasks(1))).toEqual([]);
+  });
+});

--- a/lined-web/src/hooks/useDashboard.ts
+++ b/lined-web/src/hooks/useDashboard.ts
@@ -7,8 +7,8 @@ import { useAuthStore } from '@/store/auth';
 import { useMyLobbies } from './useLobbies';
 import { useUser } from './useUsers';
 
-const FREE_SLOT_WINDOW_DAYS = 7;
-const MIN_SLOT_MS = 60 * 60 * 1000; // 1 hour
+const FREE_SLOTS_WINDOW_DAYS = 7;
+const MIN_FREE_SLOT_MS = 60 * 60 * 1000; // 1 hour
 
 export interface FreeSlotBannerData {
   lobbyId: number;
@@ -31,7 +31,7 @@ export function useFreeSlotBanner(): {
   const targetLobby = lobbies?.find((l) => l.memberIds.length > 1) ?? null;
 
   const from = new Date();
-  const to = addDays(from, FREE_SLOT_WINDOW_DAYS);
+  const to = addDays(from, FREE_SLOTS_WINDOW_DAYS);
 
   const freeSlotsQuery = useQuery({
     queryKey: [
@@ -45,7 +45,7 @@ export function useFreeSlotBanner(): {
 
   const slot =
     freeSlotsQuery.data?.find(
-      (s) => new Date(s.end).getTime() - new Date(s.start).getTime() >= MIN_SLOT_MS,
+      (s) => new Date(s.end).getTime() - new Date(s.start).getTime() >= MIN_FREE_SLOT_MS,
     ) ?? null;
 
   const otherMemberId = targetLobby?.memberIds.find((id) => id !== currentUserId);
@@ -73,9 +73,6 @@ export interface FreeSlotCandidate {
   end: string;
 }
 
-const CANDIDATE_WINDOW_DAYS = 7;
-const MIN_CANDIDATE_MS = 60 * 60 * 1000; // 1 hour
-
 /**
  * Earliest ≥1h mutual free slot per multi-member lobby (next 7 days), sorted
  * soonest-first. Used by ReserveSlotModal when opened with no specific slot
@@ -87,7 +84,7 @@ export function useFreeSlotCandidates(lobbies: LobbyDto[]): {
 } {
   const multiMemberLobbies = lobbies.filter((l) => l.memberIds.length > 1);
   const from = new Date();
-  const to = addDays(from, CANDIDATE_WINDOW_DAYS);
+  const to = addDays(from, FREE_SLOTS_WINDOW_DAYS);
   const fromKey = from.toISOString().slice(0, 10);
 
   const queries = useQueries({
@@ -100,7 +97,7 @@ export function useFreeSlotCandidates(lobbies: LobbyDto[]): {
   const candidates: FreeSlotCandidate[] = multiMemberLobbies
     .map((lobby, i) => {
       const slot = queries[i]?.data?.find(
-        (s) => new Date(s.end).getTime() - new Date(s.start).getTime() >= MIN_CANDIDATE_MS,
+        (s) => new Date(s.end).getTime() - new Date(s.start).getTime() >= MIN_FREE_SLOT_MS,
       );
       return slot ? { lobby, start: slot.start, end: slot.end } : null;
     })
@@ -110,12 +107,10 @@ export function useFreeSlotCandidates(lobbies: LobbyDto[]): {
   return { candidates, isLoading: queries.some((q) => q.isLoading) };
 }
 
-const LOBBY_FREE_SLOTS_WINDOW_DAYS = 7;
-
 /** Free slots for one lobby over the visible week, used by the lobby calendar tab. */
 export function useLobbyFreeSlots(lobbyId: number, weekStart: Date) {
   const from = weekStart.toISOString();
-  const to = addDays(weekStart, LOBBY_FREE_SLOTS_WINDOW_DAYS).toISOString();
+  const to = addDays(weekStart, FREE_SLOTS_WINDOW_DAYS).toISOString();
 
   return useQuery<FreeSlotDto[]>({
     queryKey: [...QUERY_KEYS.lobbyFreeSlots(lobbyId), from.slice(0, 10)],

--- a/lined-web/src/hooks/useDashboard.ts
+++ b/lined-web/src/hooks/useDashboard.ts
@@ -18,6 +18,16 @@ export interface FreeSlotBannerData {
   otherUsername: string | null;
 }
 
+/** First slot at least `minMs` long, or null if none qualify. */
+function findEarliestFreeSlot(
+  slots: FreeSlotDto[] | undefined,
+  minMs: number,
+): FreeSlotDto | null {
+  return (
+    slots?.find((s) => new Date(s.end).getTime() - new Date(s.start).getTime() >= minMs) ?? null
+  );
+}
+
 /**
  * Surfaces the earliest ≥1h mutual free slot (next 7 days) for the current
  * user's first multi-member lobby, using the server-side free-slots API.
@@ -43,11 +53,7 @@ export function useFreeSlotBanner(): {
     enabled: targetLobby != null,
   });
 
-  const slot =
-    freeSlotsQuery.data?.find(
-      (s) => new Date(s.end).getTime() - new Date(s.start).getTime() >= MIN_FREE_SLOT_MS,
-    ) ?? null;
-
+  const slot = findEarliestFreeSlot(freeSlotsQuery.data, MIN_FREE_SLOT_MS);
   const otherMemberId = targetLobby?.memberIds.find((id) => id !== currentUserId);
   const otherUserQuery = useUser(slot ? otherMemberId : undefined);
 
@@ -96,9 +102,7 @@ export function useFreeSlotCandidates(lobbies: LobbyDto[]): {
 
   const candidates: FreeSlotCandidate[] = multiMemberLobbies
     .map((lobby, i) => {
-      const slot = queries[i]?.data?.find(
-        (s) => new Date(s.end).getTime() - new Date(s.start).getTime() >= MIN_FREE_SLOT_MS,
-      );
+      const slot = findEarliestFreeSlot(queries[i]?.data, MIN_FREE_SLOT_MS);
       return slot ? { lobby, start: slot.start, end: slot.end } : null;
     })
     .filter((c): c is FreeSlotCandidate => c != null)

--- a/lined-web/src/hooks/useFormState.ts
+++ b/lined-web/src/hooks/useFormState.ts
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+
+/**
+ * Shared values/touched/validate bookkeeping for a plain client-side form.
+ * `validate` is expected to be pure and is re-run on every render.
+ */
+export function useFormState<T extends object>(
+  initialValues: T,
+  validate: (values: T) => Partial<Record<keyof T, string>>,
+) {
+  const [values, setValues] = useState<T>(initialValues);
+  const [touched, setTouched] = useState<Partial<Record<keyof T, boolean>>>({});
+
+  const errors = validate(values);
+
+  function set<K extends keyof T>(key: K, value: T[K]) {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function markTouched(key: keyof T) {
+    setTouched((prev) => ({ ...prev, [key]: true }));
+  }
+
+  function markAllTouched() {
+    const all = Object.keys(values).reduce(
+      (acc, key) => ({ ...acc, [key]: true }),
+      {} as Partial<Record<keyof T, boolean>>,
+    );
+    setTouched(all);
+  }
+
+  return {
+    values,
+    errors,
+    touched,
+    set,
+    markTouched,
+    markAllTouched,
+    hasErrors: Object.keys(errors).length > 0,
+  };
+}

--- a/lined-web/src/hooks/useLobbies.ts
+++ b/lined-web/src/hooks/useLobbies.ts
@@ -62,6 +62,7 @@ export const useUpdateLobbyOwner = (lobbyId: number) => {
     mutationFn: (ownerId: number) => updateLobby(lobbyId, { ownerId }),
     onSuccess: (lobby) => {
       queryClient.setQueryData<LobbyDto>(QUERY_KEYS.lobbyDetail(lobbyId), lobby);
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lobbies });
     },
   });
 };

--- a/lined-web/src/hooks/useNotifications.ts
+++ b/lined-web/src/hooks/useNotifications.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import {
   getPreferences,
   updatePreferences,
@@ -6,6 +6,7 @@ import {
   updateLobbyPreferences,
 } from '@/api/notifications';
 import { QUERY_KEYS } from '@/lib/constants';
+import { useOptimisticPatchMutation } from './useOptimisticPatchMutation';
 import type {
   NotificationPreferencesDto,
   NotificationPreferencesUpdateDto,
@@ -19,45 +20,11 @@ export const useNotificationPreferences = () =>
     queryFn: getPreferences,
   });
 
-interface UpdatePreferencesContext {
-  previous: NotificationPreferencesDto | undefined;
-}
-
-export const useUpdateNotificationPreferences = () => {
-  const queryClient = useQueryClient();
-  return useMutation<
-    NotificationPreferencesDto,
-    unknown,
-    NotificationPreferencesUpdateDto,
-    UpdatePreferencesContext
-  >({
+export const useUpdateNotificationPreferences = () =>
+  useOptimisticPatchMutation<NotificationPreferencesDto, NotificationPreferencesUpdateDto>({
+    queryKey: QUERY_KEYS.notificationPreferences,
     mutationFn: updatePreferences,
-    onMutate: async (patch) => {
-      await queryClient.cancelQueries({ queryKey: QUERY_KEYS.notificationPreferences });
-      const previous = queryClient.getQueryData<NotificationPreferencesDto>(
-        QUERY_KEYS.notificationPreferences,
-      );
-      if (previous) {
-        queryClient.setQueryData<NotificationPreferencesDto>(
-          QUERY_KEYS.notificationPreferences,
-          { ...previous, ...patch },
-        );
-      }
-      return { previous };
-    },
-    onSuccess: (updated) => {
-      queryClient.setQueryData<NotificationPreferencesDto>(
-        QUERY_KEYS.notificationPreferences,
-        updated,
-      );
-    },
-    onError: (_err, _patch, context) => {
-      if (context?.previous) {
-        queryClient.setQueryData(QUERY_KEYS.notificationPreferences, context.previous);
-      }
-    },
   });
-};
 
 export const useLobbyNotificationPreferences = (lobbyId: number) =>
   useQuery({
@@ -65,38 +32,11 @@ export const useLobbyNotificationPreferences = (lobbyId: number) =>
     queryFn: () => getLobbyPreferences(lobbyId),
   });
 
-interface UpdateLobbyPreferencesContext {
-  previous: LobbyNotificationPreferencesDto | undefined;
-}
-
-export const useUpdateLobbyNotificationPreferences = (lobbyId: number) => {
-  const queryClient = useQueryClient();
-  const queryKey = QUERY_KEYS.lobbyNotificationPreferences(lobbyId);
-  return useMutation<
+export const useUpdateLobbyNotificationPreferences = (lobbyId: number) =>
+  useOptimisticPatchMutation<
     LobbyNotificationPreferencesDto,
-    unknown,
-    LobbyNotificationPreferencesUpdateDto,
-    UpdateLobbyPreferencesContext
+    LobbyNotificationPreferencesUpdateDto
   >({
+    queryKey: QUERY_KEYS.lobbyNotificationPreferences(lobbyId),
     mutationFn: (data) => updateLobbyPreferences(lobbyId, data),
-    onMutate: async (patch) => {
-      await queryClient.cancelQueries({ queryKey });
-      const previous = queryClient.getQueryData<LobbyNotificationPreferencesDto>(queryKey);
-      if (previous) {
-        queryClient.setQueryData<LobbyNotificationPreferencesDto>(queryKey, {
-          ...previous,
-          ...patch,
-        });
-      }
-      return { previous };
-    },
-    onSuccess: (updated) => {
-      queryClient.setQueryData<LobbyNotificationPreferencesDto>(queryKey, updated);
-    },
-    onError: (_err, _patch, context) => {
-      if (context?.previous) {
-        queryClient.setQueryData(queryKey, context.previous);
-      }
-    },
   });
-};

--- a/lined-web/src/hooks/useOptimisticPatchMutation.ts
+++ b/lined-web/src/hooks/useOptimisticPatchMutation.ts
@@ -1,0 +1,41 @@
+import { useMutation, useQueryClient, type QueryKey } from '@tanstack/react-query';
+
+interface OptimisticPatchOptions<TData, TPatch> {
+  queryKey: QueryKey;
+  mutationFn: (patch: TPatch) => Promise<TData>;
+}
+
+interface OptimisticPatchContext<TData> {
+  previous: TData | undefined;
+}
+
+/**
+ * Mutation that optimistically merges `patch` into a single cached object at
+ * `queryKey`, replaces it with the server response on success, and restores
+ * the pre-mutation snapshot on failure.
+ */
+export function useOptimisticPatchMutation<TData, TPatch extends object>({
+  queryKey,
+  mutationFn,
+}: OptimisticPatchOptions<TData, TPatch>) {
+  const queryClient = useQueryClient();
+  return useMutation<TData, unknown, TPatch, OptimisticPatchContext<TData>>({
+    mutationFn,
+    onMutate: async (patch) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<TData>(queryKey);
+      if (previous) {
+        queryClient.setQueryData<TData>(queryKey, { ...previous, ...patch });
+      }
+      return { previous };
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData<TData>(queryKey, updated);
+    },
+    onError: (_err, _patch, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData<TData>(queryKey, context.previous);
+      }
+    },
+  });
+}

--- a/lined-web/src/hooks/useRowMutationState.ts
+++ b/lined-web/src/hooks/useRowMutationState.ts
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+
+/**
+ * Shared "one row busy at a time, per-row error" bookkeeping for lists where
+ * clicking a row action (invite, resend, toggle status, …) disables just
+ * that row and shows an inline error on failure.
+ */
+export function useRowMutationState() {
+  const [busyId, setBusyId] = useState<number | null>(null);
+  const [errors, setErrors] = useState<Record<number, string>>({});
+
+  function clearError(id: number) {
+    setErrors((prev) => {
+      if (!(id in prev)) return prev;
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  }
+
+  function setError(id: number, message: string) {
+    setErrors((prev) => ({ ...prev, [id]: message }));
+  }
+
+  /** Call at the start of a row action: marks it busy and clears its stale error. */
+  function start(id: number) {
+    setBusyId(id);
+    clearError(id);
+  }
+
+  /** Call in onSettled to clear the busy state. */
+  function finish() {
+    setBusyId(null);
+  }
+
+  return { busyId, errors, start, finish, setError, clearError };
+}

--- a/lined-web/src/hooks/useTasks.ts
+++ b/lined-web/src/hooks/useTasks.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, type QueryKey } from '@tanstack/react-query';
 import { createTask, deleteTask, listMyTasks, listTasks, updateTask } from '@/api/tasks';
 import { QUERY_KEYS } from '@/lib/constants';
 import type { TaskDto, TaskStatus, TaskUpdateDto } from '@/types';
@@ -40,7 +40,7 @@ export const useUpdateTask = (lobbyId: number) => {
 };
 
 interface UpdateTaskStatusContext {
-  previous: TaskDto[] | undefined;
+  previous: Array<[QueryKey, TaskDto[] | undefined]>;
 }
 
 export const useUpdateTaskStatus = () => {
@@ -48,20 +48,22 @@ export const useUpdateTaskStatus = () => {
   return useMutation<TaskDto, unknown, { id: number; status: TaskStatus }, UpdateTaskStatusContext>({
     mutationFn: ({ id, status }) => updateTask(id, { status }),
     onMutate: async ({ id, status }) => {
-      await queryClient.cancelQueries({ queryKey: QUERY_KEYS.myTasks });
-      const previous = queryClient.getQueryData<TaskDto[]>(QUERY_KEYS.myTasks);
-      queryClient.setQueryData<TaskDto[]>(QUERY_KEYS.myTasks, (old) =>
+      await queryClient.cancelQueries({ queryKey: QUERY_KEYS.tasks });
+      const previous = queryClient.getQueriesData<TaskDto[]>({ queryKey: QUERY_KEYS.tasks });
+      queryClient.setQueriesData<TaskDto[]>({ queryKey: QUERY_KEYS.tasks }, (old) =>
         old?.map((t) => (t.id === id ? { ...t, status } : t)),
       );
       return { previous };
     },
     onSuccess: (updatedTask) => {
-      queryClient.setQueryData<TaskDto[]>(QUERY_KEYS.myTasks, (old) =>
+      // Patches myTasks and every cached lobbyTasks(lobbyId) list at once, since
+      // this hook doesn't know which lobby the task belongs to.
+      queryClient.setQueriesData<TaskDto[]>({ queryKey: QUERY_KEYS.tasks }, (old) =>
         old?.map((t) => (t.id === updatedTask.id ? updatedTask : t)),
       );
     },
     onError: (_err, _vars, context) => {
-      if (context?.previous) queryClient.setQueryData(QUERY_KEYS.myTasks, context.previous);
+      context?.previous.forEach(([key, data]) => queryClient.setQueryData(key, data));
     },
   });
 };
@@ -71,7 +73,7 @@ export const useDeleteTask = () => {
   return useMutation({
     mutationFn: (id: number) => deleteTask(id),
     onSuccess: (_data, id) => {
-      queryClient.setQueryData<TaskDto[]>(QUERY_KEYS.myTasks, (old) =>
+      queryClient.setQueriesData<TaskDto[]>({ queryKey: QUERY_KEYS.tasks }, (old) =>
         old?.filter((t) => t.id !== id),
       );
     },

--- a/lined-web/src/index.css
+++ b/lined-web/src/index.css
@@ -23,6 +23,9 @@
   --color-lobby-friends: #A78BFA;
   --color-lobby-work: #3FA6FA;
 
+  /* Calendar free-slot band */
+  --color-free-slot: #B4EBD0;
+
   /* Task status */
   --color-task-todo: #94A3B8;
   --color-task-inprog: #3B82F6;

--- a/lined-web/src/lib/__tests__/apiErrors.test.ts
+++ b/lined-web/src/lib/__tests__/apiErrors.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { HTTPError } from 'ky';
+import { getApiErrorMessage } from '../apiErrors';
+
+function makeHttpError(status: number): HTTPError {
+  const response = new Response(null, { status });
+  return new HTTPError(response, new Request('http://localhost/'), {} as never);
+}
+
+describe('getApiErrorMessage', () => {
+  it('returns the mapped message for a matching status code', () => {
+    expect.assertions(1);
+    const error = makeHttpError(400);
+    expect(getApiErrorMessage(error, { 400: 'Bad input' }, 'Fallback')).toBe('Bad input');
+  });
+
+  it('returns the fallback for a non-mapped status code', () => {
+    expect.assertions(1);
+    const error = makeHttpError(500);
+    expect(getApiErrorMessage(error, { 400: 'Bad input' }, 'Fallback')).toBe('Fallback');
+  });
+
+  it('returns the fallback for a non-HTTPError value', () => {
+    expect.assertions(1);
+    expect(getApiErrorMessage(new Error('network down'), { 400: 'Bad input' }, 'Fallback')).toBe(
+      'Fallback',
+    );
+  });
+});

--- a/lined-web/src/lib/__tests__/calendarUtils.test.ts
+++ b/lined-web/src/lib/__tests__/calendarUtils.test.ts
@@ -245,6 +245,13 @@ describe('eventTouchesDay', () => {
     const event = makeEvent('2026-07-18T23:30:00', '2026-07-19T02:00:00');
     expect(eventTouchesDay(event, new Date('2026-07-20T00:00:00'))).toBe(false);
   });
+
+  it('is true for a day fully inside a multi-day event, touching neither endpoint', () => {
+    expect.assertions(2);
+    const event = makeEvent('2026-07-17T10:00:00', '2026-07-20T10:00:00');
+    expect(eventTouchesDay(event, new Date('2026-07-18T00:00:00'))).toBe(true);
+    expect(eventTouchesDay(event, new Date('2026-07-19T00:00:00'))).toBe(true);
+  });
 });
 
 describe('clipEventToDay', () => {

--- a/lined-web/src/lib/__tests__/freeSlots.test.ts
+++ b/lined-web/src/lib/__tests__/freeSlots.test.ts
@@ -37,6 +37,14 @@ describe('freeSlotsForDay', () => {
     expect(freeSlotsForDay(slots, DAY)).toEqual([{ startHour: 1, endHour: 24 }]);
   });
 
+  it('reports a full-day slot for a day strictly between the slot start/end days', () => {
+    expect.assertions(1);
+    const slots: FreeSlotDto[] = [
+      { start: '2026-03-27T10:00:00', end: '2026-03-30T10:00:00' },
+    ];
+    expect(freeSlotsForDay(slots, DAY)).toEqual([{ startHour: 1, endHour: 24 }]);
+  });
+
   it('handles multiple slots in the same day', () => {
     expect.assertions(1);
     const slots: FreeSlotDto[] = [

--- a/lined-web/src/lib/__tests__/taskUtils.test.ts
+++ b/lined-web/src/lib/__tests__/taskUtils.test.ts
@@ -93,6 +93,15 @@ describe('isTaskOverdue', () => {
     expect.assertions(1);
     expect(isTaskOverdue(makeTask({ dueDate: '2026-04-15' }), TODAY)).toBe(false);
   });
+
+  it('uses the local calendar day, not the UTC day, to decide "today"', () => {
+    expect.assertions(1);
+    // Local midnight-thirty on the 16th, which is still the 15th in UTC.
+    const justAfterLocalMidnight = new Date('2026-04-16T00:30:00');
+    expect(
+      isTaskOverdue(makeTask({ dueDate: '2026-04-16' }), justAfterLocalMidnight),
+    ).toBe(false);
+  });
 });
 
 describe('isTaskDueThisWeek', () => {

--- a/lined-web/src/lib/apiErrors.ts
+++ b/lined-web/src/lib/apiErrors.ts
@@ -1,0 +1,14 @@
+import { HTTPError } from 'ky';
+
+/** Maps an HTTP error's status code to a user-facing message, else `fallback`. */
+export function getApiErrorMessage(
+  error: unknown,
+  statusMessages: Partial<Record<number, string>>,
+  fallback: string,
+): string {
+  if (error instanceof HTTPError) {
+    const message = statusMessages[error.response.status];
+    if (message) return message;
+  }
+  return fallback;
+}

--- a/lined-web/src/lib/calendarUtils.ts
+++ b/lined-web/src/lib/calendarUtils.ts
@@ -42,6 +42,14 @@ export function getDayBounds(date: Date): { start: Date; end: Date } {
   return { start, end };
 }
 
+/** `YYYY-MM-DD` for `date` in the viewer's local timezone (not UTC). */
+export function toLocalDateString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 export function isToday(date: Date): boolean {
   return isSameDay(date, new Date());
 }
@@ -186,18 +194,17 @@ export function formatTaskDueDate(
   if (!dueDate) return { label: 'No due date', isUrgent: false };
 
   const dueStr = dueDate.slice(0, 10);
-  const todayStr = new Date().toISOString().slice(0, 10);
+  const todayStr = toLocalDateString(new Date());
 
   if (dueStr === todayStr) return { label: 'Today', isUrgent: true };
 
-  const due = new Date(`${dueStr}T00:00:00Z`);
-  const today = new Date(`${todayStr}T00:00:00Z`);
+  const due = new Date(`${dueStr}T00:00:00`);
+  const today = new Date(`${todayStr}T00:00:00`);
   const isOverdue = due.getTime() < today.getTime();
 
   const label = due.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
-    timeZone: 'UTC',
   });
 
   return { label, isUrgent: isOverdue };

--- a/lined-web/src/lib/calendarUtils.ts
+++ b/lined-web/src/lib/calendarUtils.ts
@@ -88,22 +88,26 @@ export function formatDayLabel(date: Date): string {
   return `${weekday} ${date.getDate()}`;
 }
 
-/** "9 AM", "12 PM", "2 PM" */
-export function formatHour(hour: number): string {
-  if (hour === 12) return '12 PM';
-  if (hour > 12) return `${hour - 12} PM`;
-  return `${hour} AM`;
+/** Splits a fractional grid hour (e.g. 14.5) into a 12-hour value + AM/PM. */
+function toHourClock(hour: number): { value: string; ampm: 'AM' | 'PM' } {
+  const wholeHour = Math.floor(hour);
+  const ampm = wholeHour >= 12 ? 'PM' : 'AM';
+  const h = wholeHour % 12 || 12;
+  const minutes = Math.round((hour - wholeHour) * 60);
+  const value = minutes === 0 ? `${h}` : `${h}:${minutes.toString().padStart(2, '0')}`;
+  return { value, ampm };
 }
 
-/** "9:00 AM", "12 PM", "2:30 PM" */
+/** "9 AM", "12 PM", "2 PM" */
+export function formatHour(hour: number): string {
+  const { value, ampm } = toHourClock(hour);
+  return `${value} ${ampm}`;
+}
+
+/** "9 AM", "12 PM", "2:30 PM" */
 export function formatClockTime(d: Date): string {
-  const h = d.getHours();
-  const m = d.getMinutes();
-  const ampm = h >= 12 ? 'PM' : 'AM';
-  const hour = h % 12 || 12;
-  return m === 0
-    ? `${hour} ${ampm}`
-    : `${hour}:${m.toString().padStart(2, '0')} ${ampm}`;
+  const { value, ampm } = toHourClock(d.getHours() + d.getMinutes() / 60);
+  return `${value} ${ampm}`;
 }
 
 /** "Mon 13 Apr · 9:00 – 10:00 AM" */
@@ -167,20 +171,13 @@ export function formatFreeSlotRange(start: string, end: string): string {
       ? 'Tomorrow'
       : startDate.toLocaleDateString('en-US', { weekday: 'long' });
 
-  const formatHour = (d: Date): string => {
-    const h = d.getHours();
-    const m = d.getMinutes();
-    const hour = h % 12 || 12;
-    return m === 0 ? `${hour}` : `${hour}:${m.toString().padStart(2, '0')}`;
-  };
-
-  const startAmPm = startDate.getHours() >= 12 ? 'PM' : 'AM';
-  const endAmPm = endDate.getHours() >= 12 ? 'PM' : 'AM';
+  const startClock = toHourClock(startDate.getHours() + startDate.getMinutes() / 60);
+  const endClock = toHourClock(endDate.getHours() + endDate.getMinutes() / 60);
 
   const range =
-    startAmPm === endAmPm
-      ? `${formatHour(startDate)}–${formatHour(endDate)} ${endAmPm}`
-      : `${formatHour(startDate)} ${startAmPm}–${formatHour(endDate)} ${endAmPm}`;
+    startClock.ampm === endClock.ampm
+      ? `${startClock.value}–${endClock.value} ${endClock.ampm}`
+      : `${startClock.value} ${startClock.ampm}–${endClock.value} ${endClock.ampm}`;
 
   return `${dayLabel} ${range}`;
 }
@@ -308,17 +305,8 @@ export function computeFreeSlots(events: EventDto[], day: Date): FreeSlot[] {
 
 /** "2–5 PM", "9 AM–12 PM" for a grid-relative hour range. */
 export function formatHourRange(startHour: number, endHour: number): string {
-  const formatHourAmPm = (hour: number): { value: string; ampm: 'AM' | 'PM' } => {
-    const wholeHour = Math.floor(hour);
-    const ampm = wholeHour >= 12 ? 'PM' : 'AM';
-    const h = wholeHour % 12 || 12;
-    const minutes = Math.round((hour - wholeHour) * 60);
-    const value = minutes === 0 ? `${h}` : `${h}:${minutes.toString().padStart(2, '0')}`;
-    return { value, ampm };
-  };
-
-  const start = formatHourAmPm(startHour);
-  const end = formatHourAmPm(endHour);
+  const start = toHourClock(startHour);
+  const end = toHourClock(endHour);
 
   return start.ampm === end.ampm
     ? `${start.value}–${end.value} ${end.ampm}`

--- a/lined-web/src/lib/calendarUtils.ts
+++ b/lined-web/src/lib/calendarUtils.ts
@@ -33,6 +33,15 @@ export function isSameDay(a: Date, b: Date): boolean {
   );
 }
 
+/** Midnight-to-midnight bounds of the day containing `date`. */
+export function getDayBounds(date: Date): { start: Date; end: Date } {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+  return { start, end };
+}
+
 export function isToday(date: Date): boolean {
   return isSameDay(date, new Date());
 }
@@ -211,9 +220,10 @@ export function getEventHeight(startAt: string, endAt: string): number {
 
 /** True if an event starts, ends, or spans across the given day. */
 export function eventTouchesDay(event: EventDto, day: Date): boolean {
-  return (
-    isSameDay(new Date(event.startAt), day) || isSameDay(new Date(event.endAt), day)
-  );
+  const { start: dayStart, end: dayEnd } = getDayBounds(day);
+  const eventStart = new Date(event.startAt);
+  const eventEnd = new Date(event.endAt);
+  return eventStart < dayEnd && eventEnd > dayStart;
 }
 
 /**

--- a/lined-web/src/lib/constants.ts
+++ b/lined-web/src/lib/constants.ts
@@ -27,6 +27,11 @@ export const LOBBY_TYPE_COLORS: Record<LobbyType, string> = {
   WORK: 'bg-lobby-work',
 };
 
+/** CSS var for a lobby's accent color, e.g. `var(--color-lobby-couple)`. */
+export function lobbyAccentColor(lobbyType: LobbyType): string {
+  return `var(--color-lobby-${lobbyType.toLowerCase()})`;
+}
+
 export const LOBBY_TYPE_BADGE_CLASSES: Record<LobbyType, string> = {
   COUPLE: 'bg-lobby-couple/10 text-lobby-couple',
   FAMILY: 'bg-lobby-family/10 text-lobby-family',

--- a/lined-web/src/lib/constants.ts
+++ b/lined-web/src/lib/constants.ts
@@ -10,7 +10,7 @@ export const DEFAULT_LEGEND_ITEMS: LegendItem[] = [
   { label: 'Family', color: 'var(--color-lobby-family)' },
   { label: 'Friends', color: 'var(--color-lobby-friends)' },
   { label: 'Work', color: 'var(--color-lobby-work)' },
-  { label: 'Free slot', color: '#B4EBD0' },
+  { label: 'Free slot', color: 'var(--color-free-slot)' },
 ];
 
 export const LOBBY_TYPE_LABELS: Record<LobbyType, string> = {

--- a/lined-web/src/lib/freeSlots.ts
+++ b/lined-web/src/lib/freeSlots.ts
@@ -1,5 +1,11 @@
 import type { FreeSlotDto } from '@/types';
-import { GRID_END_HOUR, GRID_START_HOUR, isSameDay, type FreeSlot } from './calendarUtils';
+import {
+  GRID_END_HOUR,
+  GRID_START_HOUR,
+  getDayBounds,
+  isSameDay,
+  type FreeSlot,
+} from './calendarUtils';
 
 const toHour = (d: Date): number => d.getHours() + d.getMinutes() / 60;
 
@@ -13,7 +19,8 @@ export function freeSlotsForDay(slots: FreeSlotDto[], day: Date): FreeSlot[] {
   for (const slot of slots) {
     const start = new Date(slot.start);
     const end = new Date(slot.end);
-    if (!isSameDay(start, day) && !isSameDay(end, day)) continue;
+    const { start: dayStart, end: dayEnd } = getDayBounds(day);
+    if (!(start < dayEnd && end > dayStart)) continue;
 
     const startHour = isSameDay(start, day)
       ? Math.max(toHour(start), GRID_START_HOUR)

--- a/lined-web/src/lib/taskUtils.ts
+++ b/lined-web/src/lib/taskUtils.ts
@@ -13,6 +13,18 @@ export const getAdjacentStatus = (
   return STATUS_ORDER[nextIndex];
 };
 
+/** Not-done tasks first, then ascending by due date (tasks with no due date last). */
+export const sortTasksByDueDate = (tasks: TaskDto[]): TaskDto[] =>
+  [...tasks].sort((a, b) => {
+    if ((a.status === 'DONE') !== (b.status === 'DONE')) {
+      return a.status === 'DONE' ? 1 : -1;
+    }
+    if (a.dueDate == null && b.dueDate == null) return 0;
+    if (a.dueDate == null) return 1;
+    if (b.dueDate == null) return -1;
+    return a.dueDate.localeCompare(b.dueDate);
+  });
+
 export const groupTasksByStatus = (tasks: TaskDto[]): Record<TaskStatus, TaskDto[]> => {
   const groups: Record<TaskStatus, TaskDto[]> = { TODO: [], IN_PROGRESS: [], DONE: [] };
   for (const task of tasks) {

--- a/lined-web/src/lib/taskUtils.ts
+++ b/lined-web/src/lib/taskUtils.ts
@@ -1,5 +1,5 @@
 import type { TaskDto, TaskStatus } from '@/types';
-import { addDays, getWeekStart } from './calendarUtils';
+import { addDays, getWeekStart, toLocalDateString } from './calendarUtils';
 
 export const STATUS_ORDER: TaskStatus[] = ['TODO', 'IN_PROGRESS', 'DONE'];
 
@@ -24,7 +24,7 @@ export const groupTasksByStatus = (tasks: TaskDto[]): Record<TaskStatus, TaskDto
 export const isTaskOverdue = (task: TaskDto, today: Date = new Date()): boolean => {
   if (task.status === 'DONE' || !task.dueDate) return false;
   const dueStr = task.dueDate.slice(0, 10);
-  const todayStr = today.toISOString().slice(0, 10);
+  const todayStr = toLocalDateString(today);
   return dueStr < todayStr;
 };
 

--- a/lined-web/src/pages/CalendarPage.tsx
+++ b/lined-web/src/pages/CalendarPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { HTTPError } from 'ky';
 import { CalendarTopBar } from '@/components/CalendarTopBar';
 import { CreateEventModal } from '@/components/CreateEventModal';
 import { EventDetailPanel } from '@/components/EventDetailPanel';
@@ -11,6 +12,13 @@ import { useCalendarStore } from '@/store/calendar';
 import { useCreateMenuStore } from '@/store/createMenu';
 import { formatMonthYear, hourRangeToIso, isSameDay, type FreeSlot } from '@/lib/calendarUtils';
 import type { EventDto } from '@/types';
+
+function getDeleteEventErrorMessage(error: unknown): string {
+  if (error instanceof HTTPError && error.response.status === 404) {
+    return 'This event was already deleted';
+  }
+  return 'Could not delete this event — please try again';
+}
 
 export function CalendarPage() {
   const {
@@ -35,6 +43,7 @@ export function CalendarPage() {
 
   const [editingEvent, setEditingEvent] = useState<EventDto | null>(null);
   const [agendaDay, setAgendaDay] = useState<Date | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const { data: allWeekEvents = [] } = useWeekEvents(weekStart);
   const { data: allMonthEvents = [] } = useMonthEvents(monthAnchor);
@@ -55,6 +64,7 @@ export function CalendarPage() {
 
   function handleEventClick(id: number) {
     setAgendaDay(null);
+    setDeleteError(null);
     setSelectedEventId(id);
   }
 
@@ -74,8 +84,10 @@ export function CalendarPage() {
 
   function handleDelete() {
     if (selectedEventId == null) return;
+    setDeleteError(null);
     deleteEvent.mutate(selectedEventId, {
       onSuccess: () => setSelectedEventId(null),
+      onError: (error) => setDeleteError(getDeleteEventErrorMessage(error)),
     });
   }
 
@@ -132,9 +144,13 @@ export function CalendarPage() {
             <EventDetailPanel
               event={selectedEvent}
               lobby={selectedLobby}
-              onClose={() => setSelectedEventId(null)}
+              onClose={() => {
+                setDeleteError(null);
+                setSelectedEventId(null);
+              }}
               onEdit={() => setEditingEvent(selectedEvent)}
               onDelete={handleDelete}
+              deleteError={deleteError}
             />
           )
         )}

--- a/lined-web/src/pages/LobbyPage.tsx
+++ b/lined-web/src/pages/LobbyPage.tsx
@@ -5,6 +5,7 @@ import { LobbyTabBar, type LobbyTab } from '@/components/lobby/LobbyTabBar';
 import { LobbyTaskList } from '@/components/lobby/LobbyTaskList';
 import { LobbyMemberList } from '@/components/lobby/LobbyMemberList';
 import { LobbyCalendarView } from '@/components/lobby/LobbyCalendarView';
+import { LobbyLoadingState, LobbyNotFoundState } from '@/components/lobby/LobbyLoadStates';
 
 const VALID_TABS: LobbyTab[] = ['calendar', 'tasks', 'members'];
 
@@ -29,22 +30,11 @@ export function LobbyPage() {
   };
 
   if (isLoading) {
-    return (
-      <div className="flex-1 overflow-y-auto p-6">
-        <div className="h-24 animate-pulse rounded-xl bg-white" data-testid="lobby-page-loading" />
-        <div className="mt-4 h-10 w-64 animate-pulse rounded-lg bg-white" />
-      </div>
-    );
+    return <LobbyLoadingState loadingTestId="lobby-page-loading" />;
   }
 
   if (isError || !lobby) {
-    return (
-      <div className="flex-1 overflow-y-auto p-6">
-        <p className="text-sm text-text-secondary">
-          Lobby not found. It may have been deleted, or you may not have access to it.
-        </p>
-      </div>
-    );
+    return <LobbyNotFoundState />;
   }
 
   return (

--- a/lined-web/src/pages/LobbySettingsPage.tsx
+++ b/lined-web/src/pages/LobbySettingsPage.tsx
@@ -5,6 +5,7 @@ import { LobbyHeader } from '@/components/lobby/LobbyHeader';
 import { LobbyGeneralCard } from '@/components/lobby/LobbyGeneralCard';
 import { LobbyNotificationsCard } from '@/components/lobby/LobbyNotificationsCard';
 import { LobbyDangerZoneCard } from '@/components/lobby/LobbyDangerZoneCard';
+import { LobbyLoadingState, LobbyNotFoundState } from '@/components/lobby/LobbyLoadStates';
 
 export function LobbySettingsPage() {
   const { id } = useParams<{ id: string }>();
@@ -14,25 +15,11 @@ export function LobbySettingsPage() {
   const { data: currentUser } = useCurrentUser();
 
   if (isLoading) {
-    return (
-      <div className="flex-1 overflow-y-auto p-6">
-        <div
-          className="h-24 animate-pulse rounded-xl bg-white"
-          data-testid="lobby-settings-page-loading"
-        />
-        <div className="mt-4 h-10 w-64 animate-pulse rounded-lg bg-white" />
-      </div>
-    );
+    return <LobbyLoadingState loadingTestId="lobby-settings-page-loading" />;
   }
 
   if (isError || !lobby) {
-    return (
-      <div className="flex-1 overflow-y-auto p-6">
-        <p className="text-sm text-text-secondary">
-          Lobby not found. It may have been deleted, or you may not have access to it.
-        </p>
-      </div>
-    );
+    return <LobbyNotFoundState />;
   }
 
   const isOwner = currentUser != null && currentUser.id === lobby.ownerId;

--- a/lined-web/src/pages/SignInPage.tsx
+++ b/lined-web/src/pages/SignInPage.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { HTTPError } from 'ky';
 import { AuthCard } from '@/components/AuthCard';
 import { FormField } from '@/components/FormField';
 import { AuthAlert } from '@/components/AuthAlert';
 import { useSignIn } from '@/hooks/useAuth';
+import { useFormState } from '@/hooks/useFormState';
 import { useAuthStore } from '@/store/auth';
 
 interface FormValues {
@@ -24,23 +24,15 @@ export function SignInPage() {
   const signIn = useSignIn();
   const setUserId = useAuthStore((s) => s.setUserId);
 
-  const [values, setValues] = useState<FormValues>({ identifier: '', password: '' });
-  const [touched, setTouched] = useState<Partial<Record<keyof FormValues, boolean>>>({});
-
-  const errors = validate(values);
-
-  function set<K extends keyof FormValues>(key: K, value: FormValues[K]) {
-    setValues((prev) => ({ ...prev, [key]: value }));
-  }
-
-  function markTouched(key: keyof FormValues) {
-    setTouched((prev) => ({ ...prev, [key]: true }));
-  }
+  const { values, errors, touched, set, markTouched, markAllTouched, hasErrors } = useFormState<FormValues>(
+    { identifier: '', password: '' },
+    validate,
+  );
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setTouched({ identifier: true, password: true });
-    if (Object.keys(errors).length > 0) return;
+    markAllTouched();
+    if (hasErrors) return;
 
     signIn.mutate(values, {
       onSuccess: (res) => {

--- a/lined-web/src/pages/SignInPage.tsx
+++ b/lined-web/src/pages/SignInPage.tsx
@@ -23,7 +23,6 @@ export function SignInPage() {
   const navigate = useNavigate();
   const signIn = useSignIn();
   const setUserId = useAuthStore((s) => s.setUserId);
-  const setToken = useAuthStore((s) => s.setToken);
 
   const [values, setValues] = useState<FormValues>({ identifier: '', password: '' });
   const [touched, setTouched] = useState<Partial<Record<keyof FormValues, boolean>>>({});
@@ -46,7 +45,6 @@ export function SignInPage() {
     signIn.mutate(values, {
       onSuccess: (res) => {
         setUserId(res.userId);
-        setToken(res.accessToken);
         navigate('/');
       },
     });

--- a/lined-web/src/pages/SignUpPage.tsx
+++ b/lined-web/src/pages/SignUpPage.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { HTTPError } from 'ky';
 import { AuthCard } from '@/components/AuthCard';
 import { FormField } from '@/components/FormField';
 import { AuthAlert } from '@/components/AuthAlert';
 import { useSignUp } from '@/hooks/useAuth';
+import { useFormState } from '@/hooks/useFormState';
 import { useAuthStore } from '@/store/auth';
 
 interface FormValues {
@@ -42,28 +42,15 @@ export function SignUpPage() {
   const signUp = useSignUp();
   const setUserId = useAuthStore((s) => s.setUserId);
 
-  const [values, setValues] = useState<FormValues>({
-    username: '',
-    email: '',
-    password: '',
-    confirmPassword: '',
-  });
-  const [touched, setTouched] = useState<Partial<Record<keyof FormValues, boolean>>>({});
-
-  const errors = validate(values);
-
-  function set<K extends keyof FormValues>(key: K, value: FormValues[K]) {
-    setValues((prev) => ({ ...prev, [key]: value }));
-  }
-
-  function markTouched(key: keyof FormValues) {
-    setTouched((prev) => ({ ...prev, [key]: true }));
-  }
+  const { values, errors, touched, set, markTouched, markAllTouched, hasErrors } = useFormState<FormValues>(
+    { username: '', email: '', password: '', confirmPassword: '' },
+    validate,
+  );
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setTouched({ username: true, email: true, password: true, confirmPassword: true });
-    if (Object.keys(errors).length > 0) return;
+    markAllTouched();
+    if (hasErrors) return;
 
     signUp.mutate(
       { username: values.username, email: values.email, password: values.password },

--- a/lined-web/src/pages/__tests__/CalendarPage.test.tsx
+++ b/lined-web/src/pages/__tests__/CalendarPage.test.tsx
@@ -1,9 +1,13 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
 import { renderWithProviders, screen, userEvent, waitFor } from '@/test/utils';
+import { server } from '@/test/server';
 import { CalendarPage } from '../CalendarPage';
 import { useAuthStore } from '@/store/auth';
 import { useCalendarStore } from '@/store/calendar';
 import { useCreateMenuStore } from '@/store/createMenu';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
 
 describe('CalendarPage', () => {
   beforeEach(() => {
@@ -114,6 +118,23 @@ describe('CalendarPage', () => {
 
     await waitFor(() => expect(screen.queryByText('Morning Coffee')).not.toBeInTheDocument());
     expect(screen.getByText('Team Lunch')).toBeInTheDocument(); // a different lobby, still visible
+  });
+
+  it('shows an inline error and keeps the event when the delete request fails', async () => {
+    expect.assertions(2);
+    server.use(
+      http.delete(`${BASE}/calendar/events/:id`, () => new HttpResponse(null, { status: 500 })),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<CalendarPage />);
+
+    await user.click(await screen.findByText('Morning Coffee'));
+    await user.click(await screen.findByRole('button', { name: 'Delete' }));
+
+    expect(
+      await screen.findByText('Could not delete this event — please try again'),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('Morning Coffee').length).toBeGreaterThan(0);
   });
 
   it('reflects a hidden lobby as unchecked and re-shows its events once re-checked', async () => {

--- a/lined-web/src/pages/__tests__/CalendarPage.test.tsx
+++ b/lined-web/src/pages/__tests__/CalendarPage.test.tsx
@@ -7,7 +7,7 @@ import { useCreateMenuStore } from '@/store/createMenu';
 
 describe('CalendarPage', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: 1, token: 'token' });
+    useAuthStore.setState({ userId: 1 });
     useCalendarStore.setState({
       weekStart: useCalendarStore.getState().weekStart,
       monthAnchor: useCalendarStore.getState().monthAnchor,

--- a/lined-web/src/pages/__tests__/DashboardPage.test.tsx
+++ b/lined-web/src/pages/__tests__/DashboardPage.test.tsx
@@ -10,7 +10,7 @@ const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
 
 describe('DashboardPage', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: 1, token: 'token' });
+    useAuthStore.setState({ userId: 1 });
   });
 
   it('renders the greeting, lobby cards, upcoming events, and my tasks', async () => {

--- a/lined-web/src/pages/__tests__/LobbySettingsPage.test.tsx
+++ b/lined-web/src/pages/__tests__/LobbySettingsPage.test.tsx
@@ -19,7 +19,7 @@ function renderSettingsPage(initialEntry: string) {
 
 describe('LobbySettingsPage', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: 1, token: 'token' });
+    useAuthStore.setState({ userId: 1 });
   });
 
   it('shows a loading state before the lobby loads', () => {
@@ -58,7 +58,7 @@ describe('LobbySettingsPage', () => {
 
   it('hides the Delete lobby action for a non-owner viewer', async () => {
     expect.assertions(2);
-    useAuthStore.setState({ userId: 2, token: 'token' });
+    useAuthStore.setState({ userId: 2 });
     renderSettingsPage('/lobbies/1/settings');
 
     expect(await screen.findByRole('button', { name: 'Leave' })).toBeInTheDocument();

--- a/lined-web/src/pages/__tests__/SignInPage.test.tsx
+++ b/lined-web/src/pages/__tests__/SignInPage.test.tsx
@@ -20,7 +20,7 @@ function renderSignIn() {
 
 describe('SignInPage', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: null, token: null });
+    useAuthStore.setState({ userId: null });
   });
 
   it('signs in with a known identifier and redirects home', async () => {

--- a/lined-web/src/pages/__tests__/SignUpPage.test.tsx
+++ b/lined-web/src/pages/__tests__/SignUpPage.test.tsx
@@ -29,7 +29,7 @@ async function fillValidForm(
 
 describe('SignUpPage', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: null, token: null });
+    useAuthStore.setState({ userId: null });
   });
 
   it('creates an account, stores the id, and redirects home', async () => {

--- a/lined-web/src/pages/__tests__/UserSettingsPage.test.tsx
+++ b/lined-web/src/pages/__tests__/UserSettingsPage.test.tsx
@@ -8,7 +8,7 @@ const user = MOCK_USERS[0]!;
 
 describe('UserSettingsPage', () => {
   beforeEach(() => {
-    useAuthStore.setState({ userId: user.id, token: 'token' });
+    useAuthStore.setState({ userId: user.id });
   });
 
   it('renders the settings menu and all five section cards', async () => {

--- a/lined-web/src/store/auth.ts
+++ b/lined-web/src/store/auth.ts
@@ -3,18 +3,14 @@ import { persist } from 'zustand/middleware';
 
 interface AuthState {
   userId: number | null;
-  token: string | null;
   setUserId: (id: number | null) => void;
-  setToken: (token: string | null) => void;
 }
 
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       userId: null,
-      token: null,
       setUserId: (id) => set({ userId: id }),
-      setToken: (token) => set({ token }),
     }),
     { name: 'lined-auth' },
   ),

--- a/lined-web/src/types/index.ts
+++ b/lined-web/src/types/index.ts
@@ -202,6 +202,11 @@ export interface SubscriptionDto {
   createdAt: string;
 }
 
+export interface SubscriptionCreateDto {
+  userId: number;
+  planId: number;
+}
+
 // --- Role ---
 
 export interface RoleDto {


### PR DESCRIPTION
## Summary

Full-codebase code-review/simplify pass over `lined-web/src` (129 files), triggered by `/code-review` and `/simplify` with no diff to target. Fixes 22 issues found by 5 parallel scan agents, each verified by re-reading the flagged code before fixing (one false positive — `createInvite`'s use of `searchParams` — was confirmed correct against the backend controller and left alone).

### Bugs fixed
- `eventTouchesDay`/`freeSlotsForDay` used same-day-only checks instead of real interval overlap, dropping events/free-slots on days strictly inside a multi-day range
- `formatTaskDueDate`/`isTaskOverdue` derived "today" from UTC instead of local time, disagreeing with `isTaskDueThisWeek` near local midnight
- `listEvents`/`listTasks` leaked the literal string `"undefined"` into query params when an optional filter was omitted
- `useDeleteTask`/`useUpdateTaskStatus` only patched the `myTasks` cache, leaving an open lobby task board stale
- `useUpdateLobbyOwner` never invalidated the lobbies list after an owner transfer
- Failed event deletes in `CalendarPage`/`LobbyCalendarView` showed no feedback
- `useAuthStore`'s `token` field was written in 3 places but never read anywhere (backend auths purely off `X-User-Id`) — removed

### Duplication / simplification
- Shared `useFormState` hook for the two auth pages
- Shared `LobbyLoadingState`/`LobbyNotFoundState` components
- Shared `toSearchParams`/`requestVoid` helpers across all of `src/api/`
- Consolidated 4 reimplementations of 12-hour clock formatting into one helper
- Shared `getApiErrorMessage` utility replacing 9 near-identical `getXErrorMessage` functions
- Shared `useRowMutationState` hook replacing 4 hand-rolled busy-id/error-map patterns
- Shared `lobbyAccentColor` helper replacing 7 inline CSS-var derivations
- Shared `sortTasksByDueDate` comparator
- Shared `useOptimisticPatchMutation` helper for the two notification-preference hooks
- Deduplicated window-size constants in `useDashboard`
- Replaced a hard-coded `#B4EBD0` hex (5 occurrences) with a `--color-free-slot` CSS token
- Split `useFreeSlotBanner` to stay under the repo's 30-line guideline
- Grouped `WeekGrid`/`KanbanColumn` props that had grown past 3 loose props into `actions`/`moveState` objects
- Added a named `SubscriptionCreateDto` type

## Test plan
- [x] `npm run test:run` — 413/413 passing
- [x] `npm run lint` — clean
- [x] `npm run build` (`tsc -b && vite build`) — clean (root `tsc --noEmit` script is a pre-existing no-op due to project references; `tsc -b` is the real check)
- [x] Manually verified in-browser: Kanban board, lobby calendar week grid, event detail panel, free-slot legend color

🤖 Generated with [Claude Code](https://claude.ai/code)