### PR TITLE
feat(web): Subscription & Plan page

### DIFF
--- a/lined-web/docs/UI_TASKS.md
+++ b/lined-web/docs/UI_TASKS.md
@@ -51,6 +51,20 @@ exist for every task, including `create-lobby` (task 4), `calendar-month`
 - **Notifications Center** — `NotificationBell`, `NotificationInbox`: dashboard bell with a live unread-count badge (capped "9+"), dropdown inbox listing `GET /api/notifications/mine` (per-row type icon, message, relative time via new `formatRelativeTimeAgo`, lobby name, unread tint/dot), click-to-mark-read (`PATCH /api/notifications/{id}/read`) with navigation to the related lobby Tasks tab / calendar (selecting the event) / lobby page depending on which ids are set, and a "Mark all read" header action. `useMyNotifications` polls every 60s. Global/per-lobby notification preference cards (`NotificationsCard`, `LobbyNotificationsCard`) were already backend-persisted from earlier work — this task only added the inbox/bell.
 - **Lobby Invites (invitee side)** — `InviteCard`, `PendingInvitesBanner`: a "Pending Invites · N" section (green-bordered cards, inviter avatar tinted by lobby-type accent, `GET /api/lobby-invites/mine`) rendered above "My Lobbies" on the dashboard; Accept (`POST /api/lobby-invites/{id}/accept`) navigates into the joined lobby, Decline goes through the shared `ConfirmDialog`, and a 409 on either (stale/already-actioned invite) shows "This invite is no longer valid" and refetches. The same `InviteCard`s now also appear at the top of the notification-bell dropdown (`NotificationInbox`), reusing the accept/decline hooks without the confirm-dialog step. New hooks: `useMyInvites`/`useAcceptInvite`/`useDeclineInvite` in `useInvites.ts` (the API client and MSW mocks already existed from Task 15). Verified `GET /api/lobbies/{id}` has no membership check server-side, so the invitee-side lobby name/type/member-count render directly instead of falling back to generic text.
 
+- **Subscription & Plan page** — `CurrentPlanCard`, `PlanCards`,
+  `SubscriptionHistoryCard`: `/subscription` route (linked from a new
+  "Subscription" item in the User Settings PREFERENCES menu); current-plan
+  card shows plan/price/renewal date with a confirm-gated "Cancel
+  subscription" (`POST /api/subscriptions/{userId}/cancel-active`) or a
+  free-plan message when `GET /api/subscriptions/{userId}/active` 404s;
+  plan cards from `GET /api/plans` highlight the active plan and
+  "Subscribe" others (`POST /api/subscriptions`, inline 409 message when
+  already subscribed); history card lists `GET
+  /api/subscriptions/{userId}/history` with ACTIVE/ENDED badges. New
+  `useSubscriptions.ts` hooks (`usePlans`, `useActivePlan`,
+  `useSubscriptionHistory`, `useStartSubscription`,
+  `useCancelSubscription`).
+
 **Stubs only ("coming soon" placeholders):**
 SignInPage, SignUpPage, DashboardPage.
 
@@ -93,7 +107,7 @@ SignInPage, SignUpPage, DashboardPage.
 | 11 | `feature/ui-11-reserve-slot` | Free-slot detection surfacing + Reserve Free Slot modal | [tasks/UI-11-reserve-slot.md](tasks/UI-11-reserve-slot.md) | DONE |
 | 12 | `feature/ui-12-user-settings` | User Settings page: profile, notifications, appearance, danger zone | [tasks/UI-12-user-settings.md](tasks/UI-12-user-settings.md) | DONE |
 | 13 | `feature/ui-13-lobby-settings` | Lobby Settings page: general, notifications, leave/delete lobby | [tasks/UI-13-lobby-settings.md](tasks/UI-13-lobby-settings.md) | DONE |
-| 14 | `feature/ui-14-subscription-page` | Subscription & Plan page: current plan, available plans, subscribe/cancel, history | [tasks/UI-14-subscription-page.md](tasks/UI-14-subscription-page.md) | TODO |
+| 14 | `feature/ui-14-subscription-page` | Subscription & Plan page: current plan, available plans, subscribe/cancel, history | [tasks/UI-14-subscription-page.md](tasks/UI-14-subscription-page.md) | DONE |
 | 15 | `feature/ui-15-api-contract-refresh` | Migrate `src/api`/`src/types`/MSW to the July 2026 backend contract (login, invites, new task/event fields, tasks/mine, free-slots, notifications) | [tasks/UI-15-api-contract-refresh.md](tasks/UI-15-api-contract-refresh.md) | DONE |
 | 16 | `feature/ui-16-notifications-center` | Notification bell + inbox (unread count, mark read) and backend-persisted notification preferences | [tasks/UI-16-notifications-center.md](tasks/UI-16-notifications-center.md) | DONE |
 | 17 | `feature/ui-17-lobby-invites-inbox` | Invitee-side invites: pending invites list, accept/decline flows | [tasks/UI-17-lobby-invites-inbox.md](tasks/UI-17-lobby-invites-inbox.md) | DONE |

--- a/lined-web/src/components/settings/SettingsMenu.tsx
+++ b/lined-web/src/components/settings/SettingsMenu.tsx
@@ -1,6 +1,8 @@
+import { Link } from 'react-router-dom';
+
 interface SettingsMenuSection {
   label: string;
-  items: { id: string; label: string; danger?: boolean }[];
+  items: { id: string; label: string; danger?: boolean; route?: string }[];
 }
 
 const SECTIONS: SettingsMenuSection[] = [
@@ -14,7 +16,10 @@ const SECTIONS: SettingsMenuSection[] = [
   },
   {
     label: 'PREFERENCES',
-    items: [{ id: 'appearance', label: 'Appearance' }],
+    items: [
+      { id: 'appearance', label: 'Appearance' },
+      { id: 'subscription', label: 'Subscription', route: '/subscription' },
+    ],
   },
   {
     label: 'DANGER',
@@ -22,7 +27,14 @@ const SECTIONS: SettingsMenuSection[] = [
   },
 ];
 
-/** Left-hand anchor jump list for the single-scroll settings page. */
+function menuItemClass(danger?: boolean): string {
+  return `block border-l-[3px] border-transparent px-5 py-2.5 text-sm ${
+    danger ? 'text-red-600' : 'text-text-secondary hover:text-text-primary'
+  }`;
+}
+
+/** Left-hand jump list for the settings page — most items scroll-anchor within the
+ * single-scroll page; items with a `route` navigate to a separate page instead. */
 export const SettingsMenu = () => (
   <nav className="w-[220px] flex-shrink-0 border-r border-border bg-white py-5">
     {SECTIONS.map((section) => (
@@ -30,17 +42,17 @@ export const SettingsMenu = () => (
         <div className="px-5 py-1.5 text-[11px] font-semibold tracking-wider text-text-muted">
           {section.label}
         </div>
-        {section.items.map((item) => (
-          <a
-            key={item.id}
-            href={`#${item.id}`}
-            className={`block border-l-[3px] border-transparent px-5 py-2.5 text-sm ${
-              item.danger ? 'text-red-600' : 'text-text-secondary hover:text-text-primary'
-            }`}
-          >
-            {item.label}
-          </a>
-        ))}
+        {section.items.map((item) =>
+          item.route ? (
+            <Link key={item.id} to={item.route} className={menuItemClass(item.danger)}>
+              {item.label}
+            </Link>
+          ) : (
+            <a key={item.id} href={`#${item.id}`} className={menuItemClass(item.danger)}>
+              {item.label}
+            </a>
+          ),
+        )}
       </div>
     ))}
   </nav>

--- a/lined-web/src/components/settings/__tests__/SettingsMenu.test.tsx
+++ b/lined-web/src/components/settings/__tests__/SettingsMenu.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { SettingsMenu } from '../SettingsMenu';
 
 describe('SettingsMenu', () => {
   it('renders every account, preference, and danger item with an anchor link', () => {
     expect.assertions(6);
-    render(<SettingsMenu />);
+    render(<SettingsMenu />, { wrapper: MemoryRouter });
 
     expect(screen.getByRole('link', { name: 'Profile' })).toHaveAttribute('href', '#profile');
     expect(screen.getByRole('link', { name: 'Password & Security' })).toHaveAttribute(
@@ -25,5 +26,15 @@ describe('SettingsMenu', () => {
       '#danger-zone',
     );
     expect(screen.getByText('DANGER')).toBeInTheDocument();
+  });
+
+  it('renders the Subscription item as a route link', () => {
+    expect.assertions(1);
+    render(<SettingsMenu />, { wrapper: MemoryRouter });
+
+    expect(screen.getByRole('link', { name: 'Subscription' })).toHaveAttribute(
+      'href',
+      '/subscription',
+    );
   });
 });

--- a/lined-web/src/components/subscription/CurrentPlanCard.tsx
+++ b/lined-web/src/components/subscription/CurrentPlanCard.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import type { PlanDto, SubscriptionDto } from '@/types';
+import { useCancelSubscription } from '@/hooks/useSubscriptions';
+import { getApiErrorMessage } from '@/lib/apiErrors';
+import { formatPlanPrice, formatShortDate } from '@/lib/subscriptionUtils';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { SettingsCard } from '@/components/settings/SettingsCard';
+
+interface CurrentPlanCardProps {
+  userId: number;
+  activeSubscription: SubscriptionDto | null | undefined;
+  activePlanDetails: PlanDto | undefined;
+  isLoading: boolean;
+}
+
+function getCancelErrorMessage(error: unknown): string {
+  return getApiErrorMessage(
+    error,
+    { 404: 'You have no active subscription to cancel' },
+    'Could not cancel your subscription — please try again',
+  );
+}
+
+export const CurrentPlanCard = ({
+  userId,
+  activeSubscription,
+  activePlanDetails,
+  isLoading,
+}: CurrentPlanCardProps) => {
+  const cancelSubscription = useCancelSubscription(userId);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+  if (isLoading) {
+    return (
+      <SettingsCard id="current-plan" title="Current Plan">
+        <div className="h-16 animate-pulse rounded-lg bg-input-bg" data-testid="current-plan-loading" />
+      </SettingsCard>
+    );
+  }
+
+  return (
+    <SettingsCard id="current-plan" title="Current Plan">
+      {activeSubscription ? (
+        <div className="flex items-center justify-between py-3.5">
+          <div>
+            <div className="text-base font-bold text-text-primary">
+              {activeSubscription.planName}
+              {activePlanDetails ? ` · ${formatPlanPrice(activePlanDetails.priceUsd)}/month` : ''}
+            </div>
+            <div className="mt-0.5 text-xs text-text-secondary">
+              Renews {formatShortDate(activeSubscription.endDate)}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setIsConfirmOpen(true)}
+            className="h-9 flex-shrink-0 rounded-lg bg-red-600 px-4 text-sm font-semibold text-white transition-colors hover:bg-red-700"
+          >
+            Cancel subscription
+          </button>
+        </div>
+      ) : (
+        <p className="py-3.5 text-sm text-text-secondary">You are on the free plan.</p>
+      )}
+
+      {isConfirmOpen && (
+        <ConfirmDialog
+          title="Cancel subscription"
+          message="Your plan will be cancelled immediately. You'll keep access to the free plan's features."
+          confirmLabel="Cancel subscription"
+          danger
+          isPending={cancelSubscription.isPending}
+          error={cancelSubscription.isError ? getCancelErrorMessage(cancelSubscription.error) : null}
+          onConfirm={() =>
+            cancelSubscription.mutate(undefined, {
+              onSuccess: () => setIsConfirmOpen(false),
+            })
+          }
+          onCancel={() => setIsConfirmOpen(false)}
+        />
+      )}
+    </SettingsCard>
+  );
+};

--- a/lined-web/src/components/subscription/PlanCards.tsx
+++ b/lined-web/src/components/subscription/PlanCards.tsx
@@ -1,0 +1,81 @@
+import type { PlanDto } from '@/types';
+import { useStartSubscription } from '@/hooks/useSubscriptions';
+import { getApiErrorMessage } from '@/lib/apiErrors';
+import { formatPlanPrice } from '@/lib/subscriptionUtils';
+
+interface PlanCardsProps {
+  userId: number;
+  plans: PlanDto[] | undefined;
+  isLoading: boolean;
+  currentPlanId: number | undefined;
+}
+
+function getSubscribeErrorMessage(error: unknown): string {
+  return getApiErrorMessage(
+    error,
+    { 409: 'You already have an active plan — cancel it first to switch' },
+    'Could not start your subscription — please try again',
+  );
+}
+
+const PlanCardsSkeleton = () => (
+  <div className="grid grid-cols-1 gap-4 md:grid-cols-3" data-testid="plan-cards-loading">
+    {Array.from({ length: 3 }, (_, i) => (
+      <div key={i} className="h-40 animate-pulse rounded-xl bg-white" />
+    ))}
+  </div>
+);
+
+export const PlanCards = ({ userId, plans, isLoading, currentPlanId }: PlanCardsProps) => {
+  const startSubscription = useStartSubscription(userId);
+
+  if (isLoading) return <PlanCardsSkeleton />;
+
+  return (
+    <div>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        {plans?.map((plan) => {
+          const isCurrent = plan.id === currentPlanId;
+          return (
+            <div
+              key={plan.id}
+              className={`relative rounded-xl border-[1.5px] bg-white p-5 ${
+                isCurrent ? 'border-brand-green' : 'border-border'
+              }`}
+            >
+              {isCurrent && (
+                <span className="absolute right-4 top-4 rounded-full bg-brand-green px-2 py-0.5 text-[10px] font-bold text-white">
+                  CURRENT
+                </span>
+              )}
+              <div className="text-sm font-semibold text-text-primary">{plan.name}</div>
+              <div className="mt-1 text-xl font-bold text-text-primary">
+                {formatPlanPrice(plan.priceUsd)}
+                {plan.priceUsd > 0 && (
+                  <span className="text-xs font-normal text-text-secondary"> / month</span>
+                )}
+              </div>
+              <button
+                type="button"
+                disabled={isCurrent || startSubscription.isPending}
+                onClick={() => startSubscription.mutate(plan.id)}
+                className={`mt-4 h-9 w-full rounded-lg text-sm font-semibold transition-colors disabled:opacity-60 ${
+                  isCurrent
+                    ? 'bg-brand-green-light text-brand-green-dark'
+                    : 'bg-brand-green text-white hover:bg-brand-green-dark'
+                }`}
+              >
+                {isCurrent ? 'Your plan' : 'Subscribe'}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      {startSubscription.isError && (
+        <p className="mt-3 text-sm text-red-600">
+          {getSubscribeErrorMessage(startSubscription.error)}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/lined-web/src/components/subscription/SubscriptionHistoryCard.tsx
+++ b/lined-web/src/components/subscription/SubscriptionHistoryCard.tsx
@@ -1,0 +1,58 @@
+import type { SubscriptionDto } from '@/types';
+import { formatPlanPrice, formatShortDate } from '@/lib/subscriptionUtils';
+import { SettingsCard } from '@/components/settings/SettingsCard';
+
+interface SubscriptionHistoryCardProps {
+  history: SubscriptionDto[] | undefined;
+  isLoading: boolean;
+  planPriceById: Map<number, number>;
+}
+
+const SubscriptionHistorySkeleton = () => (
+  <div className="space-y-2 py-3.5" data-testid="subscription-history-loading">
+    <div className="h-10 animate-pulse rounded-lg bg-input-bg" />
+    <div className="h-10 animate-pulse rounded-lg bg-input-bg" />
+  </div>
+);
+
+export const SubscriptionHistoryCard = ({
+  history,
+  isLoading,
+  planPriceById,
+}: SubscriptionHistoryCardProps) => (
+  <SettingsCard id="subscription-history" title="Subscription History">
+    {isLoading ? (
+      <SubscriptionHistorySkeleton />
+    ) : history && history.length > 0 ? (
+      history.map((sub) => {
+        const price = planPriceById.get(sub.planId);
+        return (
+          <div
+            key={sub.id}
+            className="flex items-center justify-between border-b border-border py-3.5 last:border-b-0"
+          >
+            <div>
+              <div className="text-sm font-medium text-text-primary">
+                {sub.planName}
+                {price != null ? ` · ${formatPlanPrice(price)}${price > 0 ? '/month' : ''}` : ''}
+              </div>
+              <div className="mt-0.5 text-xs text-text-secondary">
+                {formatShortDate(sub.startDate)} –{' '}
+                {sub.active ? 'present' : formatShortDate(sub.endDate)}
+              </div>
+            </div>
+            <span
+              className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${
+                sub.active ? 'bg-task-done/10 text-task-done' : 'bg-task-todo/10 text-task-todo'
+              }`}
+            >
+              {sub.active ? 'ACTIVE' : 'ENDED'}
+            </span>
+          </div>
+        );
+      })
+    ) : (
+      <p className="py-3.5 text-sm text-text-secondary">No subscription history yet.</p>
+    )}
+  </SettingsCard>
+);

--- a/lined-web/src/components/subscription/__tests__/CurrentPlanCard.test.tsx
+++ b/lined-web/src/components/subscription/__tests__/CurrentPlanCard.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
+import { server } from '@/test/server';
+import { MOCK_SUBSCRIPTIONS, MOCK_PLANS } from '@/test/data';
+import { CurrentPlanCard } from '../CurrentPlanCard';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+const activeSubscription = MOCK_SUBSCRIPTIONS[0]!;
+const proPlan = MOCK_PLANS[1]!;
+
+describe('CurrentPlanCard', () => {
+  it('shows a loading skeleton while loading', () => {
+    expect.assertions(1);
+    renderWithProviders(
+      <CurrentPlanCard
+        userId={1}
+        activeSubscription={undefined}
+        activePlanDetails={undefined}
+        isLoading
+      />,
+    );
+
+    expect(screen.getByTestId('current-plan-loading')).toBeInTheDocument();
+  });
+
+  it('shows the free-plan message when there is no active subscription', () => {
+    expect.assertions(2);
+    renderWithProviders(
+      <CurrentPlanCard userId={1} activeSubscription={null} activePlanDetails={undefined} isLoading={false} />,
+    );
+
+    expect(screen.getByText('You are on the free plan.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel subscription' })).not.toBeInTheDocument();
+  });
+
+  it('renders the active plan name, price, and renewal date', () => {
+    expect.assertions(2);
+    renderWithProviders(
+      <CurrentPlanCard
+        userId={1}
+        activeSubscription={activeSubscription}
+        activePlanDetails={proPlan}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByText('Pro · $9.99/month')).toBeInTheDocument();
+    expect(screen.getByText('Renews 28 Apr 2026')).toBeInTheDocument();
+  });
+
+  it('requires confirmation before cancelling', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderWithProviders(
+      <CurrentPlanCard
+        userId={1}
+        activeSubscription={activeSubscription}
+        activePlanDetails={proPlan}
+        isLoading={false}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Cancel subscription' }));
+
+    expect(screen.getByTestId('confirm-dialog-backdrop')).toBeInTheDocument();
+  });
+
+  it('shows an inline error message when cancelling fails', async () => {
+    expect.assertions(1);
+    server.use(
+      http.post(`${BASE}/subscriptions/:userId/cancel-active`, () => new HttpResponse(null, { status: 404 })),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(
+      <CurrentPlanCard
+        userId={1}
+        activeSubscription={activeSubscription}
+        activePlanDetails={proPlan}
+        isLoading={false}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Cancel subscription' }));
+    await user.click(screen.getAllByRole('button', { name: 'Cancel subscription' })[1]!);
+
+    expect(
+      await screen.findByText('You have no active subscription to cancel'),
+    ).toBeInTheDocument();
+  });
+});

--- a/lined-web/src/components/subscription/__tests__/PlanCards.test.tsx
+++ b/lined-web/src/components/subscription/__tests__/PlanCards.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
+import { server } from '@/test/server';
+import { MOCK_PLANS } from '@/test/data';
+import { PlanCards } from '../PlanCards';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+
+describe('PlanCards', () => {
+  it('shows a loading skeleton while loading', () => {
+    expect.assertions(1);
+    renderWithProviders(
+      <PlanCards userId={1} plans={undefined} isLoading currentPlanId={undefined} />,
+    );
+
+    expect(screen.getByTestId('plan-cards-loading')).toBeInTheDocument();
+  });
+
+  it('renders every plan and highlights/disables the current one', () => {
+    expect.assertions(4);
+    renderWithProviders(
+      <PlanCards userId={1} plans={MOCK_PLANS} isLoading={false} currentPlanId={2} />,
+    );
+
+    expect(screen.getByText('CURRENT')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Your plan' })).toBeDisabled();
+    expect(screen.getAllByRole('button', { name: 'Subscribe' })).toHaveLength(2);
+    expect(screen.getByText('Starter')).toBeInTheDocument();
+  });
+
+  it('posts the userId/planId payload when subscribing', async () => {
+    expect.assertions(1);
+    let capturedBody: unknown;
+    server.use(
+      http.post(`${BASE}/subscriptions`, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(
+          {
+            id: 300,
+            userId: 7,
+            planId: 3,
+            planName: 'Family',
+            startDate: '2026-07-18T00:00:00Z',
+            endDate: '2026-08-17T00:00:00Z',
+            active: true,
+            createdAt: '2026-07-18T00:00:00Z',
+          },
+          { status: 201 },
+        );
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(
+      <PlanCards userId={7} plans={MOCK_PLANS} isLoading={false} currentPlanId={undefined} />,
+    );
+
+    await user.click(screen.getAllByRole('button', { name: 'Subscribe' })[0]!);
+
+    expect(capturedBody).toEqual({ userId: 7, planId: 1 });
+  });
+
+  it('shows an inline error message when subscribing fails with a 409', async () => {
+    expect.assertions(1);
+    server.use(
+      http.post(`${BASE}/subscriptions`, () =>
+        HttpResponse.json({ code: 'CONFLICT', message: 'An active subscription already exists' }, { status: 409 }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(
+      <PlanCards userId={1} plans={MOCK_PLANS} isLoading={false} currentPlanId={undefined} />,
+    );
+
+    await user.click(screen.getAllByRole('button', { name: 'Subscribe' })[0]!);
+
+    expect(
+      await screen.findByText('You already have an active plan — cancel it first to switch'),
+    ).toBeInTheDocument();
+  });
+});

--- a/lined-web/src/components/subscription/__tests__/SubscriptionHistoryCard.test.tsx
+++ b/lined-web/src/components/subscription/__tests__/SubscriptionHistoryCard.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MOCK_SUBSCRIPTIONS } from '@/test/data';
+import { SubscriptionHistoryCard } from '../SubscriptionHistoryCard';
+
+const planPriceById = new Map([
+  [1, 0],
+  [2, 9.99],
+]);
+
+describe('SubscriptionHistoryCard', () => {
+  it('shows a loading skeleton while loading', () => {
+    expect.assertions(1);
+    render(
+      <SubscriptionHistoryCard history={undefined} isLoading planPriceById={planPriceById} />,
+    );
+
+    expect(screen.getByTestId('subscription-history-loading')).toBeInTheDocument();
+  });
+
+  it('renders each subscription with an ACTIVE or ENDED badge', () => {
+    expect.assertions(4);
+    render(
+      <SubscriptionHistoryCard
+        history={MOCK_SUBSCRIPTIONS}
+        isLoading={false}
+        planPriceById={planPriceById}
+      />,
+    );
+
+    expect(screen.getByText('ACTIVE')).toBeInTheDocument();
+    expect(screen.getByText('ENDED')).toBeInTheDocument();
+    expect(screen.getByText('Pro · $9.99/month')).toBeInTheDocument();
+    expect(screen.getByText('Starter · Free')).toBeInTheDocument();
+  });
+
+  it('shows an empty-history message when there is no history', () => {
+    expect.assertions(1);
+    render(<SubscriptionHistoryCard history={[]} isLoading={false} planPriceById={planPriceById} />);
+
+    expect(screen.getByText('No subscription history yet.')).toBeInTheDocument();
+  });
+});

--- a/lined-web/src/hooks/__tests__/useSubscriptions.test.tsx
+++ b/lined-web/src/hooks/__tests__/useSubscriptions.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { server } from '@/test/server';
+import {
+  usePlans,
+  useActivePlan,
+  useSubscriptionHistory,
+  useStartSubscription,
+  useCancelSubscription,
+} from '../useSubscriptions';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+
+function makeWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+async function waitUntilSettled(result: { current: { isSuccess: boolean; isError: boolean } }) {
+  await waitFor(() => {
+    if (!result.current.isSuccess && !result.current.isError) {
+      throw new Error('not settled yet');
+    }
+  });
+}
+
+describe('usePlans', () => {
+  it('fetches the available plans', async () => {
+    expect.assertions(2);
+    const queryClient = makeQueryClient();
+
+    const { result } = renderHook(() => usePlans(), { wrapper: makeWrapper(queryClient) });
+    await waitUntilSettled(result);
+
+    expect(result.current.isSuccess).toBe(true);
+    expect(result.current.data).toHaveLength(3);
+  });
+
+  it('surfaces a failed request as an error state', async () => {
+    expect.assertions(1);
+    const queryClient = makeQueryClient();
+    server.use(http.get(`${BASE}/plans`, () => new HttpResponse(null, { status: 500 })));
+
+    const { result } = renderHook(() => usePlans(), { wrapper: makeWrapper(queryClient) });
+    await waitUntilSettled(result);
+
+    expect(result.current.isError).toBe(true);
+  });
+});
+
+describe('useActivePlan', () => {
+  it('returns the active subscription for a user on the paid plan', async () => {
+    expect.assertions(2);
+    const queryClient = makeQueryClient();
+
+    const { result } = renderHook(() => useActivePlan(1), { wrapper: makeWrapper(queryClient) });
+    await waitUntilSettled(result);
+
+    expect(result.current.isSuccess).toBe(true);
+    expect(result.current.data?.planName).toBe('Pro');
+  });
+
+  it('treats a 404 as "free plan" (null) instead of an error', async () => {
+    expect.assertions(2);
+    const queryClient = makeQueryClient();
+    server.use(
+      http.get(`${BASE}/subscriptions/:userId/active`, () => new HttpResponse(null, { status: 404 })),
+    );
+
+    const { result } = renderHook(() => useActivePlan(99), { wrapper: makeWrapper(queryClient) });
+    await waitUntilSettled(result);
+
+    expect(result.current.isSuccess).toBe(true);
+    expect(result.current.data).toBeNull();
+  });
+
+  it('surfaces a non-404 failure as an error state', async () => {
+    expect.assertions(1);
+    const queryClient = makeQueryClient();
+    server.use(
+      http.get(`${BASE}/subscriptions/:userId/active`, () => new HttpResponse(null, { status: 500 })),
+    );
+
+    const { result } = renderHook(() => useActivePlan(1), { wrapper: makeWrapper(queryClient) });
+    await waitUntilSettled(result);
+
+    expect(result.current.isError).toBe(true);
+  });
+});
+
+describe('useSubscriptionHistory', () => {
+  it('fetches the subscription history for a user', async () => {
+    expect.assertions(2);
+    const queryClient = makeQueryClient();
+
+    const { result } = renderHook(() => useSubscriptionHistory(1), {
+      wrapper: makeWrapper(queryClient),
+    });
+    await waitUntilSettled(result);
+
+    expect(result.current.isSuccess).toBe(true);
+    expect(result.current.data).toHaveLength(2);
+  });
+});
+
+describe('useStartSubscription', () => {
+  it('posts the userId/planId payload and invalidates active + history', async () => {
+    expect.assertions(3);
+    const queryClient = makeQueryClient();
+    let capturedBody: unknown;
+    server.use(
+      http.post(`${BASE}/subscriptions`, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(
+          {
+            id: 200,
+            userId: 5,
+            planId: 3,
+            planName: 'Family',
+            startDate: '2026-07-18T00:00:00Z',
+            endDate: '2026-08-17T00:00:00Z',
+            active: true,
+            createdAt: '2026-07-18T00:00:00Z',
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    queryClient.setQueryData(['subscriptions', 5, 'active'], null);
+
+    const { result } = renderHook(() => useStartSubscription(5), {
+      wrapper: makeWrapper(queryClient),
+    });
+    result.current.mutate(3);
+    await waitUntilSettled(result);
+
+    expect(result.current.isSuccess).toBe(true);
+    expect(capturedBody).toEqual({ userId: 5, planId: 3 });
+    expect(queryClient.getQueryState(['subscriptions', 5, 'active'])?.isInvalidated).toBe(true);
+  });
+
+  it('rejects with a 409 when the user already has an active subscription', async () => {
+    expect.assertions(1);
+    const queryClient = makeQueryClient();
+
+    const { result } = renderHook(() => useStartSubscription(1), {
+      wrapper: makeWrapper(queryClient),
+    });
+    result.current.mutate(3);
+    await waitUntilSettled(result);
+
+    expect(result.current.isError).toBe(true);
+  });
+});
+
+describe('useCancelSubscription', () => {
+  it('cancels the active subscription and invalidates active + history', async () => {
+    expect.assertions(2);
+    const queryClient = makeQueryClient();
+
+    queryClient.setQueryData(['subscriptions', 1, 'history'], []);
+
+    const { result } = renderHook(() => useCancelSubscription(1), {
+      wrapper: makeWrapper(queryClient),
+    });
+    result.current.mutate();
+    await waitUntilSettled(result);
+
+    expect(result.current.isSuccess).toBe(true);
+    expect(queryClient.getQueryState(['subscriptions', 1, 'history'])?.isInvalidated).toBe(true);
+  });
+
+  it('rejects with a 404 when there is no active subscription to cancel', async () => {
+    expect.assertions(1);
+    const queryClient = makeQueryClient();
+
+    const { result } = renderHook(() => useCancelSubscription(99), {
+      wrapper: makeWrapper(queryClient),
+    });
+    result.current.mutate();
+    await waitUntilSettled(result);
+
+    expect(result.current.isError).toBe(true);
+  });
+});

--- a/lined-web/src/hooks/useSubscriptions.ts
+++ b/lined-web/src/hooks/useSubscriptions.ts
@@ -1,0 +1,62 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { HTTPError } from 'ky';
+import { listPlans } from '@/api/plans';
+import {
+  getActiveSubscription,
+  getSubscriptionHistory,
+  startSubscription,
+  cancelSubscription,
+} from '@/api/subscriptions';
+import { QUERY_KEYS } from '@/lib/constants';
+import type { SubscriptionDto } from '@/types';
+
+export const usePlans = () =>
+  useQuery({
+    queryKey: QUERY_KEYS.plans,
+    queryFn: listPlans,
+  });
+
+/** A 404 means "no active subscription" (free plan), not an error. */
+export const useActivePlan = (userId: number | undefined) =>
+  useQuery({
+    queryKey: QUERY_KEYS.activeSubscription(userId ?? 0),
+    queryFn: async (): Promise<SubscriptionDto | null> => {
+      try {
+        return await getActiveSubscription(userId!);
+      } catch (error) {
+        if (error instanceof HTTPError && error.response.status === 404) return null;
+        throw error;
+      }
+    },
+    enabled: userId != null,
+    retry: false,
+  });
+
+export const useSubscriptionHistory = (userId: number | undefined) =>
+  useQuery({
+    queryKey: QUERY_KEYS.subscriptionHistory(userId ?? 0),
+    queryFn: () => getSubscriptionHistory(userId!),
+    enabled: userId != null,
+  });
+
+export const useStartSubscription = (userId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (planId: number) => startSubscription({ userId, planId }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.activeSubscription(userId) });
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.subscriptionHistory(userId) });
+    },
+  });
+};
+
+export const useCancelSubscription = (userId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => cancelSubscription(userId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.activeSubscription(userId) });
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.subscriptionHistory(userId) });
+    },
+  });
+};

--- a/lined-web/src/lib/constants.ts
+++ b/lined-web/src/lib/constants.ts
@@ -94,4 +94,7 @@ export const QUERY_KEYS = {
   lobbyNotificationPreferences: (lobbyId: number) =>
     ['notifications', 'lobby-preferences', lobbyId] as const,
   myNotifications: ['notifications', 'mine'] as const,
+  plans: ['plans'] as const,
+  activeSubscription: (userId: number) => ['subscriptions', userId, 'active'] as const,
+  subscriptionHistory: (userId: number) => ['subscriptions', userId, 'history'] as const,
 } as const;

--- a/lined-web/src/lib/subscriptionUtils.ts
+++ b/lined-web/src/lib/subscriptionUtils.ts
@@ -1,0 +1,13 @@
+/** "28 Mar 2026" */
+export function formatShortDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+/** "Free" for a $0 plan, else "$9.99". */
+export function formatPlanPrice(priceUsd: number): string {
+  return priceUsd === 0 ? 'Free' : `$${priceUsd.toFixed(2)}`;
+}

--- a/lined-web/src/pages/SubscriptionPage.tsx
+++ b/lined-web/src/pages/SubscriptionPage.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { usePlans, useActivePlan, useSubscriptionHistory } from '@/hooks/useSubscriptions';
+import { CurrentPlanCard } from '@/components/subscription/CurrentPlanCard';
+import { PlanCards } from '@/components/subscription/PlanCards';
+import { SubscriptionHistoryCard } from '@/components/subscription/SubscriptionHistoryCard';
+
+export function SubscriptionPage() {
+  const { data: user } = useCurrentUser();
+  const userId = user?.id;
+
+  const { data: plans, isLoading: isPlansLoading } = usePlans();
+  const { data: activeSubscription, isLoading: isActiveLoading } = useActivePlan(userId);
+  const { data: history, isLoading: isHistoryLoading } = useSubscriptionHistory(userId);
+
+  const planPriceById = useMemo(
+    () => new Map((plans ?? []).map((plan) => [plan.id, plan.priceUsd])),
+    [plans],
+  );
+  const activePlanDetails = plans?.find((plan) => plan.id === activeSubscription?.planId);
+
+  return (
+    <div className="flex-1 overflow-y-auto bg-bg p-8">
+      <h1 className="mb-5 text-xl font-bold text-text-primary">Subscription</h1>
+
+      <CurrentPlanCard
+        userId={userId ?? 0}
+        activeSubscription={activeSubscription}
+        activePlanDetails={activePlanDetails}
+        isLoading={isActiveLoading}
+      />
+
+      <div className="mb-2 mt-2 text-sm font-bold text-text-primary">Available Plans</div>
+      <div className="mb-5">
+        <PlanCards
+          userId={userId ?? 0}
+          plans={plans}
+          isLoading={isPlansLoading}
+          currentPlanId={activeSubscription?.planId}
+        />
+      </div>
+
+      <SubscriptionHistoryCard
+        history={history}
+        isLoading={isHistoryLoading}
+        planPriceById={planPriceById}
+      />
+    </div>
+  );
+}

--- a/lined-web/src/pages/__tests__/SubscriptionPage.test.tsx
+++ b/lined-web/src/pages/__tests__/SubscriptionPage.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderWithProviders, screen } from '@/test/utils';
+import { MOCK_USERS } from '@/test/data';
+import { useAuthStore } from '@/store/auth';
+import { SubscriptionPage } from '../SubscriptionPage';
+
+const user = MOCK_USERS[0]!;
+
+describe('SubscriptionPage', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ userId: user.id });
+  });
+
+  it('renders the current plan, available plans, and history sections', async () => {
+    expect.assertions(4);
+    renderWithProviders(<SubscriptionPage />);
+
+    expect(await screen.findByText('Renews 28 Apr 2026')).toBeInTheDocument();
+    expect(await screen.findByText('CURRENT')).toBeInTheDocument();
+    expect(await screen.findByText('Family')).toBeInTheDocument();
+    expect(await screen.findByText('ENDED')).toBeInTheDocument();
+  });
+});

--- a/lined-web/src/router.tsx
+++ b/lined-web/src/router.tsx
@@ -9,6 +9,7 @@ import { LobbySettingsPage } from '@/pages/LobbySettingsPage';
 import { CalendarPage } from '@/pages/CalendarPage';
 import { TasksPage } from '@/pages/TasksPage';
 import { UserSettingsPage } from '@/pages/UserSettingsPage';
+import { SubscriptionPage } from '@/pages/SubscriptionPage';
 
 export const router = createBrowserRouter([
   {
@@ -40,6 +41,7 @@ export const router = createBrowserRouter([
           { path: 'calendar', element: <CalendarPage /> },
           { path: 'tasks', element: <TasksPage /> },
           { path: 'settings', element: <UserSettingsPage /> },
+          { path: 'subscription', element: <SubscriptionPage /> },
         ],
       },
     ],

--- a/lined-web/src/test/data.ts
+++ b/lined-web/src/test/data.ts
@@ -6,6 +6,8 @@ import type {
   FreeSlotDto,
   LobbyInviteDto,
   NotificationDto,
+  PlanDto,
+  SubscriptionDto,
 } from '@/types';
 
 export const MOCK_USERS: UserDto[] = [
@@ -539,5 +541,52 @@ export const MOCK_NOTIFICATIONS: NotificationDto[] = [
         deliveredAt: '2026-07-16T08:00:00Z',
       },
     ],
+  },
+];
+
+export const MOCK_PLANS: PlanDto[] = [
+  {
+    id: 1,
+    name: 'Starter',
+    priceUsd: 0,
+    durationDays: 0,
+    createdAt: '2025-01-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    name: 'Pro',
+    priceUsd: 9.99,
+    durationDays: 30,
+    createdAt: '2025-01-01T00:00:00Z',
+  },
+  {
+    id: 3,
+    name: 'Family',
+    priceUsd: 14.99,
+    durationDays: 30,
+    createdAt: '2025-01-01T00:00:00Z',
+  },
+];
+
+export const MOCK_SUBSCRIPTIONS: SubscriptionDto[] = [
+  {
+    id: 100,
+    userId: 1,
+    planId: 2,
+    planName: 'Pro',
+    startDate: '2026-03-28T00:00:00Z',
+    endDate: '2026-04-28T00:00:00Z',
+    active: true,
+    createdAt: '2026-03-28T00:00:00Z',
+  },
+  {
+    id: 99,
+    userId: 1,
+    planId: 1,
+    planName: 'Starter',
+    startDate: '2026-01-10T00:00:00Z',
+    endDate: '2026-03-28T00:00:00Z',
+    active: false,
+    createdAt: '2026-01-10T00:00:00Z',
   },
 ];

--- a/lined-web/src/test/handlers/index.ts
+++ b/lined-web/src/test/handlers/index.ts
@@ -5,6 +5,8 @@ import { eventHandlers } from './events';
 import { authHandlers } from './auth';
 import { inviteHandlers } from './invites';
 import { notificationHandlers } from './notifications';
+import { planHandlers } from './plans';
+import { subscriptionHandlers } from './subscriptions';
 
 export const handlers = [
   ...userHandlers,
@@ -14,4 +16,6 @@ export const handlers = [
   ...authHandlers,
   ...inviteHandlers,
   ...notificationHandlers,
+  ...planHandlers,
+  ...subscriptionHandlers,
 ];

--- a/lined-web/src/test/handlers/plans.ts
+++ b/lined-web/src/test/handlers/plans.ts
@@ -1,0 +1,10 @@
+import { http, HttpResponse } from 'msw';
+import { MOCK_PLANS } from '../data';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+
+export const planHandlers = [
+  http.get(`${BASE}/plans`, () => {
+    return HttpResponse.json(MOCK_PLANS);
+  }),
+];

--- a/lined-web/src/test/handlers/subscriptions.ts
+++ b/lined-web/src/test/handlers/subscriptions.ts
@@ -1,0 +1,71 @@
+import { http, HttpResponse } from 'msw';
+import { MOCK_SUBSCRIPTIONS, MOCK_PLANS } from '../data';
+import type { SubscriptionDto } from '@/types';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+
+let mockSubscriptions: SubscriptionDto[] = [...MOCK_SUBSCRIPTIONS];
+let nextSubscriptionId = 101;
+
+function findActive(userId: number): SubscriptionDto | undefined {
+  return mockSubscriptions.find((s) => s.userId === userId && s.active);
+}
+
+export const subscriptionHandlers = [
+  http.get(`${BASE}/subscriptions/:userId/active`, ({ params }) => {
+    const userId = Number(params['userId']);
+    const active = findActive(userId);
+    if (!active) return new HttpResponse(null, { status: 404 });
+    return HttpResponse.json(active);
+  }),
+
+  http.get(`${BASE}/subscriptions/:userId/history`, ({ params }) => {
+    const userId = Number(params['userId']);
+    return HttpResponse.json(
+      mockSubscriptions
+        .filter((s) => s.userId === userId)
+        .sort((a, b) => b.startDate.localeCompare(a.startDate)),
+    );
+  }),
+
+  http.post(`${BASE}/subscriptions`, async ({ request }) => {
+    const body = (await request.json()) as { userId: number; planId: number };
+    if (findActive(body.userId)) {
+      return HttpResponse.json(
+        { code: 'CONFLICT', message: 'An active subscription already exists' },
+        { status: 409 },
+      );
+    }
+    const plan = MOCK_PLANS.find((p) => p.id === body.planId);
+    if (!plan) return new HttpResponse(null, { status: 404 });
+
+    const now = new Date();
+    const end = new Date(now.getTime() + plan.durationDays * 24 * 60 * 60 * 1000);
+    const created: SubscriptionDto = {
+      id: nextSubscriptionId++,
+      userId: body.userId,
+      planId: plan.id,
+      planName: plan.name,
+      startDate: now.toISOString(),
+      endDate: end.toISOString(),
+      active: true,
+      createdAt: now.toISOString(),
+    };
+    mockSubscriptions = [created, ...mockSubscriptions];
+    return HttpResponse.json(created, { status: 201 });
+  }),
+
+  http.post(`${BASE}/subscriptions/:userId/cancel-active`, ({ params }) => {
+    const userId = Number(params['userId']);
+    const active = findActive(userId);
+    if (!active) return new HttpResponse(null, { status: 404 });
+
+    const cancelled: SubscriptionDto = {
+      ...active,
+      active: false,
+      endDate: new Date().toISOString(),
+    };
+    mockSubscriptions = mockSubscriptions.map((s) => (s.id === cancelled.id ? cancelled : s));
+    return HttpResponse.json(cancelled);
+  }),
+];


### PR DESCRIPTION
## Summary

Implements Task 14 — the Subscription & Plan page
([tasks/UI-14-subscription-page.md](lined-web/docs/tasks/UI-14-subscription-page.md)).

- New `/subscription` route (`SubscriptionPage`), linked from a new
  "Subscription" item in the User Settings PREFERENCES menu.
- **Current Plan** card: plan name/price/renewal date with a
  confirm-gated "Cancel subscription" button, or a "You are on the
  free plan." message when there's no active subscription.
- **Available Plans** cards: one per plan from `GET /api/plans`, the
  active plan highlighted with a CURRENT badge and disabled button,
  others get "Subscribe" (`POST /api/subscriptions`), with an inline
  error when a 409 conflict occurs (already has an active plan).
- **Subscription History** card: list from
  `GET /api/subscriptions/{userId}/history` with ACTIVE/ENDED badges.
- New `useSubscriptions.ts` hooks: `usePlans`, `useActivePlan` (treats
  a 404 as "free plan" rather than an error), `useSubscriptionHistory`,
  `useStartSubscription`, `useCancelSubscription`.
- MSW mocks for `plans`/`subscriptions` (mirrors the real backend's
  404/409 behavior) so the whole flow — including negative/error
  cases — is covered in both dev-mock and real-API modes.
- Every data-fetching card has a loading skeleton; mutations never
  swallow errors (inline messages via `getApiErrorMessage`).

## Test plan

- [x] `npm run lint` — passes
- [x] `npm run typecheck` — passes
- [x] `npm run test:run` — 25 new tests pass (hooks, all 3 components,
      page, updated `SettingsMenu` test); the only 4 failing tests in
      the suite are pre-existing date-relative fixtures in
      `CalendarPage.test.tsx`/`DashboardPage.test.tsx` unrelated to
      this change (confirmed failing identically on `main`)
- [x] `npm run build` — passes
- [x] Manually verified in the browser against the real backend
      (`localhost:8080`) at 1280×800, matching the
      `http://localhost:4321/#subscription` mockup:
  - Current-plan card renders Pro · $9.99/month, renewal date, and
    plan cards with Pro highlighted CURRENT
  - Cancel subscription → confirm dialog → free-plan message +
    history updated to ENDED
  - Subscribe (Pro) → current-plan card updates, CURRENT badge moves,
    history gets a new ACTIVE row
  - Subscribing again while already active → inline 409 error "You
    already have an active plan — cancel it first to switch"

🤖 Generated with [Claude Code](https://claude.com/claude-code)