### PR TITLE
feat(web): Task 18 — forgot-password flow (mock-only MVP)

### DIFF
--- a/lined-web/docs/UI_TASKS.md
+++ b/lined-web/docs/UI_TASKS.md
@@ -65,6 +65,20 @@ exist for every task, including `create-lobby` (task 4), `calendar-month`
   `useSubscriptionHistory`, `useStartSubscription`,
   `useCancelSubscription`).
 
+- **Forgot Password flow** — `ForgotPasswordPage`, `ResetPasswordPage`:
+  `/forgot-password` (identifier form, always shows a neutral "we've sent a
+  link" message regardless of match, avoiding account enumeration) and
+  `/reset-password?token=...` (new-password + confirm fields reusing
+  `SignUpPage`'s validation; missing token shows an `AuthAlert` before any
+  form renders; a rejected token shows the same alert with a link back to
+  `/forgot-password`; success redirects to `/sign-in?reset=success`, which
+  shows a new `AuthAlert` `success` variant). **Mock-only MVP:** the backend
+  has no password-reset endpoints yet (`POST /api/auth/password-reset-requests`,
+  `POST /api/auth/password-resets` — see `backend/lined/docs/experiment-tasks.md`,
+  `feature/password-reset-flow`); this flow is only exercised against MSW
+  and cannot be verified against the real API until that gap ships.
+  `SignInPage`'s "Forgot password?" text is now a real `<Link>`.
+
 **Stubs only ("coming soon" placeholders):**
 SignInPage, SignUpPage, DashboardPage.
 
@@ -111,7 +125,7 @@ SignInPage, SignUpPage, DashboardPage.
 | 15 | `feature/ui-15-api-contract-refresh` | Migrate `src/api`/`src/types`/MSW to the July 2026 backend contract (login, invites, new task/event fields, tasks/mine, free-slots, notifications) | [tasks/UI-15-api-contract-refresh.md](tasks/UI-15-api-contract-refresh.md) | DONE |
 | 16 | `feature/ui-16-notifications-center` | Notification bell + inbox (unread count, mark read) and backend-persisted notification preferences | [tasks/UI-16-notifications-center.md](tasks/UI-16-notifications-center.md) | DONE |
 | 17 | `feature/ui-17-lobby-invites-inbox` | Invitee-side invites: pending invites list, accept/decline flows | [tasks/UI-17-lobby-invites-inbox.md](tasks/UI-17-lobby-invites-inbox.md) | DONE |
-| 18 | `feature/ui-18-forgot-password` | Forgot password flow: request form, token redemption, new-password form | [tasks/UI-18-forgot-password.md](tasks/UI-18-forgot-password.md) | TODO |
+| 18 | `feature/ui-18-forgot-password` | Forgot password flow: request form, token redemption, new-password form | [tasks/UI-18-forgot-password.md](tasks/UI-18-forgot-password.md) | DONE |
 
 ## Suggested order
 

--- a/lined-web/docs/tasks/UI-18-forgot-password.md
+++ b/lined-web/docs/tasks/UI-18-forgot-password.md
@@ -95,3 +95,15 @@ there is no separate mockup screen to match pixel-for-pixel.
 until they (or an agreed MVP substitute) ship — see the gap entry above for
 the proposed shape (reset-request → single-use expiring token → token
 redemption sets the new password).
+
+## Progress note (mock-only MVP)
+
+Shipped against MSW only, per an explicit decision to unblock the frontend
+work ahead of the backend gap (`feature/password-reset-flow` in
+`backend/lined/docs/experiment-tasks.md`, still `No`/not started as of this
+PR). `src/api/auth.ts`'s `requestPasswordReset`/`resetPassword` call the
+exact contract from `backend/lined/docs/api-proposals/password-reset-flow.md`
+(`POST /api/auth/password-reset-requests` → 202, `POST
+/api/auth/password-resets` → 204/400), so the client is ready to point at
+the real endpoints once they ship — no frontend changes should be needed,
+only removing this note and re-verifying against the live backend.

--- a/lined-web/src/api/auth.ts
+++ b/lined-web/src/api/auth.ts
@@ -1,6 +1,19 @@
 import { api } from './client';
-import type { LoginRequestDto, LoginResponseDto } from '@/types';
+import type {
+  LoginRequestDto,
+  LoginResponseDto,
+  PasswordResetDto,
+  PasswordResetRequestDto,
+} from '@/types';
 
 export function login(data: LoginRequestDto): Promise<LoginResponseDto> {
   return api.post('auth/login', { json: data }).json<LoginResponseDto>();
+}
+
+export function requestPasswordReset(data: PasswordResetRequestDto): Promise<void> {
+  return api.post('auth/password-reset-requests', { json: data }).then(() => undefined);
+}
+
+export function resetPassword(data: PasswordResetDto): Promise<void> {
+  return api.post('auth/password-resets', { json: data }).then(() => undefined);
 }

--- a/lined-web/src/components/AuthAlert.tsx
+++ b/lined-web/src/components/AuthAlert.tsx
@@ -1,12 +1,23 @@
-import { TriangleAlert } from 'lucide-react';
+import { CircleCheck, TriangleAlert } from 'lucide-react';
 
-export function AuthAlert({ message }: { message: string }) {
+interface AuthAlertProps {
+  message: string;
+  variant?: 'error' | 'success';
+}
+
+const VARIANT_CLASSES: Record<NonNullable<AuthAlertProps['variant']>, string> = {
+  error: 'border-red-200 bg-red-50 text-red-700',
+  success: 'border-brand-green/30 bg-brand-green-light text-brand-green-dark',
+};
+
+export function AuthAlert({ message, variant = 'error' }: AuthAlertProps) {
+  const Icon = variant === 'success' ? CircleCheck : TriangleAlert;
   return (
     <div
       role="alert"
-      className="mt-4 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+      className={`mt-4 flex items-start gap-2 rounded-lg border px-4 py-3 text-sm ${VARIANT_CLASSES[variant]}`}
     >
-      <TriangleAlert className="mt-0.5 h-4 w-4 flex-shrink-0" />
+      <Icon className="mt-0.5 h-4 w-4 flex-shrink-0" />
       <span>{message}</span>
     </div>
   );

--- a/lined-web/src/hooks/useAuth.ts
+++ b/lined-web/src/hooks/useAuth.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { login } from '@/api/auth';
+import { login, requestPasswordReset, resetPassword } from '@/api/auth';
 import { createUser } from '@/api/users';
 
 export function useSignIn() {
@@ -8,4 +8,12 @@ export function useSignIn() {
 
 export function useSignUp() {
   return useMutation({ mutationFn: createUser });
+}
+
+export function useRequestPasswordReset() {
+  return useMutation({ mutationFn: requestPasswordReset });
+}
+
+export function useResetPassword() {
+  return useMutation({ mutationFn: resetPassword });
 }

--- a/lined-web/src/pages/ForgotPasswordPage.tsx
+++ b/lined-web/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,86 @@
+import { Link } from 'react-router-dom';
+import { AuthCard } from '@/components/AuthCard';
+import { FormField } from '@/components/FormField';
+import { useRequestPasswordReset } from '@/hooks/useAuth';
+import { useFormState } from '@/hooks/useFormState';
+
+interface FormValues {
+  identifier: string;
+}
+
+function validate(values: FormValues): Partial<Record<keyof FormValues, string>> {
+  const errors: Partial<Record<keyof FormValues, string>> = {};
+  if (!values.identifier.trim()) errors.identifier = 'Email or username is required';
+  return errors;
+}
+
+export function ForgotPasswordPage() {
+  const requestReset = useRequestPasswordReset();
+
+  const { values, errors, touched, set, markTouched, markAllTouched, hasErrors } = useFormState<FormValues>(
+    { identifier: '' },
+    validate,
+  );
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    markAllTouched();
+    if (hasErrors) return;
+
+    requestReset.mutate(values);
+  }
+
+  // Always shown once a submission has settled, whether it succeeded or
+  // failed — the identifier's existence must never be observable.
+  const submitted = requestReset.isSuccess || requestReset.isError;
+
+  if (submitted) {
+    return (
+      <AuthCard heading="Check your email" subheading="If an account exists for that email or username">
+        <p className="mt-5 text-sm text-text-secondary">
+          If an account exists for that email or username, we&apos;ve sent a link to reset your
+          password.
+        </p>
+        <p className="mt-6 text-center text-sm text-text-secondary">
+          <Link to="/sign-in" className="font-medium text-brand-green hover:underline">
+            ← Back to sign in
+          </Link>
+        </p>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard heading="Forgot your password?" subheading="Enter your email or username and we'll send you a reset link">
+      <form onSubmit={handleSubmit} noValidate>
+        <div className="mt-5">
+          <FormField
+            id="forgot-password-identifier"
+            label="Email or username"
+            type="text"
+            autoComplete="username"
+            value={values.identifier}
+            onChange={(v) => set('identifier', v)}
+            onBlur={() => markTouched('identifier')}
+            placeholder="alex@example.com"
+            error={touched.identifier ? errors.identifier : null}
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={requestReset.isPending}
+          className="mt-6 h-12 w-full rounded-lg bg-brand-green text-sm font-semibold text-white transition-colors hover:bg-brand-green-dark disabled:opacity-60"
+        >
+          {requestReset.isPending ? 'Sending…' : 'Send reset link'}
+        </button>
+
+        <p className="mt-6 text-center text-sm text-text-secondary">
+          <Link to="/sign-in" className="font-medium text-brand-green hover:underline">
+            ← Back to sign in
+          </Link>
+        </p>
+      </form>
+    </AuthCard>
+  );
+}

--- a/lined-web/src/pages/ResetPasswordPage.tsx
+++ b/lined-web/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,119 @@
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { AuthCard } from '@/components/AuthCard';
+import { FormField } from '@/components/FormField';
+import { AuthAlert } from '@/components/AuthAlert';
+import { useResetPassword } from '@/hooks/useAuth';
+import { useFormState } from '@/hooks/useFormState';
+
+interface FormValues {
+  newPassword: string;
+  confirmPassword: string;
+}
+
+function validate(values: FormValues): Partial<Record<keyof FormValues, string>> {
+  const errors: Partial<Record<keyof FormValues, string>> = {};
+  if (!values.newPassword) {
+    errors.newPassword = 'Password is required';
+  } else if (values.newPassword.length < 8) {
+    errors.newPassword = 'Password must be at least 8 characters';
+  }
+  if (!values.confirmPassword) {
+    errors.confirmPassword = 'Please confirm your password';
+  } else if (values.confirmPassword !== values.newPassword) {
+    errors.confirmPassword = 'Passwords do not match';
+  }
+  return errors;
+}
+
+function InvalidTokenCard() {
+  return (
+    <AuthCard heading="Reset your password" subheading="Set a new password for your account">
+      <AuthAlert message="This reset link is invalid or has expired." />
+      <p className="mt-6 text-center text-sm text-text-secondary">
+        <Link to="/forgot-password" className="font-medium text-brand-green hover:underline">
+          Request a new reset link →
+        </Link>
+      </p>
+    </AuthCard>
+  );
+}
+
+export function ResetPasswordPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
+  const resetPassword = useResetPassword();
+
+  const { values, errors, touched, set, markTouched, markAllTouched, hasErrors } = useFormState<FormValues>(
+    { newPassword: '', confirmPassword: '' },
+    validate,
+  );
+
+  if (!token) {
+    return <InvalidTokenCard />;
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    markAllTouched();
+    if (hasErrors) return;
+
+    resetPassword.mutate(
+      { token, newPassword: values.newPassword },
+      { onSuccess: () => navigate('/sign-in?reset=success') },
+    );
+  }
+
+  return (
+    <AuthCard heading="Reset your password" subheading="Set a new password for your account">
+      <form onSubmit={handleSubmit} noValidate>
+        <div className="mt-5">
+          <FormField
+            id="reset-password-new"
+            label="New password"
+            type="password"
+            autoComplete="new-password"
+            value={values.newPassword}
+            onChange={(v) => set('newPassword', v)}
+            onBlur={() => markTouched('newPassword')}
+            placeholder="Create a strong password"
+            error={touched.newPassword ? errors.newPassword : null}
+          />
+        </div>
+        <div className="mt-5">
+          <FormField
+            id="reset-password-confirm"
+            label="Confirm password"
+            type="password"
+            autoComplete="new-password"
+            value={values.confirmPassword}
+            onChange={(v) => set('confirmPassword', v)}
+            onBlur={() => markTouched('confirmPassword')}
+            placeholder="Re-enter your password"
+            error={touched.confirmPassword ? errors.confirmPassword : null}
+          />
+        </div>
+
+        {resetPassword.isError && (
+          <AuthAlert message="This reset link is invalid or has expired." />
+        )}
+
+        <button
+          type="submit"
+          disabled={resetPassword.isPending}
+          className="mt-6 h-12 w-full rounded-lg bg-brand-green text-sm font-semibold text-white transition-colors hover:bg-brand-green-dark disabled:opacity-60"
+        >
+          {resetPassword.isPending ? 'Resetting…' : 'Reset password'}
+        </button>
+
+        {resetPassword.isError && (
+          <p className="mt-6 text-center text-sm text-text-secondary">
+            <Link to="/forgot-password" className="font-medium text-brand-green hover:underline">
+              Request a new reset link →
+            </Link>
+          </p>
+        )}
+      </form>
+    </AuthCard>
+  );
+}

--- a/lined-web/src/pages/ResetPasswordPage.tsx
+++ b/lined-web/src/pages/ResetPasswordPage.tsx
@@ -52,6 +52,7 @@ export function ResetPasswordPage() {
   if (!token) {
     return <InvalidTokenCard />;
   }
+  const resetToken = token;
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -59,7 +60,7 @@ export function ResetPasswordPage() {
     if (hasErrors) return;
 
     resetPassword.mutate(
-      { token, newPassword: values.newPassword },
+      { token: resetToken, newPassword: values.newPassword },
       { onSuccess: () => navigate('/sign-in?reset=success') },
     );
   }

--- a/lined-web/src/pages/SignInPage.tsx
+++ b/lined-web/src/pages/SignInPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { HTTPError } from 'ky';
 import { AuthCard } from '@/components/AuthCard';
 import { FormField } from '@/components/FormField';
@@ -21,8 +21,10 @@ function validate(values: FormValues): Partial<Record<keyof FormValues, string>>
 
 export function SignInPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const signIn = useSignIn();
   const setUserId = useAuthStore((s) => s.setUserId);
+  const resetSucceeded = searchParams.get('reset') === 'success';
 
   const { values, errors, touched, set, markTouched, markAllTouched, hasErrors } = useFormState<FormValues>(
     { identifier: '', password: '' },
@@ -46,6 +48,9 @@ export function SignInPage() {
 
   return (
     <AuthCard heading="Welcome back" subheading="Sign in to your Lined account">
+      {resetSucceeded && (
+        <AuthAlert variant="success" message="Password reset — sign in with your new password." />
+      )}
       <form onSubmit={handleSubmit} noValidate>
         <div className="mt-5">
           <FormField
@@ -72,7 +77,11 @@ export function SignInPage() {
             placeholder="••••••••"
             error={touched.password ? errors.password : null}
           />
-          <div className="mt-1.5 text-xs text-text-secondary">Forgot password?</div>
+          <div className="mt-1.5 text-xs">
+            <Link to="/forgot-password" className="font-medium text-brand-green hover:underline">
+              Forgot password?
+            </Link>
+          </div>
         </div>
 
         {serverError && <AuthAlert message={serverError} />}

--- a/lined-web/src/pages/__tests__/ForgotPasswordPage.test.tsx
+++ b/lined-web/src/pages/__tests__/ForgotPasswordPage.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { Routes, Route } from 'react-router-dom';
+import { http, HttpResponse, delay } from 'msw';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
+import { server } from '@/test/server';
+import { ForgotPasswordPage } from '../ForgotPasswordPage';
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+
+function renderForgotPassword() {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+      <Route path="/sign-in" element={<div>Sign In Page</div>} />
+    </Routes>,
+    { initialEntries: ['/forgot-password'] },
+  );
+}
+
+describe('ForgotPasswordPage', () => {
+  it('shows the neutral success message for a known identifier', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderForgotPassword();
+
+    await user.type(screen.getByLabelText(/email or username/i), 'alex@lined.app');
+    await user.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    expect(
+      await screen.findByText(/we've sent a link to reset your password/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the same neutral success message for an unknown identifier', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderForgotPassword();
+
+    await user.type(screen.getByLabelText(/email or username/i), 'nobody@lined.app');
+    await user.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    expect(
+      await screen.findByText(/we've sent a link to reset your password/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a required-field error after blurring an empty identifier', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderForgotPassword();
+
+    await user.click(screen.getByLabelText(/email or username/i));
+    await user.tab();
+
+    expect(await screen.findByText('Email or username is required')).toBeInTheDocument();
+  });
+
+  it('shows a pending label while the request is in flight', async () => {
+    expect.assertions(1);
+    server.use(
+      http.post(`${BASE}/auth/password-reset-requests`, async () => {
+        await delay(50);
+        return new HttpResponse(null, { status: 202 });
+      }),
+    );
+    const user = userEvent.setup();
+    renderForgotPassword();
+
+    await user.type(screen.getByLabelText(/email or username/i), 'alex@lined.app');
+    await user.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    expect(screen.getByRole('button', { name: /sending/i })).toBeDisabled();
+  });
+});

--- a/lined-web/src/pages/__tests__/ResetPasswordPage.test.tsx
+++ b/lined-web/src/pages/__tests__/ResetPasswordPage.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { Routes, Route } from 'react-router-dom';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
+import { ResetPasswordPage } from '../ResetPasswordPage';
+
+function renderResetPassword(initialEntry: string) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/reset-password" element={<ResetPasswordPage />} />
+      <Route path="/sign-in" element={<div>Sign In Page</div>} />
+      <Route path="/forgot-password" element={<div>Forgot Password Page</div>} />
+    </Routes>,
+    { initialEntries: [initialEntry] },
+  );
+}
+
+async function fillPasswords(
+  user: ReturnType<typeof userEvent.setup>,
+  newPassword: string,
+  confirmPassword: string,
+) {
+  await user.type(screen.getByLabelText(/new password/i), newPassword);
+  await user.type(screen.getByLabelText(/confirm password/i), confirmPassword);
+}
+
+describe('ResetPasswordPage', () => {
+  it('shows an invalid-link alert with no form when the token is missing', () => {
+    expect.assertions(2);
+    renderResetPassword('/reset-password');
+
+    expect(screen.getByText(/invalid or has expired/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/new password/i)).not.toBeInTheDocument();
+  });
+
+  it('resets the password with a valid token and redirects to sign-in with a success flag', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderResetPassword('/reset-password?token=valid-token');
+
+    await fillPasswords(user, 'newstrongpass1', 'newstrongpass1');
+    await user.click(screen.getByRole('button', { name: /reset password/i }));
+
+    expect(await screen.findByText('Sign In Page')).toBeInTheDocument();
+  });
+
+  it('shows a mismatch error when the passwords differ and blocks submission', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderResetPassword('/reset-password?token=valid-token');
+
+    await fillPasswords(user, 'newstrongpass1', 'differentpass1');
+    await user.click(screen.getByRole('button', { name: /reset password/i }));
+
+    expect(await screen.findByText('Passwords do not match')).toBeInTheDocument();
+  });
+
+  it('shows a min-length error for a short password', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderResetPassword('/reset-password?token=valid-token');
+
+    await fillPasswords(user, 'short', 'short');
+    await user.click(screen.getByRole('button', { name: /reset password/i }));
+
+    expect(
+      await screen.findByText('Password must be at least 8 characters'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows an invalid/expired alert with a link back when the server rejects the token', async () => {
+    expect.assertions(2);
+    const user = userEvent.setup();
+    renderResetPassword('/reset-password?token=expired-token');
+
+    await fillPasswords(user, 'newstrongpass1', 'newstrongpass1');
+    await user.click(screen.getByRole('button', { name: /reset password/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/invalid or has expired/i);
+    expect(screen.getByRole('link', { name: /request a new reset link/i })).toHaveAttribute(
+      'href',
+      '/forgot-password',
+    );
+  });
+});

--- a/lined-web/src/pages/__tests__/SignInPage.test.tsx
+++ b/lined-web/src/pages/__tests__/SignInPage.test.tsx
@@ -80,4 +80,28 @@ describe('SignInPage', () => {
 
     expect(await screen.findByText('Password is required')).toBeInTheDocument();
   });
+
+  it('renders a "Forgot password?" link to /forgot-password', () => {
+    expect.assertions(1);
+    renderSignIn();
+
+    expect(screen.getByRole('link', { name: /forgot password/i })).toHaveAttribute(
+      'href',
+      '/forgot-password',
+    );
+  });
+
+  it('shows a success banner when redirected from a completed password reset', () => {
+    expect.assertions(1);
+    renderWithProviders(
+      <Routes>
+        <Route path="/sign-in" element={<SignInPage />} />
+      </Routes>,
+      { initialEntries: ['/sign-in?reset=success'] },
+    );
+
+    expect(
+      screen.getByText(/password reset — sign in with your new password/i),
+    ).toBeInTheDocument();
+  });
 });

--- a/lined-web/src/router.tsx
+++ b/lined-web/src/router.tsx
@@ -3,6 +3,8 @@ import { AppShell } from '@/components/AppShell';
 import { RequireAuth, RedirectIfAuthed } from '@/components/RequireAuth';
 import { SignInPage } from '@/pages/SignInPage';
 import { SignUpPage } from '@/pages/SignUpPage';
+import { ForgotPasswordPage } from '@/pages/ForgotPasswordPage';
+import { ResetPasswordPage } from '@/pages/ResetPasswordPage';
 import { DashboardPage } from '@/pages/DashboardPage';
 import { LobbyPage } from '@/pages/LobbyPage';
 import { LobbySettingsPage } from '@/pages/LobbySettingsPage';
@@ -25,6 +27,22 @@ export const router = createBrowserRouter([
     element: (
       <RedirectIfAuthed>
         <SignUpPage />
+      </RedirectIfAuthed>
+    ),
+  },
+  {
+    path: '/forgot-password',
+    element: (
+      <RedirectIfAuthed>
+        <ForgotPasswordPage />
+      </RedirectIfAuthed>
+    ),
+  },
+  {
+    path: '/reset-password',
+    element: (
+      <RedirectIfAuthed>
+        <ResetPasswordPage />
       </RedirectIfAuthed>
     ),
   },

--- a/lined-web/src/test/handlers/auth.ts
+++ b/lined-web/src/test/handlers/auth.ts
@@ -26,4 +26,17 @@ export const authHandlers = [
       roles: user.roles,
     });
   }),
+
+  http.post(`${BASE}/auth/password-reset-requests`, () => new HttpResponse(null, { status: 202 })),
+
+  http.post(`${BASE}/auth/password-resets`, async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    if (body['token'] !== 'valid-token') {
+      return HttpResponse.json(
+        { title: 'Bad Request', detail: 'Invalid or expired reset token' },
+        { status: 400 },
+      );
+    }
+    return new HttpResponse(null, { status: 204 });
+  }),
 ];

--- a/lined-web/src/types/index.ts
+++ b/lined-web/src/types/index.ts
@@ -231,6 +231,15 @@ export interface LoginResponseDto {
   roles: string[];
 }
 
+export interface PasswordResetRequestDto {
+  identifier: string;
+}
+
+export interface PasswordResetDto {
+  token: string;
+  newPassword: string;
+}
+
 // --- Notifications ---
 
 export interface NotificationPreferencesDto {


### PR DESCRIPTION
## Summary

Implements UI Task 18 — forgot/reset password flow — as a **mock-only MVP**.

The task spec ([`docs/tasks/UI-18-forgot-password.md`](lined-web/docs/tasks/UI-18-forgot-password.md)) explicitly blocks starting until the backend ships `POST /api/auth/password-reset-requests` / `POST /api/auth/password-resets`. Confirmed those endpoints still don't exist (`backend/lined/docs/experiment-tasks.md`, `feature/password-reset-flow` row still `No`). Decided with the requester to build the full client-side flow against the exact contract already specified in `backend/lined/docs/api-proposals/password-reset-flow.md`, so the app is ready to point at the real endpoints the moment they ship — this is the one gap in this task versus the usual "verify against the real backend too" bar.

- `ForgotPasswordPage` (`/forgot-password`): identifier form; always shows the same neutral "if an account exists…" success message regardless of match, to avoid account enumeration.
- `ResetPasswordPage` (`/reset-password?token=...`): reads the token from the query string; missing token shows an `AuthAlert` before any form renders; new-password/confirm fields reuse `SignUpPage`'s validation (required, min 8 chars, must match); a server-rejected (invalid/expired) token shows the same alert with a link back to `/forgot-password`; success redirects to `/sign-in?reset=success`.
- `AuthAlert` gained a `success` variant (green, brand tokens) reused for the sign-in banner instead of a new component.
- `SignInPage`'s static "Forgot password?" text is now a real `<Link>`; shows the green success banner when redirected from a completed reset.
- New `src/api/auth.ts` functions + `useAuth.ts` mutation hooks (`useRequestPasswordReset`, `useResetPassword`) and `PasswordResetRequestDto`/`PasswordResetDto` types, matching the proposal doc's request/response shapes exactly (202 empty / 204 empty / 400 with `title`+`detail`).
- MSW handlers in `src/test/handlers/auth.ts`: request step always 202s; redemption 204s for a `valid-token` sentinel, 400s otherwise.
- `docs/UI_TASKS.md` Task 18 row flipped to `DONE`, with a note that this shipped mock-only; a matching progress note added to the task file itself.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:run` — 489/493 passing; the 4 failures are in `CalendarPage.test.tsx`/`DashboardPage.test.tsx`, pre-existing and unrelated (verified identical failures with this branch's changes stashed out against `main`)
- [x] `npm run build`
- [x] Manually verified in-browser at 1280×800 against the `AuthCard` shell (no dedicated mockup screen exists for this flow): request-success state, missing-token state, valid-token reset → redirect → green success banner on Sign In, and the new "Forgot password?" link.

## Screenshots

**Forgot password — success state**

Shows the neutral "Check your email" message after submitting, regardless of whether the identifier matched an account.

**Reset password — missing token**

`/reset-password` with no `token` query param renders the invalid-link alert with no form and a link back to `/forgot-password`.

**Reset password — form (valid token)**

`/reset-password?token=valid-token` renders the new-password/confirm-password form.

**Sign in — success banner**

After a successful reset, redirected to `/sign-in?reset=success`, showing the new green `AuthAlert` variant and the real "Forgot password?" link.

*(Captured via the in-app browser during manual verification; not re-attached as image files in this description — happy to add if useful for review.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)