### PR TITLE
Task 21: First-run onboarding & empty states

### DIFF
--- a/lined-web/docs/UI_TASKS.md
+++ b/lined-web/docs/UI_TASKS.md
@@ -122,6 +122,26 @@ dark-mode toggle shipped in Task 12 has never been audited screen-by-screen.
   the banner only, per spec. The check fails open: a loading or failed
   conflicts request never blocks submission or shows a banner.
 
+- **First-run onboarding & empty states** — `EmptyState` (`src/components/EmptyState.tsx`,
+  card/inline variants with an optional icon and a button-or-`Link` action),
+  `DashboardHero` (`src/components/dashboard/DashboardHero.tsx`): when
+  `useMyLobbies()` and `useMyInvites()` both resolve empty, `DashboardPage`
+  swaps the "My Lobbies" section for a welcome hero with the four lobby-type
+  cards (each opens `CreateLobbyModal` with that type preselected via a new
+  `openCreateLobby(lobbyType?)` / `lobbyTypeInitial` field on
+  `useCreateMenuStore`) and a primary "+ Create your first lobby" CTA
+  (opens with no type preselected); a pending invite always wins and keeps
+  the normal empty "My Lobbies" text below the invites banner instead.
+  Swept every other bare "nothing here" text onto the same primitive:
+  `LobbyCardGrid`, `UpcomingEventsList`, `MyTasksList`, `Sidebar`'s "No
+  lobbies yet", kanban's per-column "No tasks in {status}", and the lobby
+  `LobbyTaskList` empty state (now with an "Invite someone" link to the
+  Members tab). Added a same-pattern empty-state banner (previously
+  missing entirely) above the grid when a week has zero events, in both
+  the lobby `LobbyCalendarView` ("Invite someone") and the global
+  `CalendarPage` ("Create event"); `WeekGrid`/`MonthGrid` themselves are
+  unchanged since a blank day cell is normal even in a populated week.
+
 ## Backend API summary
 
 | Domain | Endpoints |
@@ -168,7 +188,7 @@ dark-mode toggle shipped in Task 12 has never been audited screen-by-screen.
 | 18 | `feature/ui-18-forgot-password` | Forgot password flow: request form, token redemption, new-password form | [tasks/UI-18-forgot-password.md](tasks/UI-18-forgot-password.md) | DONE |
 | 19 | `feature/ui-19-event-conflict-warnings` | Conflict warnings in event/reserve modals via the unused `GET /api/calendar/conflicts`, with next-free-slot suggestion | [tasks/UI-19-event-conflict-warnings.md](tasks/UI-19-event-conflict-warnings.md) | DONE |
 | 20 | `feature/ui-20-task-detail-edit` | Task detail/edit drawer (open from kanban card & task row, edit all fields incl. priority, delete) | [tasks/UI-20-task-detail-edit.md](tasks/UI-20-task-detail-edit.md) | DONE |
-| 21 | `feature/ui-21-onboarding-empty-states` | First-run dashboard hero ("create your first lobby") + designed empty states everywhere | [tasks/UI-21-onboarding-empty-states.md](tasks/UI-21-onboarding-empty-states.md) | TODO |
+| 21 | `feature/ui-21-onboarding-empty-states` | First-run dashboard hero ("create your first lobby") + designed empty states everywhere | [tasks/UI-21-onboarding-empty-states.md](tasks/UI-21-onboarding-empty-states.md) | DONE |
 | 22 | `feature/ui-22-responsive-layout` | Mobile/tablet responsive layout: sidebar drawer, bottom tabs, calendar day view, kanban scroll-snap, sheet modals | [tasks/UI-22-responsive-layout.md](tasks/UI-22-responsive-layout.md) | TODO |
 | 23 | `feature/ui-23-dark-mode-audit` | Dark-mode token layer + screen-by-screen audit of the theme toggle shipped in Task 12 | [tasks/UI-23-dark-mode-audit.md](tasks/UI-23-dark-mode-audit.md) | TODO |
 | 24 | `feature/ui-24-i18n-localization` | Localization (react-i18next): English + Ukrainian, plurals, locale dates, settings switcher | [tasks/UI-24-i18n-localization.md](tasks/UI-24-i18n-localization.md) | TODO |

--- a/lined-web/src/components/CreateLobbyModal.tsx
+++ b/lined-web/src/components/CreateLobbyModal.tsx
@@ -7,6 +7,7 @@ import { LobbyTypePicker } from '@/components/LobbyTypePicker';
 import { FormField } from '@/components/FormField';
 import { AuthAlert } from '@/components/AuthAlert';
 import { getApiErrorMessage } from '@/lib/apiErrors';
+import { useCreateMenuStore } from '@/store/createMenu';
 
 interface CreateLobbyModalProps {
   onClose: () => void;
@@ -15,9 +16,10 @@ interface CreateLobbyModalProps {
 export const CreateLobbyModal = ({ onClose }: CreateLobbyModalProps) => {
   const navigate = useNavigate();
   const createLobby = useCreateLobby();
+  const lobbyTypeInitial = useCreateMenuStore((s) => s.lobbyTypeInitial);
 
   const [name, setName] = useState('');
-  const [lobbyType, setLobbyType] = useState<LobbyType>('COUPLE');
+  const [lobbyType, setLobbyType] = useState<LobbyType>(lobbyTypeInitial ?? 'COUPLE');
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/lined-web/src/components/CreateMenu.tsx
+++ b/lined-web/src/components/CreateMenu.tsx
@@ -28,7 +28,7 @@ export const CreateMenu = () => {
           <ListPlus className="h-4 w-4" />
           New Task
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={openCreateLobby} className="gap-2.5 py-2">
+        <DropdownMenuItem onClick={() => openCreateLobby()} className="gap-2.5 py-2">
           <Users className="h-4 w-4" />
           New Lobby
         </DropdownMenuItem>

--- a/lined-web/src/components/EmptyState.tsx
+++ b/lined-web/src/components/EmptyState.tsx
@@ -1,0 +1,72 @@
+import { Link } from 'react-router-dom';
+
+interface EmptyStateAction {
+  label: string;
+  onClick?: () => void;
+  /** react-router Link target; mutually exclusive with onClick. */
+  to?: string;
+}
+
+interface EmptyStateProps {
+  icon?: string;
+  message: string;
+  action?: EmptyStateAction;
+  variant?: 'card' | 'inline';
+  /** Override the message text color, e.g. for a dark-background container. */
+  className?: string;
+  testId?: string;
+}
+
+function ActionControl({ action }: { action: EmptyStateAction }) {
+  const className = 'text-brand-green hover:underline';
+  if (action.to) {
+    return (
+      <Link to={action.to} className={className}>
+        {action.label}
+      </Link>
+    );
+  }
+  return (
+    <button type="button" onClick={action.onClick} className={className}>
+      {action.label}
+    </button>
+  );
+}
+
+export function EmptyState({
+  icon,
+  message,
+  action,
+  variant = 'card',
+  className = 'text-text-secondary',
+  testId,
+}: EmptyStateProps) {
+  if (variant === 'inline') {
+    return (
+      <p className={`text-sm ${className}`} data-testid={testId}>
+        {message}
+        {action && (
+          <>
+            {' — '}
+            <ActionControl action={action} />
+          </>
+        )}
+      </p>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-col items-center gap-2 rounded-xl border-2 border-dashed border-border p-6 text-center"
+      data-testid={testId}
+    >
+      {icon && <span className="text-2xl leading-none">{icon}</span>}
+      <p className={`text-sm ${className}`}>{message}</p>
+      {action && (
+        <div className="mt-1 text-sm font-medium">
+          <ActionControl action={action} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lined-web/src/components/LobbyTypePicker.tsx
+++ b/lined-web/src/components/LobbyTypePicker.tsx
@@ -1,12 +1,10 @@
 import type { LobbyType } from '@/types';
-import { LOBBY_TYPE_ICONS, LOBBY_TYPE_LABELS } from '@/lib/constants';
+import { LOBBY_TYPE_ICONS, LOBBY_TYPE_LABELS, LOBBY_TYPES } from '@/lib/constants';
 
 interface LobbyTypePickerProps {
   value: LobbyType;
   onChange: (type: LobbyType) => void;
 }
-
-const LOBBY_TYPES: LobbyType[] = ['COUPLE', 'FAMILY', 'FRIENDS', 'WORK'];
 
 export const LobbyTypePicker = ({ value, onChange }: LobbyTypePickerProps) => {
   return (

--- a/lined-web/src/components/Sidebar.tsx
+++ b/lined-web/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useAuthStore } from '@/store/auth';
 import { useCreateMenuStore } from '@/store/createMenu';
 import { LOBBY_TYPE_COLORS } from '@/lib/constants';
+import { EmptyState } from '@/components/EmptyState';
 
 const NAV_ITEMS = [
   { to: '/', icon: LayoutDashboard, label: 'Dashboard' },
@@ -64,7 +65,7 @@ export function Sidebar() {
           </span>
           <button
             type="button"
-            onClick={openCreateLobby}
+            onClick={() => openCreateLobby()}
             className="text-xs font-medium text-brand-green hover:underline"
           >
             + New
@@ -83,16 +84,14 @@ export function Sidebar() {
         )}
 
         {!lobbiesLoading && lobbies?.length === 0 && (
-          <p className="px-3 py-2 text-sm text-text-muted">
-            No lobbies yet —{' '}
-            <button
-              type="button"
-              onClick={openCreateLobby}
-              className="text-brand-green hover:underline"
-            >
-              + New
-            </button>
-          </p>
+          <div className="px-3 py-2">
+            <EmptyState
+              variant="inline"
+              message="No lobbies yet"
+              action={{ label: '+ New', onClick: () => openCreateLobby() }}
+              className="text-text-muted"
+            />
+          </div>
         )}
 
         {!lobbiesLoading &&

--- a/lined-web/src/components/__tests__/EmptyState.test.tsx
+++ b/lined-web/src/components/__tests__/EmptyState.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
+import { EmptyState } from '../EmptyState';
+
+describe('EmptyState', () => {
+  it('renders the icon and message', () => {
+    expect.assertions(2);
+    renderWithProviders(<EmptyState icon="📅" message="No events yet." />);
+
+    expect(screen.getByText('📅')).toBeInTheDocument();
+    expect(screen.getByText('No events yet.')).toBeInTheDocument();
+  });
+
+  it('renders no icon when none is given', () => {
+    expect.assertions(1);
+    const { container } = renderWithProviders(<EmptyState message="No events yet." />);
+
+    expect(container.querySelector('span')).not.toBeInTheDocument();
+  });
+
+  it('calls onClick when the button action is clicked', async () => {
+    expect.assertions(1);
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(
+      <EmptyState message="No lobbies yet" action={{ label: '+ Create lobby', onClick }} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: '+ Create lobby' }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a working router Link when the action has a "to" target', () => {
+    expect.assertions(1);
+    renderWithProviders(
+      <EmptyState message="No tasks yet." action={{ label: 'Invite someone', to: '/lobbies/1?tab=members' }} />,
+    );
+
+    expect(screen.getByRole('link', { name: 'Invite someone' })).toHaveAttribute(
+      'href',
+      '/lobbies/1?tab=members',
+    );
+  });
+
+  it('renders the inline variant as a single paragraph with the action inline', () => {
+    expect.assertions(2);
+    renderWithProviders(
+      <EmptyState
+        variant="inline"
+        message="No lobbies yet"
+        action={{ label: '+ New', onClick: () => undefined }}
+        testId="sidebar-empty"
+      />,
+    );
+
+    const el = screen.getByTestId('sidebar-empty');
+    expect(el.tagName).toBe('P');
+    expect(el).toHaveTextContent('No lobbies yet — + New');
+  });
+
+  it('renders the card variant with no action when none is given', () => {
+    expect.assertions(2);
+    renderWithProviders(<EmptyState message="No tasks in To Do." testId="kanban-empty" />);
+
+    expect(screen.getByTestId('kanban-empty').tagName).toBe('DIV');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/lined-web/src/components/calendar/WeekEmptyBanner.tsx
+++ b/lined-web/src/components/calendar/WeekEmptyBanner.tsx
@@ -1,0 +1,21 @@
+import { EmptyState } from '@/components/EmptyState';
+
+interface WeekEmptyBannerAction {
+  label: string;
+  onClick?: () => void;
+  to?: string;
+}
+
+interface WeekEmptyBannerProps {
+  message: string;
+  action: WeekEmptyBannerAction;
+}
+
+/** Shown above the week grid when the visible week has zero events. */
+export function WeekEmptyBanner({ message, action }: WeekEmptyBannerProps) {
+  return (
+    <div className="px-6 pt-4">
+      <EmptyState icon="📅" message={message} action={action} />
+    </div>
+  );
+}

--- a/lined-web/src/components/calendar/__tests__/WeekEmptyBanner.test.tsx
+++ b/lined-web/src/components/calendar/__tests__/WeekEmptyBanner.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
+import { WeekEmptyBanner } from '../WeekEmptyBanner';
+
+describe('WeekEmptyBanner', () => {
+  it('renders the message and calls onClick when the action button is clicked', async () => {
+    expect.assertions(2);
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(
+      <WeekEmptyBanner
+        message="No events this week — create one."
+        action={{ label: 'Create event', onClick }}
+      />,
+    );
+
+    expect(screen.getByText('No events this week — create one.')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Create event' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a router Link when the action has a "to" target', () => {
+    expect.assertions(1);
+    renderWithProviders(
+      <WeekEmptyBanner message="No events yet." action={{ label: 'Invite someone', to: '/lobbies/1?tab=members' }} />,
+    );
+
+    expect(screen.getByRole('link', { name: 'Invite someone' })).toHaveAttribute(
+      'href',
+      '/lobbies/1?tab=members',
+    );
+  });
+});

--- a/lined-web/src/components/dashboard/DashboardHero.tsx
+++ b/lined-web/src/components/dashboard/DashboardHero.tsx
@@ -1,0 +1,53 @@
+import {
+  LOBBY_TYPE_ICONS,
+  LOBBY_TYPE_LABELS,
+  LOBBY_TYPE_TAGLINES,
+  LOBBY_TYPES,
+} from '@/lib/constants';
+import { useCreateMenuStore } from '@/store/createMenu';
+
+interface DashboardHeroProps {
+  username: string;
+}
+
+export function DashboardHero({ username }: DashboardHeroProps) {
+  const openCreateLobby = useCreateMenuStore((s) => s.openCreateLobby);
+
+  return (
+    <section className="flex flex-col items-center gap-5 rounded-2xl border-2 border-dashed border-border bg-white px-8 py-10 text-center">
+      <span className="text-4xl leading-none">🌱</span>
+      <div>
+        <h2 className="text-xl font-bold text-text-primary">Welcome to Lined, {username}!</h2>
+        <p className="mx-auto mt-2 max-w-md text-sm text-text-secondary">
+          A lobby is a shared space for the people you plan life with. Create your first one to
+          start syncing schedules, tasks and free time.
+        </p>
+      </div>
+
+      <div className="grid w-full max-w-md grid-cols-2 gap-3">
+        {LOBBY_TYPES.map((type) => (
+          <button
+            key={type}
+            type="button"
+            onClick={() => openCreateLobby(type)}
+            className="cursor-pointer rounded-lg border-2 border-border bg-white px-3 py-3.5 text-center transition-colors hover:bg-gray-50"
+          >
+            <div className="mb-1.5 text-xl leading-none">{LOBBY_TYPE_ICONS[type]}</div>
+            <div className="text-sm font-semibold text-text-primary">
+              {LOBBY_TYPE_LABELS[type]}
+            </div>
+            <div className="text-xs text-text-secondary">{LOBBY_TYPE_TAGLINES[type]}</div>
+          </button>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => openCreateLobby()}
+        className="h-10 rounded-lg bg-brand-green px-6 text-sm font-semibold text-white transition-colors hover:bg-brand-green-dark"
+      >
+        + Create your first lobby
+      </button>
+    </section>
+  );
+}

--- a/lined-web/src/components/dashboard/LobbyCardGrid.tsx
+++ b/lined-web/src/components/dashboard/LobbyCardGrid.tsx
@@ -1,5 +1,6 @@
 import type { EventDto, LobbyDto, TaskDto } from '@/types';
 import { useCreateMenuStore } from '@/store/createMenu';
+import { EmptyState } from '@/components/EmptyState';
 import { LobbyCard } from './LobbyCard';
 
 interface LobbyCardGridProps {
@@ -41,16 +42,11 @@ export function LobbyCardGrid({
       )}
 
       {!isLoading && !isError && lobbies?.length === 0 && (
-        <p className="text-sm text-text-secondary">
-          No lobbies yet —{' '}
-          <button
-            type="button"
-            onClick={openCreateLobby}
-            className="text-brand-green hover:underline"
-          >
-            + Create lobby
-          </button>
-        </p>
+        <EmptyState
+          variant="inline"
+          message="No lobbies yet"
+          action={{ label: '+ Create lobby', onClick: () => openCreateLobby() }}
+        />
       )}
 
       {!isLoading && !isError && lobbies != null && lobbies.length > 0 && (

--- a/lined-web/src/components/dashboard/MyTasksList.tsx
+++ b/lined-web/src/components/dashboard/MyTasksList.tsx
@@ -3,6 +3,7 @@ import type { TaskDto } from '@/types';
 import { TASK_STATUS_COLORS } from '@/lib/constants';
 import { formatTaskDueDate } from '@/lib/calendarUtils';
 import { sortTasksByDueDate } from '@/lib/taskUtils';
+import { EmptyState } from '@/components/EmptyState';
 import { StatusBadge } from './StatusBadge';
 
 const MAX_TASKS_SHOWN = 5;
@@ -44,7 +45,10 @@ export function MyTasksList({ tasks, isLoading, isError }: MyTasksListProps) {
       )}
 
       {!isLoading && !isError && tasks?.length === 0 && (
-        <p className="text-sm text-text-secondary">No tasks assigned to you.</p>
+        <EmptyState
+          icon="✅"
+          message="No tasks yet — tasks you create or get assigned will appear here."
+        />
       )}
 
       {!isLoading && !isError && tasks != null && tasks.length > 0 && (

--- a/lined-web/src/components/dashboard/UpcomingEventsList.tsx
+++ b/lined-web/src/components/dashboard/UpcomingEventsList.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import type { EventDto, LobbyDto } from '@/types';
 import { LOBBY_TYPE_BADGE_CLASSES, LOBBY_TYPE_COLORS } from '@/lib/constants';
 import { formatRelativeEventTime } from '@/lib/calendarUtils';
+import { EmptyState } from '@/components/EmptyState';
 
 interface UpcomingEventsListProps {
   events: EventDto[] | undefined;
@@ -42,7 +43,10 @@ export function UpcomingEventsList({
       )}
 
       {!isLoading && !isError && events?.length === 0 && (
-        <p className="text-sm text-text-secondary">No upcoming events.</p>
+        <EmptyState
+          icon="📅"
+          message="No events yet — once you have a lobby, your shared calendar shows up here."
+        />
       )}
 
       {!isLoading && !isError && events != null && events.length > 0 && (

--- a/lined-web/src/components/dashboard/__tests__/MyTasksList.test.tsx
+++ b/lined-web/src/components/dashboard/__tests__/MyTasksList.test.tsx
@@ -84,7 +84,7 @@ describe('MyTasksList', () => {
     expect.assertions(1);
     renderWithProviders(<MyTasksList tasks={[]} isLoading={false} isError={false} />);
 
-    expect(screen.getByText(/no tasks assigned to you/i)).toBeInTheDocument();
+    expect(screen.getByText(/no tasks yet/i)).toBeInTheDocument();
   });
 
   it('shows an inline error message when tasks fail to load', () => {

--- a/lined-web/src/components/dashboard/__tests__/UpcomingEventsList.test.tsx
+++ b/lined-web/src/components/dashboard/__tests__/UpcomingEventsList.test.tsx
@@ -38,7 +38,7 @@ describe('UpcomingEventsList', () => {
       <UpcomingEventsList events={[]} lobbies={MOCK_LOBBIES} isLoading={false} isError={false} />,
     );
 
-    expect(screen.getByText(/no upcoming events/i)).toBeInTheDocument();
+    expect(screen.getByText(/no events yet/i)).toBeInTheDocument();
   });
 
   it('shows an inline error message when events fail to load', () => {

--- a/lined-web/src/components/lobby/LobbyCalendarView.tsx
+++ b/lined-web/src/components/lobby/LobbyCalendarView.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/lib/calendarUtils';
 import { freeSlotsForDay } from '@/lib/freeSlots';
 import { lobbyAccentColor } from '@/lib/constants';
+import { WeekEmptyBanner } from '@/components/calendar/WeekEmptyBanner';
 import { useCreateMenuStore } from '@/store/createMenu';
 import type { ViewMode } from '@/store/calendar';
 import type { EventDto } from '@/types';
@@ -90,36 +91,45 @@ export function LobbyCalendarView({ lobby }: LobbyCalendarViewProps) {
           Couldn&apos;t load the calendar. Try again later.
         </p>
       ) : (
-        <div className="flex flex-1 min-h-0 overflow-hidden">
-          <WeekGrid
-            weekStart={weekStart}
-            events={events ?? []}
-            lobbies={[lobby]}
-            selectedEventId={selectedEventId}
-            onEventClick={(id) => {
-              setDeleteError(null);
-              setSelectedEventId(id);
-            }}
-            getFreeSlotsForDay={(day) => freeSlotsForDay(freeSlots ?? [], day)}
-            legendItems={legendItems}
-            onDayClick={(day) => setAgendaDay(day)}
-            maxVisibleEvents={4}
-            onFreeSlotClick={handleFreeSlotClick}
-          />
-
-          {selectedEvent && (
-            <EventDetailPanel
-              event={selectedEvent}
-              lobby={lobby}
-              onClose={() => {
-                setDeleteError(null);
-                setSelectedEventId(null);
-              }}
-              onEdit={() => setEditingEvent(selectedEvent)}
-              onDelete={handleDelete}
-              deleteError={deleteError}
+        <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
+          {(events ?? []).length === 0 && (
+            <WeekEmptyBanner
+              message="No events yet."
+              action={{ label: 'Invite someone', to: `/lobbies/${lobby.id}?tab=members` }}
             />
           )}
+
+          <div className="flex flex-1 min-h-0 overflow-hidden">
+            <WeekGrid
+              weekStart={weekStart}
+              events={events ?? []}
+              lobbies={[lobby]}
+              selectedEventId={selectedEventId}
+              onEventClick={(id) => {
+                setDeleteError(null);
+                setSelectedEventId(id);
+              }}
+              getFreeSlotsForDay={(day) => freeSlotsForDay(freeSlots ?? [], day)}
+              legendItems={legendItems}
+              onDayClick={(day) => setAgendaDay(day)}
+              maxVisibleEvents={4}
+              onFreeSlotClick={handleFreeSlotClick}
+            />
+
+            {selectedEvent && (
+              <EventDetailPanel
+                event={selectedEvent}
+                lobby={lobby}
+                onClose={() => {
+                  setDeleteError(null);
+                  setSelectedEventId(null);
+                }}
+                onEdit={() => setEditingEvent(selectedEvent)}
+                onDelete={handleDelete}
+                deleteError={deleteError}
+              />
+            )}
+          </div>
         </div>
       )}
 

--- a/lined-web/src/components/lobby/LobbyTaskList.tsx
+++ b/lined-web/src/components/lobby/LobbyTaskList.tsx
@@ -6,6 +6,7 @@ import { useRowMutationState } from '@/hooks/useRowMutationState';
 import { useCreateMenuStore } from '@/store/createMenu';
 import { TASK_STATUS_LABELS } from '@/lib/constants';
 import { sortTasksByDueDate } from '@/lib/taskUtils';
+import { EmptyState } from '@/components/EmptyState';
 import { TaskRow } from './TaskRow';
 
 type FilterId = 'ALL' | TaskStatus;
@@ -18,6 +19,7 @@ const FILTERS: { id: FilterId; label: string }[] = [
 ];
 
 interface TaskListContentProps {
+  lobbyId: number;
   isLoading: boolean;
   isError: boolean;
   tasks: TaskDto[] | undefined;
@@ -30,6 +32,7 @@ interface TaskListContentProps {
 }
 
 const TaskListContent = ({
+  lobbyId,
   isLoading,
   isError,
   tasks,
@@ -57,11 +60,17 @@ const TaskListContent = ({
   }
 
   if (tasks != null && tasks.length === 0) {
-    return <p className="text-sm text-text-secondary">No tasks yet.</p>;
+    return (
+      <EmptyState
+        icon="✅"
+        message="No tasks yet."
+        action={{ label: 'Invite someone', to: `/lobbies/${lobbyId}?tab=members` }}
+      />
+    );
   }
 
   if (sorted.length === 0) {
-    return <p className="text-sm text-text-secondary">No tasks match this filter.</p>;
+    return <EmptyState message="No tasks match this filter." />;
   }
 
   return (
@@ -143,6 +152,7 @@ export const LobbyTaskList = ({ lobbyId }: LobbyTaskListProps) => {
       </div>
 
       <TaskListContent
+        lobbyId={lobbyId}
         isLoading={isLoading}
         isError={isError}
         tasks={tasks}

--- a/lined-web/src/components/lobby/__tests__/LobbyCalendarView.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/LobbyCalendarView.test.tsx
@@ -161,6 +161,31 @@ describe('LobbyCalendarView', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows an empty state with an invite link when the lobby has no events this week', async () => {
+    expect.assertions(2);
+    server.use(http.get(`${BASE}/calendar/events`, () => HttpResponse.json([])));
+    renderWithProviders(<LobbyCalendarView lobby={LOBBY} />);
+
+    expect(await screen.findByText('No events yet.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Invite someone' })).toHaveAttribute(
+      'href',
+      `/lobbies/${LOBBY.id}?tab=members`,
+    );
+  });
+
+  it('does not show the empty state when the lobby has events this week', async () => {
+    expect.assertions(1);
+    server.use(
+      http.get(`${BASE}/calendar/events`, () =>
+        HttpResponse.json([makeEvent(1, LOBBY.id, 9, 'Morning Coffee')]),
+      ),
+    );
+    renderWithProviders(<LobbyCalendarView lobby={LOBBY} />);
+    await screen.findByText('Morning Coffee');
+
+    expect(screen.queryByText('No events yet.')).not.toBeInTheDocument();
+  });
+
   it('clicking a free-slot band opens the reserve-slot overlay locked to this lobby', async () => {
     expect.assertions(2);
     const today = new Date();

--- a/lined-web/src/components/lobby/__tests__/LobbyTaskList.test.tsx
+++ b/lined-web/src/components/lobby/__tests__/LobbyTaskList.test.tsx
@@ -47,12 +47,16 @@ describe('LobbyTaskList', () => {
     expect(await screen.findByText("Couldn't load tasks. Try again later.")).toBeInTheDocument();
   });
 
-  it('shows an empty state when the lobby has no tasks', async () => {
-    expect.assertions(1);
+  it('shows an empty state with an invite link when the lobby has no tasks', async () => {
+    expect.assertions(2);
     server.use(http.get(`${BASE}/tasks`, () => HttpResponse.json([])));
     renderWithProviders(<LobbyTaskList lobbyId={1} />);
 
     expect(await screen.findByText('No tasks yet.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Invite someone' })).toHaveAttribute(
+      'href',
+      '/lobbies/1?tab=members',
+    );
   });
 
   it('checking a row PATCHes the status and moves it to Done styling', async () => {

--- a/lined-web/src/components/tasks/KanbanColumn.tsx
+++ b/lined-web/src/components/tasks/KanbanColumn.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { DragEvent } from 'react';
 import type { LobbyDto, TaskDto, TaskStatus, UserDto } from '@/types';
 import { TASK_STATUS_BADGE_CLASSES, TASK_STATUS_COLORS, TASK_STATUS_LABELS } from '@/lib/constants';
+import { EmptyState } from '@/components/EmptyState';
 import { KanbanCard, TASK_DRAG_DATA_FORMAT } from './KanbanCard';
 import { KANBAN_LABELS, KANBAN_TEST_IDS, KANBAN_TEXT } from './kanbanConstants';
 
@@ -46,7 +47,7 @@ const KanbanCardList = ({
   actions,
 }: KanbanCardListProps) => {
   if (tasks.length === 0) {
-    return <p className="text-xs text-text-secondary">No tasks in {TASK_STATUS_LABELS[status]}.</p>;
+    return <EmptyState variant="inline" message={`No tasks in ${TASK_STATUS_LABELS[status]}.`} />;
   }
 
   return (

--- a/lined-web/src/lib/constants.ts
+++ b/lined-web/src/lib/constants.ts
@@ -13,6 +13,8 @@ export const DEFAULT_LEGEND_ITEMS: LegendItem[] = [
   { label: 'Free slot', color: 'var(--color-free-slot)' },
 ];
 
+export const LOBBY_TYPES: LobbyType[] = ['COUPLE', 'FAMILY', 'FRIENDS', 'WORK'];
+
 export const LOBBY_TYPE_LABELS: Record<LobbyType, string> = {
   COUPLE: 'Couple',
   FAMILY: 'Family',
@@ -51,6 +53,13 @@ export const LOBBY_TYPE_ICONS: Record<LobbyType, string> = {
   FAMILY: '👨‍👩‍👧‍👦',
   FRIENDS: '🎉',
   WORK: '💼',
+};
+
+export const LOBBY_TYPE_TAGLINES: Record<LobbyType, string> = {
+  COUPLE: 'Just the two of you',
+  FAMILY: 'Household & kids',
+  FRIENDS: 'Your crew',
+  WORK: 'Team planning',
 };
 
 export const TASK_STATUS_LABELS: Record<TaskStatus, string> = {

--- a/lined-web/src/pages/CalendarPage.tsx
+++ b/lined-web/src/pages/CalendarPage.tsx
@@ -11,6 +11,7 @@ import { useMyLobbies } from '@/hooks/useLobbies';
 import { useCalendarStore } from '@/store/calendar';
 import { useCreateMenuStore } from '@/store/createMenu';
 import { formatMonthYear, hourRangeToIso, isSameDay, type FreeSlot } from '@/lib/calendarUtils';
+import { WeekEmptyBanner } from '@/components/calendar/WeekEmptyBanner';
 import type { EventDto } from '@/types';
 
 function getDeleteEventErrorMessage(error: unknown): string {
@@ -106,6 +107,13 @@ export function CalendarPage() {
         hiddenLobbyIds={hiddenLobbyIds}
         onToggleLobby={toggleLobbyVisibility}
       />
+
+      {viewMode === 'week' && weekEvents.length === 0 && (
+        <WeekEmptyBanner
+          message="No events this week — create one."
+          action={{ label: 'Create event', onClick: openCreateModal }}
+        />
+      )}
 
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {viewMode === 'month' ? (

--- a/lined-web/src/pages/DashboardPage.tsx
+++ b/lined-web/src/pages/DashboardPage.tsx
@@ -1,10 +1,12 @@
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useMyLobbies } from '@/hooks/useLobbies';
+import { useMyInvites } from '@/hooks/useInvites';
 import { useUpcomingEvents } from '@/hooks/useEvents';
 import { useMyTasks } from '@/hooks/useTasks';
 import { useFreeSlotBanner } from '@/hooks/useDashboard';
 import { getGreeting, formatFullDate } from '@/lib/calendarUtils';
 import { LobbyCardGrid } from '@/components/dashboard/LobbyCardGrid';
+import { DashboardHero } from '@/components/dashboard/DashboardHero';
 import { UpcomingEventsList } from '@/components/dashboard/UpcomingEventsList';
 import { MyTasksList } from '@/components/dashboard/MyTasksList';
 import { FreeSlotBanner } from '@/components/dashboard/FreeSlotBanner';
@@ -16,10 +18,15 @@ import { useCreateMenuStore } from '@/store/createMenu';
 export function DashboardPage() {
   const { data: user } = useCurrentUser();
   const { data: lobbies, isLoading: lobbiesLoading, isError: lobbiesError } = useMyLobbies();
+  const { data: invites, isLoading: invitesLoading, isError: invitesError } = useMyInvites();
   const { data: events, isLoading: eventsLoading, isError: eventsError } = useUpcomingEvents();
   const { data: tasks, isLoading: tasksLoading, isError: tasksError } = useMyTasks();
   const { slot, isLoading: slotLoading } = useFreeSlotBanner();
   const openReserveSlot = useCreateMenuStore((s) => s.openReserveSlot);
+
+  const noLobbies = !lobbiesLoading && !lobbiesError && lobbies?.length === 0;
+  const noInvites = !invitesLoading && !invitesError && (invites?.length ?? 0) === 0;
+  const showHero = noLobbies && noInvites;
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -41,13 +48,17 @@ export function DashboardPage() {
       <div className="flex flex-col gap-6 p-6">
         <PendingInvitesBanner />
 
-        <LobbyCardGrid
-          lobbies={lobbies}
-          upcomingEvents={events}
-          myTasks={tasks}
-          isLoading={lobbiesLoading}
-          isError={lobbiesError}
-        />
+        {showHero ? (
+          <DashboardHero username={user?.username ?? 'there'} />
+        ) : (
+          <LobbyCardGrid
+            lobbies={lobbies}
+            upcomingEvents={events}
+            myTasks={tasks}
+            isLoading={lobbiesLoading}
+            isError={lobbiesError}
+          />
+        )}
 
         <div className="grid grid-cols-2 gap-6">
           <UpcomingEventsList

--- a/lined-web/src/pages/__tests__/CalendarPage.test.tsx
+++ b/lined-web/src/pages/__tests__/CalendarPage.test.tsx
@@ -137,6 +137,29 @@ describe('CalendarPage', () => {
     expect(screen.getAllByText('Morning Coffee').length).toBeGreaterThan(0);
   });
 
+  it('shows an empty-week state with a "Create event" action when there are no events', async () => {
+    expect.assertions(2);
+    server.use(http.get(`${BASE}/calendar/events`, () => HttpResponse.json([])));
+    const user = userEvent.setup();
+    renderWithProviders(<CalendarPage />);
+
+    expect(
+      await screen.findByText('No events this week — create one.'),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Create event' }));
+
+    expect(useCalendarStore.getState().isCreateModalOpen).toBe(true);
+  });
+
+  it('does not show the empty-week state when events exist', async () => {
+    expect.assertions(1);
+    renderWithProviders(<CalendarPage />);
+    await screen.findByText('Morning Coffee');
+
+    expect(screen.queryByText('No events this week — create one.')).not.toBeInTheDocument();
+  });
+
   it('reflects a hidden lobby as unchecked and re-shows its events once re-checked', async () => {
     expect.assertions(2);
     const user = userEvent.setup();

--- a/lined-web/src/pages/__tests__/DashboardPage.test.tsx
+++ b/lined-web/src/pages/__tests__/DashboardPage.test.tsx
@@ -73,4 +73,60 @@ describe('DashboardPage', () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
+
+  describe('first-run hero', () => {
+    beforeEach(() => {
+      server.use(
+        http.get(`${BASE}/lobbies/mine`, () => HttpResponse.json([])),
+        http.get(`${BASE}/lobby-invites/mine`, () => HttpResponse.json([])),
+      );
+    });
+
+    it('renders the welcome hero instead of "My Lobbies" when there are no lobbies or invites', async () => {
+      expect.assertions(2);
+      renderWithProviders(<DashboardPage />);
+
+      expect(await screen.findByText(/welcome to lined/i)).toBeInTheDocument();
+      expect(screen.queryByText('My Lobbies')).not.toBeInTheDocument();
+    });
+
+    it('opens the create-lobby overlay with the clicked type preselected', async () => {
+      expect.assertions(2);
+      const user = userEvent.setup();
+      renderWithProviders(<DashboardPage />);
+
+      await user.click(await screen.findByText('Family'));
+
+      expect(useCreateMenuStore.getState().isCreateLobbyOpen).toBe(true);
+      expect(useCreateMenuStore.getState().lobbyTypeInitial).toBe('FAMILY');
+    });
+
+    it('opens the create-lobby overlay with no type preselected from the primary CTA', async () => {
+      expect.assertions(2);
+      const user = userEvent.setup();
+      renderWithProviders(<DashboardPage />);
+
+      await user.click(await screen.findByRole('button', { name: /create your first lobby/i }));
+
+      expect(useCreateMenuStore.getState().isCreateLobbyOpen).toBe(true);
+      expect(useCreateMenuStore.getState().lobbyTypeInitial).toBeNull();
+    });
+  });
+
+  it('does not render the hero when lobbies exist', async () => {
+    expect.assertions(1);
+    renderWithProviders(<DashboardPage />);
+
+    await screen.findByText('My Lobbies');
+    expect(screen.queryByText(/welcome to lined/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the pending invites banner instead of the hero when the account has invites but no lobbies', async () => {
+    expect.assertions(2);
+    server.use(http.get(`${BASE}/lobbies/mine`, () => HttpResponse.json([])));
+    renderWithProviders(<DashboardPage />);
+
+    expect(await screen.findByText('Pending Invites · 3')).toBeInTheDocument();
+    expect(screen.queryByText(/welcome to lined/i)).not.toBeInTheDocument();
+  });
 });

--- a/lined-web/src/store/createMenu.ts
+++ b/lined-web/src/store/createMenu.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { TaskDto, TaskStatus } from '@/types';
+import type { LobbyType, TaskDto, TaskStatus } from '@/types';
 
 export type CreateOverlay = 'event' | 'task' | 'reserveSlot' | null;
 
@@ -13,7 +13,9 @@ export interface ReserveSlotInitial {
 
 interface CreateMenuState {
   isCreateLobbyOpen: boolean;
-  openCreateLobby: () => void;
+  /** Preselected type for the create-lobby modal, e.g. from the dashboard onboarding hero. */
+  lobbyTypeInitial: LobbyType | null;
+  openCreateLobby: (lobbyType?: LobbyType) => void;
   closeCreateLobby: () => void;
   overlay: CreateOverlay;
   /** Preselected status for the 'task' overlay, e.g. when opened from a kanban column. */
@@ -30,8 +32,9 @@ interface CreateMenuState {
 
 export const useCreateMenuStore = create<CreateMenuState>()((set) => ({
   isCreateLobbyOpen: false,
-  openCreateLobby: () => set({ isCreateLobbyOpen: true }),
-  closeCreateLobby: () => set({ isCreateLobbyOpen: false }),
+  lobbyTypeInitial: null,
+  openCreateLobby: (lobbyType) => set({ isCreateLobbyOpen: true, lobbyTypeInitial: lobbyType ?? null }),
+  closeCreateLobby: () => set({ isCreateLobbyOpen: false, lobbyTypeInitial: null }),
   overlay: null,
   taskInitialStatus: null,
   editingTask: null,


### PR DESCRIPTION
## Summary
- Adds a shared `EmptyState` primitive (card/inline variants, optional icon and button-or-link action) and sweeps every bare "nothing here" text in the app onto it: dashboard's My Lobbies / Upcoming Events / My Tasks, Sidebar's "No lobbies yet", kanban's per-column empty message, and the lobby Tasks tab.
- Adds a `DashboardHero` shown in place of "My Lobbies" when a fresh account has zero lobbies **and** zero pending invites — greeting, the four lobby-type cards (each opens the create-lobby modal with that type preselected via a new `openCreateLobby(lobbyType?)` on the create-menu store), and a primary "+ Create your first lobby" CTA. A pending invite always wins and keeps the normal empty state below the invites banner instead.
- Adds a `WeekEmptyBanner` (shared by the global `CalendarPage` and the lobby `LobbyCalendarView`) shown above the week grid when the visible week has zero events, with a "Create event" / "Invite someone" action respectively. `WeekGrid`/`MonthGrid` are unchanged — a blank day cell is normal in a populated week.
- `LobbyTaskList`'s empty state now links to that lobby's Members tab ("Invite someone").
- Marks UI task 21 as `DONE` in `docs/UI_TASKS.md`.

Reviewed with `/simplify` (4 parallel angles: reuse, simplification, efficiency, altitude) after the initial implementation; applied the confirmed fixes (readability of the hero's show/hide condition, deduping the lobby-type tagline map into `constants.ts`, reusing `EmptyState` for one remaining bare `<p>`, and extracting the shared `WeekEmptyBanner` to remove duplicated empty-week logic between the two calendar views).

## Test plan
- [x] `npm run lint`, `npm run typecheck`, `npm run test:run` (79 files / 550 tests), `npm run build` all pass
- [x] New/updated tests: `EmptyState`, `WeekEmptyBanner`, `DashboardPage` (hero renders/hidden, type preselection, invites-win-over-hero), `LobbyTaskList`, `LobbyCalendarView`, `CalendarPage`
- [x] Manually verified in-browser against the mock API (MSW) with lobbies/invites forced empty: hero renders exactly per the `dashboard-empty` mockup screen, clicking a type card preselects it in the modal (verified `Family` → radio checked), the primary CTA opens with no type preselected, and the modal's default correctly falls back to `Couple` afterward
- [ ] Real backend verification — no backend changes were needed for this task (client-only, using data already fetched by `useMyLobbies`/`useMyInvites`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)