### PR TITLE
Task 22: Responsive layout (mobile & tablet)

### DIFF
--- a/lined-web/docs/UI_TASKS.md
+++ b/lined-web/docs/UI_TASKS.md
@@ -142,6 +142,25 @@ dark-mode toggle shipped in Task 12 has never been audited screen-by-screen.
   `CalendarPage` ("Create event"); `WeekGrid`/`MonthGrid` themselves are
   unchanged since a blank day cell is normal even in a populated week.
 
+- **Responsive layout (mobile & tablet)** — `useMediaQuery` (`src/hooks/`),
+  `useUiStore` (`src/store/ui.ts`), `BottomTabBar`, `DayChipStrip`:
+  `AppShell`/`Sidebar` gain an off-canvas drawer under `lg` (☰ trigger in
+  `TopBar`, body-scroll-locked, closes on backdrop click or nav) plus a
+  phone-only `BottomTabBar`; dashboard/settings/lobby pages stack to one
+  column under `md`. Calendar forces a single-day view under `md` (day-chip
+  strip + a floating "+ New event" button), reusing `WeekGrid`'s hour-grid
+  internals via a new optional `days` prop instead of a parallel component;
+  `MonthGrid` shows dots-per-day below `lg`. The kanban board's columns
+  become full-width horizontal scroll-snap panes under `md` (drag-and-drop
+  stays desktop-only; the move buttons now meet a 44px touch target).
+  `CreateEventModal`, `CreateLobbyModal`, `ReserveSlotModal` and
+  `ConfirmDialog` become edge-to-edge full-height sheets under `md`;
+  `TaskDrawer` (shadcn `Sheet`) swaps `side="right"` for `side="bottom"` on
+  phones via its own prop rather than editing the shadcn-owned
+  `sheet.tsx`; `EventDetailPanel`/`DayAgendaPanel` (previously inline flex
+  siblings next to the grid) become fixed bottom sheets under `md` and stay
+  in-flow at `md` and above. Desktop (`≥lg`) is unchanged.
+
 ## Backend API summary
 
 | Domain | Endpoints |
@@ -189,7 +208,7 @@ dark-mode toggle shipped in Task 12 has never been audited screen-by-screen.
 | 19 | `feature/ui-19-event-conflict-warnings` | Conflict warnings in event/reserve modals via the unused `GET /api/calendar/conflicts`, with next-free-slot suggestion | [tasks/UI-19-event-conflict-warnings.md](tasks/UI-19-event-conflict-warnings.md) | DONE |
 | 20 | `feature/ui-20-task-detail-edit` | Task detail/edit drawer (open from kanban card & task row, edit all fields incl. priority, delete) | [tasks/UI-20-task-detail-edit.md](tasks/UI-20-task-detail-edit.md) | DONE |
 | 21 | `feature/ui-21-onboarding-empty-states` | First-run dashboard hero ("create your first lobby") + designed empty states everywhere | [tasks/UI-21-onboarding-empty-states.md](tasks/UI-21-onboarding-empty-states.md) | DONE |
-| 22 | `feature/ui-22-responsive-layout` | Mobile/tablet responsive layout: sidebar drawer, bottom tabs, calendar day view, kanban scroll-snap, sheet modals | [tasks/UI-22-responsive-layout.md](tasks/UI-22-responsive-layout.md) | TODO |
+| 22 | `feature/ui-22-responsive-layout` | Mobile/tablet responsive layout: sidebar drawer, bottom tabs, calendar day view, kanban scroll-snap, sheet modals | [tasks/UI-22-responsive-layout.md](tasks/UI-22-responsive-layout.md) | DONE |
 | 23 | `feature/ui-23-dark-mode-audit` | Dark-mode token layer + screen-by-screen audit of the theme toggle shipped in Task 12 | [tasks/UI-23-dark-mode-audit.md](tasks/UI-23-dark-mode-audit.md) | TODO |
 | 24 | `feature/ui-24-i18n-localization` | Localization (react-i18next): English + Ukrainian, plurals, locale dates, settings switcher | [tasks/UI-24-i18n-localization.md](tasks/UI-24-i18n-localization.md) | TODO |
 | 25 | `feature/ui-25-loading-states-audit` | Skeleton system: route/section/action loading tiers, zero layout shift, no full-page spinners | [tasks/UI-25-loading-states-audit.md](tasks/UI-25-loading-states-audit.md) | TODO |

--- a/lined-web/src/components/ConfirmDialog/index.tsx
+++ b/lined-web/src/components/ConfirmDialog/index.tsx
@@ -38,7 +38,7 @@ export const ConfirmDialog = ({
         if (e.target === e.currentTarget) onCancel();
       }}
     >
-      <div className="w-[400px] max-w-[90vw] rounded-2xl bg-white p-6 shadow-[var(--shadow-lg)]">
+      <div className="flex max-h-full w-[400px] max-w-[90vw] flex-col overflow-y-auto rounded-2xl bg-white p-6 shadow-[var(--shadow-lg)] max-md:h-full max-md:w-full max-md:max-w-none max-md:justify-center max-md:rounded-none">
         <h2 className="text-lg font-bold text-text-primary">{title}</h2>
         <p className="mt-2 text-sm text-text-secondary">{message}</p>
 

--- a/lined-web/src/features/calendar/events/CreateEventModal.tsx
+++ b/lined-web/src/features/calendar/events/CreateEventModal.tsx
@@ -148,8 +148,8 @@ export const CreateEventModal = ({
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      {/* Dialog */}
-      <div className="w-[520px] max-w-[90vw] overflow-hidden rounded-2xl bg-white shadow-[var(--shadow-lg)]">
+      {/* Dialog — full-screen sheet under md, centered card at md and above */}
+      <div className="flex h-full w-full flex-col overflow-y-auto bg-white md:h-auto md:max-h-[90vh] md:w-[520px] md:max-w-[90vw] md:flex-none md:rounded-2xl md:shadow-[var(--shadow-lg)]">
         {/* Header */}
         <div className="flex items-center justify-between px-6 pt-5">
           <h2 className="text-lg font-bold text-text-primary">
@@ -208,7 +208,7 @@ export const CreateEventModal = ({
             </div>
 
             {/* Start / End */}
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <div>
                 <label className="mb-1.5 block text-xs font-medium text-text-secondary">
                   Start

--- a/lined-web/src/features/calendar/events/ReserveSlotModal.tsx
+++ b/lined-web/src/features/calendar/events/ReserveSlotModal.tsx
@@ -48,7 +48,7 @@ export const ReserveSlotModal = ({ lobbies, initial, onClose, onReserved }: Rese
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="w-[520px] max-w-[90vw] overflow-hidden rounded-2xl bg-white shadow-[var(--shadow-lg)]">
+      <div className="flex h-full w-full flex-col overflow-y-auto bg-white md:h-auto md:max-h-[90vh] md:w-[520px] md:max-w-[90vw] md:flex-none md:rounded-2xl md:shadow-[var(--shadow-lg)]">
         {/* Header */}
         <div className="flex items-start justify-between px-6 pt-5">
           <div>
@@ -203,7 +203,7 @@ const ReserveSlotForm = ({ lobbies, slot, onClose, onReserved }: ReserveSlotForm
           required
         />
 
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div>
             <label className="mb-1.5 block text-xs font-medium text-text-secondary">Start time</label>
             <input

--- a/lined-web/src/features/calendar/grid/CalendarLegend.tsx
+++ b/lined-web/src/features/calendar/grid/CalendarLegend.tsx
@@ -2,9 +2,9 @@ import { DEFAULT_LEGEND_ITEMS, type LegendItem } from '@/features/calendar/lib/c
 
 export const CalendarLegend = ({ items = DEFAULT_LEGEND_ITEMS }: { items?: LegendItem[] }) => {
   return (
-    <div className="flex flex-shrink-0 items-center gap-5 border-t border-border bg-white px-8 py-2">
+    <div className="flex flex-shrink-0 items-center gap-5 overflow-x-auto whitespace-nowrap border-t border-border bg-white px-4 py-2 md:px-8">
       {items.map(({ label, color }) => (
-        <div key={label} className="flex items-center gap-1.5 text-[11px] text-text-secondary">
+        <div key={label} className="flex flex-shrink-0 items-center gap-1.5 text-[11px] text-text-secondary">
           <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />
           {label}
         </div>

--- a/lined-web/src/features/calendar/grid/DayChipStrip.tsx
+++ b/lined-web/src/features/calendar/grid/DayChipStrip.tsx
@@ -1,0 +1,45 @@
+import { addDays, getWeekStart, isSameDay, isToday } from '@/features/calendar/lib/calendarUtils';
+
+interface DayChipStripProps {
+  selectedDay: Date;
+  onSelectDay: (day: Date) => void;
+}
+
+/** Horizontal, scrollable week-of-`selectedDay` strip of day chips — the
+ *  phone-only date picker above the single-day calendar column. */
+export const DayChipStrip = ({ selectedDay, onSelectDay }: DayChipStripProps) => {
+  const weekStart = getWeekStart(selectedDay);
+  const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Select day"
+      className="flex flex-shrink-0 gap-2 overflow-x-auto border-b border-border bg-white px-3 py-2"
+    >
+      {days.map((day) => {
+        const selected = isSameDay(day, selectedDay);
+        const today = isToday(day);
+        return (
+          <button
+            key={day.toISOString()}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            onClick={() => onSelectDay(day)}
+            className={`flex flex-shrink-0 flex-col items-center gap-0.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+              selected
+                ? 'bg-brand-green text-white'
+                : today
+                  ? 'bg-brand-green-light text-brand-green-dark'
+                  : 'text-text-secondary hover:bg-bg'
+            }`}
+          >
+            <span>{day.toLocaleDateString('en-US', { weekday: 'short' })}</span>
+            <span className="text-sm font-semibold">{day.getDate()}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/lined-web/src/features/calendar/grid/MonthGrid.tsx
+++ b/lined-web/src/features/calendar/grid/MonthGrid.tsx
@@ -41,7 +41,25 @@ const MonthDayCell = ({ day, monthAnchor, events, lobbyMap, onDayClick }: MonthD
       >
         {day.getDate()}
       </div>
-      <div className="flex w-full flex-col gap-0.5">
+      {/* Tablet (<lg): compact colored dots instead of full title chips — a
+          day cell is too narrow at that width to fit readable text. */}
+      <div className="flex w-full flex-wrap gap-1 lg:hidden">
+        {visible.map((event) => {
+          const lobby = lobbyMap.get(event.lobbyId);
+          const accentColor = lobby ? lobbyAccentColor(lobby.lobbyType) : 'var(--color-lobby-couple)';
+          return (
+            <span
+              key={event.id}
+              aria-label={event.title}
+              className="h-1.5 w-1.5 flex-shrink-0 rounded-full"
+              style={{ backgroundColor: accentColor }}
+            />
+          );
+        })}
+        {overflowCount > 0 && <span className="text-[9px] font-medium text-text-muted">+{overflowCount}</span>}
+      </div>
+
+      <div className="hidden w-full flex-col gap-0.5 lg:flex">
         {visible.map((event) => {
           const lobby = lobbyMap.get(event.lobbyId);
           const accentColor = lobby ? lobbyAccentColor(lobby.lobbyType) : 'var(--color-lobby-couple)';

--- a/lined-web/src/features/calendar/grid/WeekGrid.tsx
+++ b/lined-web/src/features/calendar/grid/WeekGrid.tsx
@@ -249,6 +249,9 @@ const DayColumn = ({
 
 interface WeekGridProps {
   weekStart: Date;
+  /** Overrides the default 7-day week — a 1-length array renders the same
+   *  hour-grid/free-slot/event internals as a single day column (phone day view). */
+  days?: Date[];
   events: EventDto[];
   lobbies: LobbyDto[];
   selectedEventId: number | null;
@@ -275,6 +278,7 @@ const defaultGetFreeSlotsForDay = (day: Date, dayEvents: EventDto[]): FreeSlot[]
 
 export const WeekGrid = ({
   weekStart,
+  days,
   events,
   lobbies,
   selectedEventId,
@@ -285,7 +289,7 @@ export const WeekGrid = ({
   maxVisibleEvents = 4,
   onFreeSlotClick,
 }: WeekGridProps) => {
-  const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+  const weekDays = days ?? Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
   const lobbyMap = new Map(lobbies.map((l) => [l.id, l]));
 
   // Auto-scroll to current time on mount

--- a/lined-web/src/features/calendar/grid/__tests__/DayChipStrip.test.tsx
+++ b/lined-web/src/features/calendar/grid/__tests__/DayChipStrip.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DayChipStrip } from '../DayChipStrip';
+
+describe('DayChipStrip', () => {
+  it('renders a chip for each of the 7 days in the selected day\'s week', () => {
+    expect.assertions(1);
+    render(<DayChipStrip selectedDay={new Date('2026-03-25')} onSelectDay={() => {}} />);
+
+    expect(screen.getAllByRole('tab')).toHaveLength(7);
+  });
+
+  it('marks the selected day as the active tab', () => {
+    expect.assertions(1);
+    const selectedDay = new Date('2026-03-25');
+    render(<DayChipStrip selectedDay={selectedDay} onSelectDay={() => {}} />);
+
+    const active = screen.getAllByRole('tab').filter((tab) => tab.getAttribute('aria-selected') === 'true');
+    expect(active).toHaveLength(1);
+  });
+
+  it('calls onSelectDay with the clicked day', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    const onSelectDay = vi.fn();
+    render(<DayChipStrip selectedDay={new Date('2026-03-25')} onSelectDay={onSelectDay} />);
+
+    await user.click(screen.getAllByRole('tab')[2]!);
+
+    expect(onSelectDay).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onSelectDay on mount', () => {
+    expect.assertions(1);
+    const onSelectDay = vi.fn();
+    render(<DayChipStrip selectedDay={new Date('2026-03-25')} onSelectDay={onSelectDay} />);
+
+    expect(onSelectDay).not.toHaveBeenCalled();
+  });
+});

--- a/lined-web/src/features/calendar/pages/CalendarPage.tsx
+++ b/lined-web/src/features/calendar/pages/CalendarPage.tsx
@@ -235,7 +235,7 @@ export const CalendarPage = () => {
           type="button"
           onClick={openCreateModal}
           aria-label="New event"
-          className="fixed bottom-20 right-4 z-20 flex h-14 w-14 items-center justify-center rounded-full bg-brand-green text-white shadow-[var(--shadow-lg)] hover:bg-brand-green-dark md:hidden"
+          className="fixed bottom-24 right-4 z-20 flex h-14 w-14 items-center justify-center rounded-full bg-brand-green text-white shadow-[var(--shadow-lg)] hover:bg-brand-green-dark md:hidden"
         >
           <Plus className="h-6 w-6" />
         </button>

--- a/lined-web/src/features/calendar/pages/CalendarPage.tsx
+++ b/lined-web/src/features/calendar/pages/CalendarPage.tsx
@@ -1,16 +1,27 @@
 import { useState } from 'react';
+import { Plus, ChevronLeft, ChevronRight } from 'lucide-react';
 import { getErrorStatus } from '@/lib/apiClient';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { CalendarTopBar } from '@/features/calendar/CalendarTopBar';
 import { CreateEventModal } from '@/features/calendar/events/CreateEventModal';
 import { EventDetailPanel } from '@/features/calendar/panels/EventDetailPanel';
 import { DayAgendaPanel } from '@/features/calendar/panels/DayAgendaPanel';
 import { WeekGrid } from '@/features/calendar/grid/WeekGrid';
 import { MonthGrid } from '@/features/calendar/grid/MonthGrid';
+import { DayChipStrip } from '@/features/calendar/grid/DayChipStrip';
 import { useWeekEvents, useMonthEvents, useDeleteEvent } from '@/features/calendar/hooks/useEvents';
 import { useMyLobbies } from '@/features/lobby/hooks/useLobbies';
 import { useCalendarStore } from '@/store/calendar';
 import { useCreateMenuStore } from '@/store/createMenu';
-import { formatMonthYear, hourRangeToIso, isSameDay, type FreeSlot } from '@/features/calendar/lib/calendarUtils';
+import {
+  formatFullDate,
+  formatMonthYear,
+  getWeekStart,
+  hourRangeToIso,
+  isSameDay,
+  eventTouchesDay,
+  type FreeSlot,
+} from '@/features/calendar/lib/calendarUtils';
 import { WeekEmptyBanner } from '@/features/calendar/grid/WeekEmptyBanner';
 import type { EventDto } from '@/features/calendar/model';
 
@@ -26,6 +37,7 @@ export const CalendarPage = () => {
     weekStart,
     monthAnchor,
     viewMode,
+    dayAnchor,
     selectedEventId,
     isCreateModalOpen,
     hiddenLobbyIds,
@@ -33,6 +45,9 @@ export const CalendarPage = () => {
     goToNextWeek,
     goToPrevMonth,
     goToNextMonth,
+    goToPrevDay,
+    goToNextDay,
+    goToDay,
     goToToday,
     goToWeekOf,
     setViewMode,
@@ -42,18 +57,27 @@ export const CalendarPage = () => {
     toggleLobbyVisibility,
   } = useCalendarStore();
 
+  // Phones always show a single-day view (auto, not user-toggled) — the
+  // week/month toggle in CalendarTopBar stays desktop/tablet-only.
+  const isPhone = useMediaQuery('(max-width: 767px)');
+
   const [editingEvent, setEditingEvent] = useState<EventDto | null>(null);
   const [agendaDay, setAgendaDay] = useState<Date | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
+  const dayWeekStart = getWeekStart(dayAnchor);
   const { data: allWeekEvents = [] } = useWeekEvents(weekStart);
   const { data: allMonthEvents = [] } = useMonthEvents(monthAnchor);
+  const { data: allDayWeekEvents = [] } = useWeekEvents(dayWeekStart);
   // Lobby-filter dropdown decluttering: same intent as Google/Outlook's
   // per-calendar checkboxes — hidden lobbies vanish from the grid entirely,
   // including free-slot detection (a hidden lobby's time isn't "free").
   const weekEvents = allWeekEvents.filter((e) => !hiddenLobbyIds.includes(e.lobbyId));
   const monthEvents = allMonthEvents.filter((e) => !hiddenLobbyIds.includes(e.lobbyId));
-  const events = viewMode === 'month' ? monthEvents : weekEvents;
+  const dayEvents = allDayWeekEvents.filter(
+    (e) => !hiddenLobbyIds.includes(e.lobbyId) && eventTouchesDay(e, dayAnchor),
+  );
+  const events = isPhone ? dayEvents : viewMode === 'month' ? monthEvents : weekEvents;
   const { data: lobbies = [] } = useMyLobbies();
   const deleteEvent = useDeleteEvent();
   const openReserveSlot = useCreateMenuStore((s) => s.openReserveSlot);
@@ -95,74 +119,127 @@ export const CalendarPage = () => {
   return (
     // h-full fills the flex-1 main area; overflow-hidden so the grid controls its own scroll
     <div className="relative flex h-full flex-col overflow-hidden">
-      <CalendarTopBar
-        title={formatMonthYear(viewMode === 'month' ? monthAnchor : weekStart)}
-        viewMode={viewMode}
-        onPrev={viewMode === 'month' ? goToPrevMonth : goToPrevWeek}
-        onNext={viewMode === 'month' ? goToNextMonth : goToNextWeek}
-        onToday={goToToday}
-        onViewModeChange={setViewMode}
-        onNewEvent={openCreateModal}
-        lobbies={lobbies}
-        hiddenLobbyIds={hiddenLobbyIds}
-        onToggleLobby={toggleLobbyVisibility}
-      />
+      {isPhone ? (
+        <div className="flex h-14 flex-shrink-0 items-center justify-between border-b border-border bg-white px-4">
+          <button
+            type="button"
+            onClick={goToPrevDay}
+            aria-label="Previous day"
+            className="flex h-8 w-8 items-center justify-center rounded-lg text-text-secondary hover:bg-bg"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={goToToday}
+            className="text-sm font-semibold text-text-primary"
+          >
+            {formatFullDate(dayAnchor)}
+          </button>
+          <button
+            type="button"
+            onClick={goToNextDay}
+            aria-label="Next day"
+            className="flex h-8 w-8 items-center justify-center rounded-lg text-text-secondary hover:bg-bg"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      ) : (
+        <CalendarTopBar
+          title={formatMonthYear(viewMode === 'month' ? monthAnchor : weekStart)}
+          viewMode={viewMode}
+          onPrev={viewMode === 'month' ? goToPrevMonth : goToPrevWeek}
+          onNext={viewMode === 'month' ? goToNextMonth : goToNextWeek}
+          onToday={goToToday}
+          onViewModeChange={setViewMode}
+          onNewEvent={openCreateModal}
+          lobbies={lobbies}
+          hiddenLobbyIds={hiddenLobbyIds}
+          onToggleLobby={toggleLobbyVisibility}
+        />
+      )}
 
-      {viewMode === 'week' && weekEvents.length === 0 && (
+      {!isPhone && viewMode === 'week' && weekEvents.length === 0 && (
         <WeekEmptyBanner
           message="No events this week — create one."
           action={{ label: 'Create event', onClick: openCreateModal }}
         />
       )}
 
-      <div className="flex flex-1 min-h-0 overflow-hidden">
-        {viewMode === 'month' ? (
-          <MonthGrid
-            monthAnchor={monthAnchor}
-            events={monthEvents}
-            lobbies={lobbies}
-            onDayClick={goToWeekOf}
-          />
-        ) : (
-          <WeekGrid
-            weekStart={weekStart}
-            events={weekEvents}
-            lobbies={lobbies}
-            selectedEventId={selectedEventId}
-            onEventClick={handleEventClick}
-            onFreeSlotClick={handleFreeSlotClick}
-            onDayClick={handleDayClick}
-            maxVisibleEvents={4}
-          />
-        )}
+      <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
+        {isPhone && <DayChipStrip selectedDay={dayAnchor} onSelectDay={goToDay} />}
 
-        {agendaDay && viewMode === 'week' ? (
-          <DayAgendaPanel
-            day={agendaDay}
-            events={weekEvents.filter((e) => isSameDay(new Date(e.startAt), agendaDay))}
-            lobbies={lobbies}
-            selectedEventId={selectedEventId}
-            onEventClick={handleEventClick}
-            onClose={() => setAgendaDay(null)}
-          />
-        ) : (
-          selectedEvent &&
-          selectedLobby &&
-          viewMode === 'week' && (
-            <EventDetailPanel
-              event={selectedEvent}
-              lobby={selectedLobby}
-              onClose={() => {
-                setDeleteError(null);
-                setSelectedEventId(null);
-              }}
-              onEdit={() => setEditingEvent(selectedEvent)}
-              onDelete={handleDelete}
-              deleteError={deleteError}
+        <div className="flex flex-1 min-h-0 overflow-hidden">
+          {isPhone ? (
+            <WeekGrid
+              weekStart={dayWeekStart}
+              days={[dayAnchor]}
+              events={dayEvents}
+              lobbies={lobbies}
+              selectedEventId={selectedEventId}
+              onEventClick={handleEventClick}
+              onFreeSlotClick={handleFreeSlotClick}
             />
-          )
-        )}
+          ) : viewMode === 'month' ? (
+            <MonthGrid
+              monthAnchor={monthAnchor}
+              events={monthEvents}
+              lobbies={lobbies}
+              onDayClick={goToWeekOf}
+            />
+          ) : (
+            <WeekGrid
+              weekStart={weekStart}
+              events={weekEvents}
+              lobbies={lobbies}
+              selectedEventId={selectedEventId}
+              onEventClick={handleEventClick}
+              onFreeSlotClick={handleFreeSlotClick}
+              onDayClick={handleDayClick}
+              maxVisibleEvents={4}
+            />
+          )}
+
+          {agendaDay && !isPhone && viewMode === 'week' ? (
+            <DayAgendaPanel
+              day={agendaDay}
+              events={weekEvents.filter((e) => isSameDay(new Date(e.startAt), agendaDay))}
+              lobbies={lobbies}
+              selectedEventId={selectedEventId}
+              onEventClick={handleEventClick}
+              onClose={() => setAgendaDay(null)}
+            />
+          ) : (
+            selectedEvent &&
+            selectedLobby &&
+            (isPhone || viewMode === 'week') && (
+              <EventDetailPanel
+                event={selectedEvent}
+                lobby={selectedLobby}
+                onClose={() => {
+                  setDeleteError(null);
+                  setSelectedEventId(null);
+                }}
+                onEdit={() => setEditingEvent(selectedEvent)}
+                onDelete={handleDelete}
+                deleteError={deleteError}
+              />
+            )
+          )}
+        </div>
       </div>
+
+      {isPhone && (
+        <button
+          type="button"
+          onClick={openCreateModal}
+          aria-label="New event"
+          className="fixed bottom-20 right-4 z-20 flex h-14 w-14 items-center justify-center rounded-full bg-brand-green text-white shadow-[var(--shadow-lg)] hover:bg-brand-green-dark md:hidden"
+        >
+          <Plus className="h-6 w-6" />
+        </button>
+      )}
 
       {isCreateModalOpen && (
         <CreateEventModal

--- a/lined-web/src/features/calendar/pages/__tests__/CalendarPage.test.tsx
+++ b/lined-web/src/features/calendar/pages/__tests__/CalendarPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { renderWithProviders, screen, userEvent, waitFor } from '@/test/utils';
 import { server } from '@/test/server';
@@ -6,8 +6,33 @@ import { CalendarPage } from '../CalendarPage';
 import { useAuthStore } from '@/store/auth';
 import { useCalendarStore } from '@/store/calendar';
 import { useCreateMenuStore } from '@/store/createMenu';
+import { MOCK_EVENTS } from '@/features/calendar/api/mockData';
 
 const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+
+/** "Morning Coffee"'s local calendar day — deriving it from the mock event
+ *  (rather than assuming it equals `new Date()`) keeps these tests stable
+ *  regardless of the machine's timezone/time-of-day relative to the mock
+ *  data's UTC-sliced "today" fixture. */
+const morningCoffeeLocalDay = (): Date => {
+  const day = new Date(MOCK_EVENTS[0]!.startAt);
+  day.setHours(0, 0, 0, 0);
+  return day;
+};
+
+/** Forces useMediaQuery('(max-width: 767px)') to report a phone width. */
+const mockPhoneViewport = () => {
+  vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+    matches: query === '(max-width: 767px)',
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+};
 
 describe('CalendarPage', () => {
   beforeEach(() => {
@@ -172,5 +197,49 @@ describe('CalendarPage', () => {
     await user.click(await screen.findByRole('menuitemcheckbox', { name: /Alex & Anastasiia/ }));
 
     expect(await screen.findByText('Morning Coffee')).toBeInTheDocument();
+  });
+
+  describe('phone viewport', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('renders a single-day view with a day-chip strip instead of the week/month toggle', async () => {
+      expect.assertions(3);
+      mockPhoneViewport();
+      useCalendarStore.setState({ dayAnchor: morningCoffeeLocalDay() });
+      renderWithProviders(<CalendarPage />);
+
+      expect(await screen.findByText('Morning Coffee')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Week' })).not.toBeInTheDocument();
+      expect(screen.getByRole('tablist', { name: 'Select day' })).toBeInTheDocument();
+    });
+
+    it('shows a floating "+" button that opens the create-event modal', async () => {
+      expect.assertions(1);
+      mockPhoneViewport();
+      useCalendarStore.setState({ dayAnchor: morningCoffeeLocalDay() });
+      const user = userEvent.setup();
+      renderWithProviders(<CalendarPage />);
+      await screen.findByText('Morning Coffee');
+
+      await user.click(screen.getByRole('button', { name: 'New event' }));
+
+      expect(useCalendarStore.getState().isCreateModalOpen).toBe(true);
+    });
+
+    it('moves to the next day when the next-day chevron is clicked', async () => {
+      expect.assertions(1);
+      mockPhoneViewport();
+      useCalendarStore.setState({ dayAnchor: morningCoffeeLocalDay() });
+      const user = userEvent.setup();
+      const initialDay = useCalendarStore.getState().dayAnchor;
+      renderWithProviders(<CalendarPage />);
+      await screen.findByText('Morning Coffee');
+
+      await user.click(screen.getByRole('button', { name: 'Next day' }));
+
+      expect(useCalendarStore.getState().dayAnchor.getTime()).toBeGreaterThan(initialDay.getTime());
+    });
   });
 });

--- a/lined-web/src/features/calendar/panels/DayAgendaPanel.tsx
+++ b/lined-web/src/features/calendar/panels/DayAgendaPanel.tsx
@@ -25,7 +25,7 @@ export const DayAgendaPanel = ({
   const sorted = [...events].sort((a, b) => a.startAt.localeCompare(b.startAt));
 
   return (
-    <div className="m-4 ml-0 w-72 flex-shrink-0 self-start overflow-hidden rounded-xl bg-white shadow-[var(--shadow-md)]">
+    <div className="fixed inset-x-0 bottom-0 z-30 max-h-[70vh] w-full overflow-y-auto rounded-t-2xl bg-white shadow-[var(--shadow-md)] md:relative md:inset-auto md:z-auto md:m-4 md:ml-0 md:max-h-none md:w-72 md:flex-shrink-0 md:self-start md:overflow-hidden md:rounded-xl">
       <div className="flex items-center justify-between px-5 pt-4 pb-3">
         <h3 className="text-sm font-bold text-text-primary">{formatFullDate(day)}</h3>
         <button

--- a/lined-web/src/features/calendar/panels/EventDetailPanel.tsx
+++ b/lined-web/src/features/calendar/panels/EventDetailPanel.tsx
@@ -24,7 +24,7 @@ export const EventDetailPanel = ({
   const accentColor = lobbyAccentColor(lobby.lobbyType);
 
   return (
-    <div className="m-4 ml-0 w-72 flex-shrink-0 self-start overflow-hidden rounded-xl bg-white shadow-[var(--shadow-md)]">
+    <div className="fixed inset-x-0 bottom-0 z-30 max-h-[70vh] w-full overflow-y-auto rounded-t-2xl bg-white shadow-[var(--shadow-md)] md:relative md:inset-auto md:z-auto md:m-4 md:ml-0 md:max-h-none md:w-72 md:flex-shrink-0 md:self-start md:overflow-hidden md:rounded-xl">
       {/* Coloured accent bar */}
       <div className="h-1" style={{ backgroundColor: accentColor }} />
 

--- a/lined-web/src/features/dashboard/pages/DashboardPage.tsx
+++ b/lined-web/src/features/dashboard/pages/DashboardPage.tsx
@@ -31,9 +31,9 @@ export const DashboardPage = () => {
   return (
     <div className="flex-1 overflow-y-auto">
       {/* Greeting top bar */}
-      <div className="flex h-16 flex-shrink-0 items-center justify-between border-b border-border bg-white px-8">
+      <div className="flex h-16 flex-shrink-0 items-center justify-between border-b border-border bg-white px-4 md:px-8">
         <div>
-          <h1 className="text-lg font-semibold text-text-primary">
+          <h1 className="text-base font-semibold text-text-primary md:text-lg">
             {getGreeting()}, {user?.username ?? 'there'} 👋
           </h1>
           <p className="text-xs text-text-secondary">{formatFullDate(new Date())}</p>
@@ -45,7 +45,7 @@ export const DashboardPage = () => {
       </div>
 
       {/* Content */}
-      <div className="flex flex-col gap-6 p-6">
+      <div className="flex flex-col gap-6 p-4 md:p-6">
         <PendingInvitesBanner />
 
         {showHero ? (
@@ -60,7 +60,7 @@ export const DashboardPage = () => {
           />
         )}
 
-        <div className="grid grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
           <UpcomingEventsList
             events={events}
             lobbies={lobbies}

--- a/lined-web/src/features/layout/AppShell.tsx
+++ b/lined-web/src/features/layout/AppShell.tsx
@@ -1,12 +1,15 @@
+import { useEffect } from 'react';
 import { useNavigate, useParams, Outlet } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 import { TopBar } from './TopBar';
+import { BottomTabBar } from './BottomTabBar';
 import { CreateLobbyModal } from '@/features/lobby/CreateLobbyModal';
 import { CreateEventModal } from '@/features/calendar/events/CreateEventModal';
 import { TaskDrawer } from '@/features/tasks/TaskDrawer';
 import { ReserveSlotModal } from '@/features/calendar/events/ReserveSlotModal';
 import { useCreateMenuStore } from '@/store/createMenu';
 import { useCalendarStore } from '@/store/calendar';
+import { useUiStore } from '@/store/ui';
 import { useMyLobbies } from '@/features/lobby/hooks/useLobbies';
 
 export const AppShell = () => {
@@ -21,15 +24,41 @@ export const AppShell = () => {
   const reserveSlotInitial = useCreateMenuStore((s) => s.reserveSlotInitial);
   const closeOverlay = useCreateMenuStore((s) => s.closeOverlay);
   const setSelectedEventId = useCalendarStore((s) => s.setSelectedEventId);
+  const isSidebarDrawerOpen = useUiStore((s) => s.isSidebarDrawerOpen);
+  const closeSidebarDrawer = useUiStore((s) => s.closeSidebarDrawer);
   const { data: lobbies = [] } = useMyLobbies();
+
+  useEffect(() => {
+    if (!isSidebarDrawerOpen) return undefined;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isSidebarDrawerOpen]);
 
   return (
     <div className="flex h-screen overflow-hidden bg-bg">
-      <Sidebar />
+      <div className="hidden lg:flex">
+        <Sidebar />
+      </div>
+
+      {isSidebarDrawerOpen && (
+        <div data-testid="sidebar-drawer" className="fixed inset-0 z-40 flex lg:hidden">
+          <div
+            data-testid="sidebar-drawer-backdrop"
+            className="absolute inset-0 bg-black/45"
+            onClick={closeSidebarDrawer}
+          />
+          <div className="relative flex h-full">
+            <Sidebar onNavigate={closeSidebarDrawer} />
+          </div>
+        </div>
+      )}
+
       <div className="flex flex-1 flex-col min-w-0">
         <TopBar />
         {/* overflow-hidden so full-height pages (e.g. CalendarPage) control their own scroll */}
-        <main className="relative flex flex-1 flex-col overflow-hidden">
+        <main className="relative flex flex-1 flex-col overflow-hidden pb-16 md:pb-0">
           <Outlet />
 
           {isCreateLobbyOpen && <CreateLobbyModal onClose={closeCreateLobby} />}
@@ -68,6 +97,8 @@ export const AppShell = () => {
             />
           )}
         </main>
+
+        <BottomTabBar />
       </div>
     </div>
   );

--- a/lined-web/src/features/layout/BottomTabBar.tsx
+++ b/lined-web/src/features/layout/BottomTabBar.tsx
@@ -1,0 +1,26 @@
+import { NavLink } from 'react-router-dom';
+import { NAV_ITEMS } from './navItems';
+
+/** Primary nav on phones, replacing the sidebar. Hidden at `md` and above. */
+export const BottomTabBar = () => (
+  <nav
+    aria-label="Primary"
+    className="fixed inset-x-0 bottom-0 z-30 flex h-16 flex-shrink-0 items-stretch border-t border-border bg-white md:hidden"
+  >
+    {NAV_ITEMS.map(({ to, icon: Icon, label }) => (
+      <NavLink
+        key={to}
+        to={to}
+        end={to === '/'}
+        className={({ isActive }) =>
+          `flex flex-1 flex-col items-center justify-center gap-1 text-xs font-medium ${
+            isActive ? 'text-brand-green' : 'text-text-secondary'
+          }`
+        }
+      >
+        <Icon className="h-5 w-5" />
+        {label}
+      </NavLink>
+    ))}
+  </nav>
+);

--- a/lined-web/src/features/layout/Sidebar.tsx
+++ b/lined-web/src/features/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink, useNavigate } from 'react-router-dom';
-import { LayoutDashboard, Calendar, ListTodo, Settings, LogOut } from 'lucide-react';
+import { Settings, LogOut } from 'lucide-react';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Separator } from '@/components/ui/separator';
 import { useMyLobbies } from '@/features/lobby/hooks/useLobbies';
@@ -8,14 +8,14 @@ import { useAuthStore } from '@/store/auth';
 import { useCreateMenuStore } from '@/store/createMenu';
 import { LOBBY_TYPE_COLORS } from '@/features/lobby/lib/constants';
 import { EmptyState } from '@/components/EmptyState';
+import { NAV_ITEMS } from './navItems';
 
-const NAV_ITEMS = [
-  { to: '/', icon: LayoutDashboard, label: 'Dashboard' },
-  { to: '/calendar', icon: Calendar, label: 'Calendar' },
-  { to: '/tasks', icon: ListTodo, label: 'Tasks' },
-] as const;
+interface SidebarProps {
+  /** Called after any nav link is clicked — used by the mobile drawer to close itself. */
+  onNavigate?: () => void;
+}
 
-export const Sidebar = () => {
+export const Sidebar = ({ onNavigate }: SidebarProps = {}) => {
   const navigate = useNavigate();
   const { data: lobbies, isLoading: lobbiesLoading } = useMyLobbies();
   const { data: user, isLoading: userLoading } = useCurrentUser();
@@ -41,6 +41,7 @@ export const Sidebar = () => {
             key={to}
             to={to}
             end={to === '/'}
+            onClick={onNavigate}
             className={({ isActive }) =>
               `flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
                 isActive
@@ -99,6 +100,7 @@ export const Sidebar = () => {
             <NavLink
               key={lobby.id}
               to={`/lobbies/${lobby.id}`}
+              onClick={onNavigate}
               className={({ isActive }) =>
                 `flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
                   isActive
@@ -122,6 +124,7 @@ export const Sidebar = () => {
       <div className="px-3 pb-2">
         <NavLink
           to="/settings"
+          onClick={onNavigate}
           className={({ isActive }) =>
             `flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
               isActive

--- a/lined-web/src/features/layout/TopBar.tsx
+++ b/lined-web/src/features/layout/TopBar.tsx
@@ -1,4 +1,6 @@
 import { useLocation } from 'react-router-dom';
+import { Menu } from 'lucide-react';
+import { useUiStore } from '@/store/ui';
 
 const ROUTE_TITLES: Record<string, string> = {
   '/': 'Dashboard',
@@ -9,14 +11,23 @@ const ROUTE_TITLES: Record<string, string> = {
 
 export const TopBar = () => {
   const location = useLocation();
+  const openSidebarDrawer = useUiStore((s) => s.openSidebarDrawer);
 
   const title =
     ROUTE_TITLES[location.pathname] ??
     (location.pathname.startsWith('/lobbies/') ? 'Lobby' : 'Lined');
 
   return (
-    <header className="flex h-16 flex-shrink-0 items-center justify-between border-b border-border bg-white px-6">
-      <h1 className="text-lg font-semibold text-text-primary">{title}</h1>
+    <header className="flex h-14 flex-shrink-0 items-center gap-3 border-b border-border bg-white px-4 md:h-16 md:px-6">
+      <button
+        type="button"
+        onClick={openSidebarDrawer}
+        aria-label="Open menu"
+        className="-ml-1 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg text-text-secondary hover:bg-bg lg:hidden"
+      >
+        <Menu className="h-5 w-5" />
+      </button>
+      <h1 className="truncate text-base font-semibold text-text-primary md:text-lg">{title}</h1>
     </header>
   );
 }

--- a/lined-web/src/features/layout/__tests__/AppShell.test.tsx
+++ b/lined-web/src/features/layout/__tests__/AppShell.test.tsx
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Routes, Route } from 'react-router-dom';
-import { renderWithProviders, screen } from '@/test/utils';
+import { within } from '@testing-library/react';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
 import { MOCK_TASKS } from '@/features/tasks/api/mockData';
 import { AppShell } from '../AppShell';
 import { useAuthStore } from '@/store/auth';
 import { useCreateMenuStore } from '@/store/createMenu';
+import { useUiStore } from '@/store/ui';
 import { CREATE_MENU_TEXT } from '@/test/createMenuContent';
 
 describe('AppShell', () => {
@@ -16,6 +18,7 @@ describe('AppShell', () => {
       editingTask: null,
       reserveSlotInitial: null,
     });
+    useUiStore.setState({ isSidebarDrawerOpen: false });
   });
 
   const renderShell = (initialEntries: string[] = ['/']) => {
@@ -105,5 +108,43 @@ describe('AppShell', () => {
     renderShell();
 
     expect(await screen.findByLabelText('What would you like to do?')).toBeInTheDocument();
+  });
+
+  it('does not render the sidebar drawer by default', () => {
+    expect.assertions(1);
+    renderShell();
+
+    expect(screen.queryByTestId('sidebar-drawer-backdrop')).not.toBeInTheDocument();
+  });
+
+  it('renders the sidebar drawer when the ui store flags it open', async () => {
+    expect.assertions(1);
+    useUiStore.setState({ isSidebarDrawerOpen: true });
+    renderShell();
+
+    expect(await screen.findByTestId('sidebar-drawer-backdrop')).toBeInTheDocument();
+  });
+
+  it('closes the sidebar drawer when the backdrop is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    useUiStore.setState({ isSidebarDrawerOpen: true });
+    renderShell();
+
+    await user.click(await screen.findByTestId('sidebar-drawer-backdrop'));
+
+    expect(useUiStore.getState().isSidebarDrawerOpen).toBe(false);
+  });
+
+  it('closes the sidebar drawer when a nav link inside it is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    useUiStore.setState({ isSidebarDrawerOpen: true });
+    renderShell();
+    const drawer = await screen.findByTestId('sidebar-drawer');
+
+    await user.click(within(drawer).getByRole('link', { name: /calendar/i }));
+
+    expect(useUiStore.getState().isSidebarDrawerOpen).toBe(false);
   });
 });

--- a/lined-web/src/features/layout/__tests__/BottomTabBar.test.tsx
+++ b/lined-web/src/features/layout/__tests__/BottomTabBar.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { Routes, Route } from 'react-router-dom';
+import { renderWithProviders, screen } from '@/test/utils';
+import { BottomTabBar } from '../BottomTabBar';
+
+const renderBar = (initialEntries: string[]) =>
+  renderWithProviders(
+    <Routes>
+      <Route path="*" element={<BottomTabBar />} />
+    </Routes>,
+    { initialEntries },
+  );
+
+describe('BottomTabBar', () => {
+  it('renders a nav item for each of Dashboard, Calendar and Tasks', () => {
+    expect.assertions(3);
+    renderBar(['/']);
+
+    expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /calendar/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /tasks/i })).toBeInTheDocument();
+  });
+
+  it('marks the current route active via aria-current', () => {
+    expect.assertions(2);
+    renderBar(['/calendar']);
+
+    expect(screen.getByRole('link', { name: /calendar/i })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: /dashboard/i })).not.toHaveAttribute('aria-current');
+  });
+
+  it('links to the calendar and tasks routes', () => {
+    expect.assertions(2);
+    renderBar(['/']);
+
+    expect(screen.getByRole('link', { name: /calendar/i })).toHaveAttribute('href', '/calendar');
+    expect(screen.getByRole('link', { name: /tasks/i })).toHaveAttribute('href', '/tasks');
+  });
+});

--- a/lined-web/src/features/layout/__tests__/TopBar.test.tsx
+++ b/lined-web/src/features/layout/__tests__/TopBar.test.tsx
@@ -1,8 +1,23 @@
-import { describe, it, expect } from 'vitest';
-import { renderWithProviders, screen } from '@/test/utils';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
 import { TopBar } from '../TopBar';
+import { useUiStore } from '@/store/ui';
 
 describe('TopBar', () => {
+  beforeEach(() => {
+    useUiStore.setState({ isSidebarDrawerOpen: false });
+  });
+
+  it('opens the sidebar drawer when the menu button is clicked', async () => {
+    expect.assertions(1);
+    const user = userEvent.setup();
+    renderWithProviders(<TopBar />, { initialEntries: ['/'] });
+
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    expect(useUiStore.getState().isSidebarDrawerOpen).toBe(true);
+  });
+
   it('shows "Dashboard" for the root route', () => {
     expect.assertions(1);
     renderWithProviders(<TopBar />, { initialEntries: ['/'] });

--- a/lined-web/src/features/layout/navItems.ts
+++ b/lined-web/src/features/layout/navItems.ts
@@ -1,0 +1,8 @@
+import { LayoutDashboard, Calendar, ListTodo } from 'lucide-react';
+
+/** Primary nav destinations, shared by the desktop Sidebar and the mobile BottomTabBar. */
+export const NAV_ITEMS = [
+  { to: '/', icon: LayoutDashboard, label: 'Dashboard' },
+  { to: '/calendar', icon: Calendar, label: 'Calendar' },
+  { to: '/tasks', icon: ListTodo, label: 'Tasks' },
+] as const;

--- a/lined-web/src/features/lobby/CreateLobbyModal.tsx
+++ b/lined-web/src/features/lobby/CreateLobbyModal.tsx
@@ -44,8 +44,8 @@ export const CreateLobbyModal = ({ onClose }: CreateLobbyModalProps) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      {/* Dialog */}
-      <div className="w-[460px] max-w-[90vw] overflow-hidden rounded-2xl bg-white shadow-[var(--shadow-lg)]">
+      {/* Dialog — full-screen sheet under md, centered card at md and above */}
+      <div className="flex h-full w-full flex-col overflow-y-auto bg-white md:h-auto md:max-h-[90vh] md:w-[460px] md:max-w-[90vw] md:flex-none md:rounded-2xl md:shadow-[var(--shadow-lg)]">
         {/* Header */}
         <div className="flex items-center justify-between px-6 pt-5">
           <h2 className="text-lg font-bold text-text-primary">New Lobby</h2>

--- a/lined-web/src/features/lobby/header/LobbyHeader.tsx
+++ b/lined-web/src/features/lobby/header/LobbyHeader.tsx
@@ -19,7 +19,7 @@ export const LobbyHeader = ({ lobby }: LobbyHeaderProps) => {
 
   return (
     <div className={`border-t-4 bg-white ${LOBBY_TYPE_BORDER_CLASSES[lobby.lobbyType]}`}>
-      <div className="flex items-center justify-between gap-4 p-6">
+      <div className="flex flex-col items-start gap-4 p-4 md:flex-row md:items-center md:justify-between md:p-6">
         <div className="flex items-center gap-4">
           <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-xl bg-gray-100 text-2xl">
             {LOBBY_TYPE_ICONS[lobby.lobbyType]}

--- a/lined-web/src/features/lobby/header/LobbyTabBar.tsx
+++ b/lined-web/src/features/lobby/header/LobbyTabBar.tsx
@@ -17,7 +17,7 @@ interface LobbyTabBarProps {
 
 export const LobbyTabBar = ({ lobbyType, activeTab, onTabChange }: LobbyTabBarProps) => {
   return (
-    <div role="tablist" className="flex gap-6 border-b border-border bg-white px-6">
+    <div role="tablist" className="flex gap-6 overflow-x-auto border-b border-border bg-white px-4 md:px-6">
       {TABS.map((tab) => {
         const isActive = tab.id === activeTab;
         return (

--- a/lined-web/src/features/lobby/pages/LobbySettingsPage.tsx
+++ b/lined-web/src/features/lobby/pages/LobbySettingsPage.tsx
@@ -28,7 +28,7 @@ export const LobbySettingsPage = () => {
     <div className="flex-1 overflow-y-auto">
       <LobbyHeader lobby={lobby} />
 
-      <div className="p-8">
+      <div className="p-4 md:p-8">
         <div className="mb-6 flex items-center gap-2 text-sm text-text-secondary">
           <Link to={`/lobbies/${lobby.id}`} className="text-brand-green hover:underline">
             ← Back to lobby

--- a/lined-web/src/features/settings/SettingsMenu.tsx
+++ b/lined-web/src/features/settings/SettingsMenu.tsx
@@ -36,7 +36,7 @@ const menuItemClass = (danger?: boolean): string => {
 /** Left-hand jump list for the settings page — most items scroll-anchor within the
  * single-scroll page; items with a `route` navigate to a separate page instead. */
 export const SettingsMenu = () => (
-  <nav className="w-[220px] flex-shrink-0 border-r border-border bg-white py-5">
+  <nav className="w-full flex-shrink-0 border-b border-border bg-white py-5 md:w-[220px] md:border-b-0 md:border-r">
     {SECTIONS.map((section) => (
       <div key={section.label}>
         <div className="px-5 py-1.5 text-[11px] font-semibold tracking-wider text-text-muted">

--- a/lined-web/src/features/settings/pages/UserSettingsPage.tsx
+++ b/lined-web/src/features/settings/pages/UserSettingsPage.tsx
@@ -10,9 +10,9 @@ export const UserSettingsPage = () => {
   const { data: user, isLoading } = useCurrentUser();
 
   return (
-    <div className="flex flex-1 overflow-hidden">
+    <div className="flex flex-1 flex-col overflow-y-auto md:flex-row md:overflow-hidden">
       <SettingsMenu />
-      <div className="flex-1 overflow-y-auto bg-bg p-8">
+      <div className="flex-1 overflow-y-auto bg-bg p-4 md:p-8">
         <ProfileCard user={user} isLoading={isLoading} />
         <PasswordCard userId={user?.id} />
         <NotificationsCard />

--- a/lined-web/src/features/tasks/TaskDrawer.tsx
+++ b/lined-web/src/features/tasks/TaskDrawer.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 import type { LobbyDto } from '@/features/lobby/model';
 import type { TaskDto, TaskPriority, TaskStatus, TaskUpdateDto } from '@/features/tasks/model';
 import { useCreateTask, useUpdateTask, useDeleteTask } from '@/features/tasks/hooks/useTasks';
@@ -80,6 +81,8 @@ export const TaskDrawer = ({
   task,
 }: TaskDrawerProps) => {
   const isEditMode = task != null;
+  // Right-side sheet on tablet/desktop, bottom sheet on phones.
+  const isPhone = useMediaQuery('(max-width: 767px)');
   const createTask = useCreateTask();
   const updateTask = useUpdateTask();
   const deleteTask = useDeleteTask();
@@ -148,7 +151,10 @@ export const TaskDrawer = ({
   return (
     <>
       <Sheet open onOpenChange={(open) => !open && onClose()}>
-        <SheetContent className="w-full gap-0 p-0 sm:max-w-[420px]" side="right">
+        <SheetContent
+          className="w-full gap-0 p-0 sm:max-w-[420px] max-md:h-[85vh] max-md:rounded-t-2xl"
+          side={isPhone ? 'bottom' : 'right'}
+        >
           <SheetHeader className="border-b border-border px-6 py-5">
             <SheetTitle>{isEditMode ? 'Task details' : 'Add Task'}</SheetTitle>
             {isEditMode && (

--- a/lined-web/src/features/tasks/TaskDrawer.tsx
+++ b/lined-web/src/features/tasks/TaskDrawer.tsx
@@ -152,7 +152,7 @@ export const TaskDrawer = ({
     <>
       <Sheet open onOpenChange={(open) => !open && onClose()}>
         <SheetContent
-          className="w-full gap-0 p-0 sm:max-w-[420px] max-md:h-[85vh] max-md:rounded-t-2xl"
+          className="w-full gap-0 p-0 sm:max-w-[420px] data-[side=bottom]:h-[85vh] data-[side=bottom]:rounded-t-2xl"
           side={isPhone ? 'bottom' : 'right'}
         >
           <SheetHeader className="border-b border-border px-6 py-5">

--- a/lined-web/src/features/tasks/kanban/KanbanBoard.tsx
+++ b/lined-web/src/features/tasks/kanban/KanbanBoard.tsx
@@ -18,9 +18,12 @@ const SKELETON_CARDS_PER_COLUMN = 2;
 
 /** Placeholder columns shown while the first `tasks/mine` fetch is in flight. */
 const KanbanBoardSkeleton = () => (
-  <div className="grid flex-1 grid-cols-1 gap-6 md:grid-cols-3" data-testid={KANBAN_TEST_IDS.loading}>
+  <div
+    className="flex flex-1 snap-x snap-mandatory gap-6 overflow-x-auto pb-2 md:snap-none"
+    data-testid={KANBAN_TEST_IDS.loading}
+  >
     {Array.from({ length: SKELETON_COLUMN_COUNT }, (_, columnIndex) => (
-      <div key={columnIndex} className="flex flex-col gap-2.5">
+      <div key={columnIndex} className="flex min-w-full flex-col gap-2.5 snap-center md:min-w-0 md:flex-1 md:snap-align-none">
         <div className="h-6 w-24 animate-pulse rounded bg-white" />
         {Array.from({ length: SKELETON_CARDS_PER_COLUMN }, (_, cardIndex) => (
           <div key={cardIndex} className="h-20 animate-pulse rounded-lg bg-white" />
@@ -57,7 +60,7 @@ const KanbanBoardContent = ({
   }
 
   return (
-    <div className="flex flex-1 flex-col gap-6 overflow-x-auto md:flex-row">
+    <div className="flex flex-1 snap-x snap-mandatory gap-6 overflow-x-auto pb-2 md:snap-none">
       {STATUS_ORDER.map((status) => (
         <KanbanColumn
           key={status}

--- a/lined-web/src/features/tasks/kanban/KanbanCard.tsx
+++ b/lined-web/src/features/tasks/kanban/KanbanCard.tsx
@@ -124,7 +124,7 @@ export const KanbanCard = ({
                   e.stopPropagation();
                   onMove(task, 'prev');
                 }}
-                className="rounded px-1 text-xs text-text-secondary hover:bg-gray-100 disabled:opacity-50"
+                className="flex min-h-11 min-w-11 items-center justify-center rounded text-xs text-text-secondary hover:bg-gray-100 disabled:opacity-50 md:min-h-0 md:min-w-0 md:px-1"
               >
                 ←
               </button>
@@ -139,7 +139,7 @@ export const KanbanCard = ({
                   e.stopPropagation();
                   onMove(task, 'next');
                 }}
-                className="rounded px-1 text-xs text-text-secondary hover:bg-gray-100 disabled:opacity-50"
+                className="flex min-h-11 min-w-11 items-center justify-center rounded text-xs text-text-secondary hover:bg-gray-100 disabled:opacity-50 md:min-h-0 md:min-w-0 md:px-1"
               >
                 →
               </button>

--- a/lined-web/src/features/tasks/kanban/KanbanColumn.tsx
+++ b/lined-web/src/features/tasks/kanban/KanbanColumn.tsx
@@ -97,7 +97,7 @@ export const KanbanColumn = ({
 
   return (
     <div
-      className={`flex min-w-[280px] flex-1 flex-col rounded-lg transition-colors ${
+      className={`flex min-w-full flex-1 flex-col snap-center rounded-lg transition-colors md:min-w-[280px] md:snap-align-none ${
         isDragOver ? 'bg-brand-green-light/60' : ''
       }`}
       data-testid={KANBAN_TEST_IDS.column(status)}

--- a/lined-web/src/hooks/__tests__/useMediaQuery.test.ts
+++ b/lined-web/src/hooks/__tests__/useMediaQuery.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useMediaQuery } from '../useMediaQuery';
+
+type Listener = () => void;
+
+const createMatchMediaMock = (initialMatches: boolean) => {
+  let matches = initialMatches;
+  const listeners = new Set<Listener>();
+
+  const mql = {
+    get matches() {
+      return matches;
+    },
+    media: '',
+    addEventListener: (_: string, listener: Listener) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_: string, listener: Listener) => {
+      listeners.delete(listener);
+    },
+  };
+
+  return {
+    mql,
+    setMatches: (value: boolean) => {
+      matches = value;
+      listeners.forEach((listener) => listener());
+    },
+    listenerCount: () => listeners.size,
+  };
+};
+
+describe('useMediaQuery', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns true immediately when the query matches on mount', () => {
+    expect.assertions(1);
+    const { mql } = createMatchMediaMock(true);
+    vi.spyOn(window, 'matchMedia').mockReturnValue(mql as unknown as MediaQueryList);
+
+    const { result } = renderHook(() => useMediaQuery('(max-width: 767px)'));
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false immediately when the query does not match on mount', () => {
+    expect.assertions(1);
+    const { mql } = createMatchMediaMock(false);
+    vi.spyOn(window, 'matchMedia').mockReturnValue(mql as unknown as MediaQueryList);
+
+    const { result } = renderHook(() => useMediaQuery('(max-width: 767px)'));
+
+    expect(result.current).toBe(false);
+  });
+
+  it('updates when the underlying media query changes', () => {
+    expect.assertions(2);
+    const { mql, setMatches } = createMatchMediaMock(false);
+    vi.spyOn(window, 'matchMedia').mockReturnValue(mql as unknown as MediaQueryList);
+
+    const { result } = renderHook(() => useMediaQuery('(max-width: 767px)'));
+    expect(result.current).toBe(false);
+
+    act(() => {
+      setMatches(true);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('removes its change listener on unmount', () => {
+    expect.assertions(1);
+    const { mql, listenerCount } = createMatchMediaMock(false);
+    vi.spyOn(window, 'matchMedia').mockReturnValue(mql as unknown as MediaQueryList);
+
+    const { unmount } = renderHook(() => useMediaQuery('(max-width: 767px)'));
+    unmount();
+
+    expect(listenerCount()).toBe(0);
+  });
+});

--- a/lined-web/src/hooks/useMediaQuery.ts
+++ b/lined-web/src/hooks/useMediaQuery.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Tracks whether a CSS media query currently matches, re-rendering on change.
+ * Used for the rare cases where a layout decision has to happen in JS (e.g.
+ * driving Zustand state), not just via Tailwind responsive classes.
+ */
+export const useMediaQuery = (query: string): boolean => {
+  const [matches, setMatches] = useState(() => window.matchMedia(query).matches);
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(query);
+    const handleChange = () => setMatches(mediaQueryList.matches);
+
+    handleChange();
+    mediaQueryList.addEventListener('change', handleChange);
+    return () => mediaQueryList.removeEventListener('change', handleChange);
+  }, [query]);
+
+  return matches;
+};

--- a/lined-web/src/store/calendar.ts
+++ b/lined-web/src/store/calendar.ts
@@ -7,6 +7,9 @@ interface CalendarState {
   weekStart: Date;
   monthAnchor: Date;
   viewMode: ViewMode;
+  /** The single day shown by the phone-only day view (forced under `md`,
+   *  not a user-selectable ViewMode — see CalendarPage). */
+  dayAnchor: Date;
   selectedEventId: number | null;
   isCreateModalOpen: boolean;
   /** Lobby ids excluded from the global calendar grid — mirrors Google/Outlook's
@@ -16,6 +19,9 @@ interface CalendarState {
   goToNextWeek: () => void;
   goToPrevMonth: () => void;
   goToNextMonth: () => void;
+  goToPrevDay: () => void;
+  goToNextDay: () => void;
+  goToDay: (day: Date) => void;
   goToToday: () => void;
   goToWeekOf: (day: Date) => void;
   setViewMode: (mode: ViewMode) => void;
@@ -29,6 +35,7 @@ export const useCalendarStore = create<CalendarState>()((set) => ({
   weekStart: getWeekStart(),
   monthAnchor: getMonthStart(new Date()),
   viewMode: 'week',
+  dayAnchor: new Date(new Date().setHours(0, 0, 0, 0)),
   selectedEventId: null,
   isCreateModalOpen: false,
   hiddenLobbyIds: [],
@@ -39,7 +46,15 @@ export const useCalendarStore = create<CalendarState>()((set) => ({
     set((s) => ({ monthAnchor: getMonthStart(addDays(s.monthAnchor, -1)) })),
   goToNextMonth: () =>
     set((s) => ({ monthAnchor: getMonthStart(addDays(s.monthAnchor, 32)) })),
-  goToToday: () => set({ weekStart: getWeekStart(), monthAnchor: getMonthStart(new Date()) }),
+  goToPrevDay: () => set((s) => ({ dayAnchor: addDays(s.dayAnchor, -1) })),
+  goToNextDay: () => set((s) => ({ dayAnchor: addDays(s.dayAnchor, 1) })),
+  goToDay: (day) => set({ dayAnchor: day }),
+  goToToday: () =>
+    set({
+      weekStart: getWeekStart(),
+      monthAnchor: getMonthStart(new Date()),
+      dayAnchor: new Date(new Date().setHours(0, 0, 0, 0)),
+    }),
   goToWeekOf: (day) => set({ weekStart: getWeekStart(day), viewMode: 'week' }),
   setViewMode: (mode) => set({ viewMode: mode }),
   setSelectedEventId: (id) => set({ selectedEventId: id }),

--- a/lined-web/src/store/ui.ts
+++ b/lined-web/src/store/ui.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+
+interface UiState {
+  /** Off-canvas sidebar drawer, shown under `lg` in place of the fixed desktop sidebar. */
+  isSidebarDrawerOpen: boolean;
+  openSidebarDrawer: () => void;
+  closeSidebarDrawer: () => void;
+  toggleSidebarDrawer: () => void;
+}
+
+export const useUiStore = create<UiState>()((set) => ({
+  isSidebarDrawerOpen: false,
+  openSidebarDrawer: () => set({ isSidebarDrawerOpen: true }),
+  closeSidebarDrawer: () => set({ isSidebarDrawerOpen: false }),
+  toggleSidebarDrawer: () => set((s) => ({ isSidebarDrawerOpen: !s.isSidebarDrawerOpen })),
+}));


### PR DESCRIPTION
## Summary

Implements [Task 22](lined-web/docs/tasks/UI-22-responsive-layout.md) from `lined-web/docs/UI_TASKS.md` — brings the existing desktop-only UI to phone (`<md`) and tablet (`md`–`lg`) widths using Tailwind's default breakpoints, with `≥lg` unchanged. Layout-only; no new REST endpoints.

- **Shared responsive shell** — new `useMediaQuery` hook, `useUiStore` (sidebar drawer state), an off-canvas `Sidebar` drawer under `lg` (☰ trigger in `TopBar`, backdrop-click/nav-click to close, body-scroll-locked), and a phone-only `BottomTabBar` (Dashboard/Calendar/Tasks).
- **Dashboard / Settings / Lobby pages** — pure Tailwind: single-column dashboard grid, settings two-pane nav collapses above content, lobby header wraps, lobby/settings tab bars scroll horizontally.
- **Calendar day view** — forced (not user-toggled) single-day view under `md`: a `DayChipStrip` date picker + a floating "+ New event" button, reusing `WeekGrid`'s hour-grid/free-slot/event internals via a new optional `days` prop instead of a parallel component. `MonthGrid` shows compact dots-per-day below `lg`.
- **Kanban board** — columns become full-width horizontal scroll-snap panes under `md` (drag-and-drop stays desktop-only; move buttons now meet a 44px touch target).
- **Modals & drawers** — `CreateEventModal`, `CreateLobbyModal`, `ReserveSlotModal`, `ConfirmDialog` become edge-to-edge full-height sheets under `md`. `TaskDrawer` (shadcn `Sheet`) swaps `side="right"` for `side="bottom"` on phones via its own prop — no edits to the shadcn-owned `sheet.tsx`. `EventDetailPanel`/`DayAgendaPanel` become fixed bottom sheets under `md`, staying in-flow at `md`+.

Two visual bugs (legend/FAB overlap, TaskDrawer bottom-sheet height losing a CSS-source-order fight against the shadcn Sheet's own `data-[side=bottom]:h-auto`) were found and fixed during manual browser verification — see the last two commits.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm run test:run`, `npm run build` all pass (4 pre-existing, unrelated test failures on `main` are unaffected — verified via `git stash`)
- [x] New/updated tests: `useMediaQuery`, `store/ui.ts` (via Sidebar/AppShell/TopBar/BottomTabBar tests), `DayChipStrip`, `CalendarPage` phone-viewport behavior, `BottomTabBar`
- [x] Manual pass in-browser at 390×812 (iPhone): sidebar drawer, bottom tab bar, dashboard stack, calendar day view + FAB + day-chip strip, kanban horizontal snap-scroll, `CreateEventModal`, `TaskDrawer` bottom sheet, `ConfirmDialog` full-screen, Settings stack
- [x] Manual pass at 768×1024 (tablet): 2-column dashboard grid, hamburger nav, no bottom tab bar
- [x] Manual pass at 1280×800 (desktop): pixel-equivalent to `main` — fixed sidebar, full week grid, unchanged modals
- [x] `docs/UI_TASKS.md` row 22 updated `TODO` → `DONE` with a summary bullet

🤖 Generated with [Claude Code](https://claude.com/claude-code)