### PR TITLE
Task 23: Dark mode audit & polish

### DIFF
--- a/lined-web/docs/UI_TASKS.md
+++ b/lined-web/docs/UI_TASKS.md
@@ -161,6 +161,31 @@ dark-mode toggle shipped in Task 12 has never been audited screen-by-screen.
   siblings next to the grid) become fixed bottom sheets under `md` and stay
   in-flow at `md` and above. Desktop (`≥lg`) is unchanged.
 
+- **Dark mode audit & polish** — `useThemeSync` (`src/hooks/`): fixed a real
+  bug where the theme-application effect lived inside `AppearanceCard`
+  (Settings-page-only), so the `dark` class was never applied outside that
+  page and the System `matchMedia` listener was torn down on navigating
+  away; moved to a hook mounted once at the app root (`App.tsx`), which
+  also now sets `color-scheme` and a `<meta name="theme-color">`. Added a
+  dark token layer in `src/index.css` for every custom brand/surface/text
+  token that previously had no dark value (`--color-bg`, new
+  `--color-surface`/`--color-surface-hover`, `--color-input-bg`,
+  `--color-text-primary/secondary/muted/light`, `--color-brand-beige*`,
+  `--color-brand-green-light`), then swept `bg-white` → `bg-surface` and
+  `bg-gray-50`/`bg-gray-100` → `bg-surface-hover` across ~45 files.
+  Hard-coded red/amber danger/warning colours (danger zones, inline
+  validation errors, the conflict-warning banner) and the
+  brand-green-light/brand-green-dark tint+text pairing got `dark:` variants
+  at each call site instead, since some of those same shades are also used
+  on solid buttons/badges that must stay theme-invariant. See
+  `docs/mockups.md`'s "Dark mode (Task 23)" section for the full token
+  table. Screen-by-screen audit (auth, dashboard + bell, calendar
+  week/month + event panel, lobby tabs, kanban, both settings pages,
+  subscription, all modals/drawers/confirm dialogs) found and fixed the
+  Danger Zone cards as the only broken-beyond-illegible screens; lobby/
+  status/priority accent hues and the free-slot band opacity overlay were
+  left unchanged as already legible in both themes.
+
 ## Backend API summary
 
 | Domain | Endpoints |
@@ -209,7 +234,7 @@ dark-mode toggle shipped in Task 12 has never been audited screen-by-screen.
 | 20 | `feature/ui-20-task-detail-edit` | Task detail/edit drawer (open from kanban card & task row, edit all fields incl. priority, delete) | [tasks/UI-20-task-detail-edit.md](tasks/UI-20-task-detail-edit.md) | DONE |
 | 21 | `feature/ui-21-onboarding-empty-states` | First-run dashboard hero ("create your first lobby") + designed empty states everywhere | [tasks/UI-21-onboarding-empty-states.md](tasks/UI-21-onboarding-empty-states.md) | DONE |
 | 22 | `feature/ui-22-responsive-layout` | Mobile/tablet responsive layout: sidebar drawer, bottom tabs, calendar day view, kanban scroll-snap, sheet modals | [tasks/UI-22-responsive-layout.md](tasks/UI-22-responsive-layout.md) | DONE |
-| 23 | `feature/ui-23-dark-mode-audit` | Dark-mode token layer + screen-by-screen audit of the theme toggle shipped in Task 12 | [tasks/UI-23-dark-mode-audit.md](tasks/UI-23-dark-mode-audit.md) | TODO |
+| 23 | `feature/ui-23-dark-mode-audit` | Dark-mode token layer + screen-by-screen audit of the theme toggle shipped in Task 12 | [tasks/UI-23-dark-mode-audit.md](tasks/UI-23-dark-mode-audit.md) | DONE |
 | 24 | `feature/ui-24-i18n-localization` | Localization (react-i18next): English + Ukrainian, plurals, locale dates, settings switcher | [tasks/UI-24-i18n-localization.md](tasks/UI-24-i18n-localization.md) | TODO |
 | 25 | `feature/ui-25-loading-states-audit` | Skeleton system: route/section/action loading tiers, zero layout shift, no full-page spinners | [tasks/UI-25-loading-states-audit.md](tasks/UI-25-loading-states-audit.md) | TODO |
 | 26 | `feature/ui-26-payment-checkout` | Payment flow: checkout modal → provider-hosted payment → return states + payment history | [tasks/UI-26-payment-checkout.md](tasks/UI-26-payment-checkout.md) | TODO |

--- a/lined-web/docs/mockups.md
+++ b/lined-web/docs/mockups.md
@@ -176,6 +176,39 @@ The mockup uses CSS variables. Map them to Tailwind tokens in `tailwind.config.t
 | `--friends` `#A78BFA` | `lobby.friends` | Friends lobby accent |
 | `--work` `#3FA6FA` | `lobby.work` | Work lobby accent |
 
+### Dark mode (Task 23)
+
+No dedicated dark mockup screen exists — the mapping below is the source of
+truth, defined once in `src/index.css`'s `.dark { … }` block. Lobby/status/
+priority accent hues are unchanged between themes (kept for brand
+recognition); only surfaces, text, and the brand-green tint/text pair get
+dark values. Danger (red) and warning (amber) colours that were previously
+hard-coded Tailwind shades (`red-50`, `amber-50`, …) get a `dark:` variant
+at each call site instead of a token, since they're also used as solid
+buttons/badges that must stay theme-invariant.
+
+| Token | Light value | Dark value | Usage |
+|---|---|---|---|
+| `--color-bg` | `#F4F4F7` | `#10231A` | Page background |
+| `--color-surface` | `#FFFFFF` | `#16281E` | Cards, modals, panels (replaces raw `bg-white`) |
+| `--color-surface-hover` | `#F9FAFB` | `#1E3327` | Hover/secondary surfaces (replaces `bg-gray-50`/`bg-gray-100`) |
+| `--color-input-bg` | `#F9F9FB` | `#1C2E23` | Text inputs, textareas |
+| `--color-text-primary` | `#1A1A2E` | `#EAF3EC` | Headings, primary body text |
+| `--color-text-secondary` | `#6B7280` | `#A9BDB0` | Secondary body text |
+| `--color-text-muted` | `#9CA3AF` | `#7C9187` | Placeholder/disabled text |
+| `--color-text-light` | `#C8D4C9` | `#4E6459` | Lightest text tier (sidebar sub-labels) |
+| `--color-brand-beige` | `#F7F3ED` | `#1C2E23` | Auth card / tip-box background |
+| `--color-brand-beige-dark` | `#EDE7DC` | `#24382C` | Auth card secondary background |
+| `--color-brand-green-light` | `#E8F5EE` | `rgba(91,155,107,0.18)` | Tinted selected/highlight backgrounds |
+
+`--color-brand-green-dark` (`#3D7050`) is intentionally **not** overridden —
+it's shared between a text-on-tint role (paired with
+`--color-brand-green-light`, which now gets `dark:text-brand-green` inline
+at each of those ~15 call sites) and a solid-button hover shade
+(`bg-brand-green` → `hover:bg-brand-green-dark`, white text, unaffected by
+theme). Overriding it globally would have broken the solid-button hover
+state.
+
 ---
 
 ## Personas in Mockups

--- a/lined-web/src/App.tsx
+++ b/lined-web/src/App.tsx
@@ -2,6 +2,7 @@ import { RouterProvider } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { router } from './router';
+import { useThemeSync } from './hooks/useThemeSync';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -13,6 +14,8 @@ const queryClient = new QueryClient({
 });
 
 export const App = () => {
+  useThemeSync();
+
   return (
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />

--- a/lined-web/src/components/AssigneeAvatar/index.tsx
+++ b/lined-web/src/components/AssigneeAvatar/index.tsx
@@ -19,7 +19,7 @@ export const AssigneeAvatar = ({
         {assignee.username.charAt(0).toUpperCase()}
       </AvatarFallback>
     ) : (
-      <AvatarFallback className={`bg-gray-300 font-semibold text-white ${fallbackTextClassName}`}>
+      <AvatarFallback className={`bg-muted-foreground font-semibold text-white ${fallbackTextClassName}`}>
         ?
       </AvatarFallback>
     )}

--- a/lined-web/src/components/ConfirmDialog/index.tsx
+++ b/lined-web/src/components/ConfirmDialog/index.tsx
@@ -38,7 +38,7 @@ export const ConfirmDialog = ({
         if (e.target === e.currentTarget) onCancel();
       }}
     >
-      <div className="flex max-h-full w-[400px] max-w-[90vw] flex-col overflow-y-auto rounded-2xl bg-white p-6 shadow-[var(--shadow-lg)] max-md:h-full max-md:w-full max-md:max-w-none max-md:justify-center max-md:rounded-none">
+      <div className="flex max-h-full w-[400px] max-w-[90vw] flex-col overflow-y-auto rounded-2xl bg-surface p-6 shadow-[var(--shadow-lg)] max-md:h-full max-md:w-full max-md:max-w-none max-md:justify-center max-md:rounded-none">
         <h2 className="text-lg font-bold text-text-primary">{title}</h2>
         <p className="mt-2 text-sm text-text-secondary">{message}</p>
 
@@ -62,7 +62,7 @@ export const ConfirmDialog = ({
           <button
             type="button"
             onClick={onCancel}
-            className="h-10 rounded-lg border border-border bg-white px-4 text-sm text-text-secondary hover:bg-gray-50"
+            className="h-10 rounded-lg border border-border bg-surface px-4 text-sm text-text-secondary hover:bg-surface-hover"
           >
             Cancel
           </button>

--- a/lined-web/src/components/ConfirmDialog/index.tsx
+++ b/lined-web/src/components/ConfirmDialog/index.tsx
@@ -56,7 +56,7 @@ export const ConfirmDialog = ({
           </div>
         )}
 
-        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+        {error && <p className="mt-3 text-sm text-red-600 dark:text-red-400">{error}</p>}
 
         <div className="mt-6 flex items-center justify-end gap-2.5">
           <button

--- a/lined-web/src/components/FormField/index.tsx
+++ b/lined-web/src/components/FormField/index.tsx
@@ -25,13 +25,13 @@ export const FormField = ({ id, label, value, onChange, error, ...rest }: FormFi
         aria-describedby={error ? errorId : undefined}
         className={`h-12 w-full rounded-lg border bg-input-bg px-4 text-sm text-text-primary placeholder:text-text-muted focus:outline-none ${
           error
-            ? 'border-red-500 focus:border-red-500'
+            ? 'border-red-500 focus:border-red-500 dark:border-red-500/70 dark:focus:border-red-500/70'
             : 'border-border focus:border-brand-green'
         }`}
         {...rest}
       />
       {error && (
-        <p id={errorId} className="mt-1.5 text-xs text-red-600" role="alert">
+        <p id={errorId} className="mt-1.5 text-xs text-red-600 dark:text-red-400" role="alert">
           {error}
         </p>
       )}

--- a/lined-web/src/components/ToggleRow/index.tsx
+++ b/lined-web/src/components/ToggleRow/index.tsx
@@ -22,7 +22,7 @@ export const ToggleRow = ({ label, description, checked, onChange }: ToggleRowPr
         }`}
       >
         <span
-          className={`absolute top-[3px] h-[18px] w-[18px] rounded-full bg-white shadow-sm transition-[left] ${
+          className={`absolute top-[3px] h-[18px] w-[18px] rounded-full bg-surface shadow-sm transition-[left] ${
             checked ? 'left-[23px]' : 'left-[3px]'
           }`}
         />

--- a/lined-web/src/features/auth/AuthAlert.tsx
+++ b/lined-web/src/features/auth/AuthAlert.tsx
@@ -6,8 +6,8 @@ interface AuthAlertProps {
 }
 
 const VARIANT_CLASSES: Record<NonNullable<AuthAlertProps['variant']>, string> = {
-  error: 'border-red-200 bg-red-50 text-red-700',
-  success: 'border-brand-green/30 bg-brand-green-light text-brand-green-dark',
+  error: 'border-red-200 bg-red-50 text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-400',
+  success: 'border-brand-green/30 bg-brand-green-light text-brand-green-dark dark:text-brand-green',
 };
 
 export const AuthAlert = ({ message, variant = 'error' }: AuthAlertProps) => {

--- a/lined-web/src/features/auth/AuthCard.tsx
+++ b/lined-web/src/features/auth/AuthCard.tsx
@@ -12,7 +12,7 @@ export const AuthCard = ({ heading, subheading, children }: AuthCardProps) => {
       <div className="absolute -left-20 -top-20 h-80 w-80 rounded-full bg-brand-green-light opacity-50" />
       <div className="absolute -bottom-16 -right-10 h-60 w-60 rounded-full bg-brand-beige-dark opacity-60" />
 
-      <div className="relative z-10 w-[480px] max-w-[90vw] overflow-hidden rounded-2xl bg-white shadow-lg">
+      <div className="relative z-10 w-[480px] max-w-[90vw] overflow-hidden rounded-2xl bg-surface shadow-lg">
         <div className="h-1 bg-brand-green" />
         <div className="px-10 pb-10 pt-8">
           <div className="text-center text-3xl font-bold text-brand-green">Lined</div>

--- a/lined-web/src/features/calendar/CalendarTopBar.tsx
+++ b/lined-web/src/features/calendar/CalendarTopBar.tsx
@@ -40,13 +40,13 @@ export const CalendarTopBar = ({
 }: CalendarTopBarProps) => {
   const showLobbyFilter = lobbies != null && onToggleLobby != null && lobbies.length > 1;
   return (
-    <div className="flex h-16 flex-shrink-0 items-center gap-4 border-b border-border bg-white px-8 shadow-[var(--shadow-sm)]">
+    <div className="flex h-16 flex-shrink-0 items-center gap-4 border-b border-border bg-surface px-8 shadow-[var(--shadow-sm)]">
       {/* Month / week navigation */}
       <div className="flex items-center gap-1">
         <button
           onClick={onPrev}
           aria-label={viewMode === 'month' ? 'Previous month' : 'Previous week'}
-          className="flex h-7 w-7 items-center justify-center rounded-lg text-text-secondary hover:bg-gray-100"
+          className="flex h-7 w-7 items-center justify-center rounded-lg text-text-secondary hover:bg-surface-hover"
         >
           <ChevronLeft className="h-4 w-4" />
         </button>
@@ -56,7 +56,7 @@ export const CalendarTopBar = ({
         <button
           onClick={onNext}
           aria-label={viewMode === 'month' ? 'Next month' : 'Next week'}
-          className="flex h-7 w-7 items-center justify-center rounded-lg text-text-secondary hover:bg-gray-100"
+          className="flex h-7 w-7 items-center justify-center rounded-lg text-text-secondary hover:bg-surface-hover"
         >
           <ChevronRight className="h-4 w-4" />
         </button>
@@ -65,7 +65,7 @@ export const CalendarTopBar = ({
       {/* Today button */}
       <button
         onClick={onToday}
-        className="h-8 rounded-lg border border-border bg-white px-3 text-sm text-text-secondary hover:bg-gray-50"
+        className="h-8 rounded-lg border border-border bg-surface px-3 text-sm text-text-secondary hover:bg-surface-hover"
       >
         Today
       </button>
@@ -79,7 +79,7 @@ export const CalendarTopBar = ({
             className={`px-4 py-1.5 text-sm font-[inherit] capitalize transition-colors ${
               viewMode === mode
                 ? 'bg-brand-green font-semibold text-white'
-                : 'bg-white text-text-secondary hover:bg-gray-50'
+                : 'bg-surface text-text-secondary hover:bg-surface-hover'
             }`}
           >
             {mode.charAt(0).toUpperCase() + mode.slice(1)}
@@ -92,7 +92,7 @@ export const CalendarTopBar = ({
       {/* Lobby filter — hide/show individual lobbies' events, like Google/Outlook's calendar checklists */}
       {showLobbyFilter && (
         <DropdownMenu>
-          <DropdownMenuTrigger className="flex h-9 items-center gap-1.5 rounded-lg border border-border bg-white px-3 text-sm text-text-secondary hover:bg-gray-50">
+          <DropdownMenuTrigger className="flex h-9 items-center gap-1.5 rounded-lg border border-border bg-surface px-3 text-sm text-text-secondary hover:bg-surface-hover">
             <ListFilter className="h-4 w-4" />
             Filters
             {hiddenLobbyIds.length > 0 && (

--- a/lined-web/src/features/calendar/events/ConflictBanner.tsx
+++ b/lined-web/src/features/calendar/events/ConflictBanner.tsx
@@ -39,10 +39,10 @@ export const ConflictBanner = ({
   return (
     <div
       role="status"
-      className="mt-4 flex items-start gap-2.5 rounded-lg border border-amber-300 bg-amber-50 px-3.5 py-3"
+      className="mt-4 flex items-start gap-2.5 rounded-lg border border-amber-300 bg-amber-50 px-3.5 py-3 dark:border-amber-800/60 dark:bg-amber-950/30"
     >
-      <TriangleAlert className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-700" />
-      <div className="text-xs text-amber-700">
+      <TriangleAlert className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-700 dark:text-amber-400" />
+      <div className="text-xs text-amber-700 dark:text-amber-400">
         <div className="text-[13px] font-bold">
           Scheduling conflict for {ownerIds.length} member{ownerIds.length === 1 ? '' : 's'}
         </div>

--- a/lined-web/src/features/calendar/events/CreateEventModal.tsx
+++ b/lined-web/src/features/calendar/events/CreateEventModal.tsx
@@ -149,7 +149,7 @@ export const CreateEventModal = ({
       }}
     >
       {/* Dialog — full-screen sheet under md, centered card at md and above */}
-      <div className="flex h-full w-full flex-col overflow-y-auto bg-white md:h-auto md:max-h-[90vh] md:w-[520px] md:max-w-[90vw] md:flex-none md:rounded-2xl md:shadow-[var(--shadow-lg)]">
+      <div className="flex h-full w-full flex-col overflow-y-auto bg-surface md:h-auto md:max-h-[90vh] md:w-[520px] md:max-w-[90vw] md:flex-none md:rounded-2xl md:shadow-[var(--shadow-lg)]">
         {/* Header */}
         <div className="flex items-center justify-between px-6 pt-5">
           <h2 className="text-lg font-bold text-text-primary">
@@ -279,7 +279,7 @@ export const CreateEventModal = ({
             <button
               type="button"
               onClick={onClose}
-              className="h-10 rounded-lg border border-border bg-white px-4 text-sm text-text-secondary hover:bg-gray-50"
+              className="h-10 rounded-lg border border-border bg-surface px-4 text-sm text-text-secondary hover:bg-surface-hover"
             >
               Cancel
             </button>

--- a/lined-web/src/features/calendar/events/ReserveSlotModal.tsx
+++ b/lined-web/src/features/calendar/events/ReserveSlotModal.tsx
@@ -54,7 +54,7 @@ export const ReserveSlotModal = ({ lobbies, initial, onClose, onReserved }: Rese
           <div>
             <h2 className="text-lg font-bold text-text-primary">Reserve Free Slot</h2>
             {resolved && (
-              <span className="mt-1.5 inline-flex items-center gap-1.5 rounded-full bg-brand-green-light px-3 py-1 text-xs font-semibold text-brand-green-dark">
+              <span className="mt-1.5 inline-flex items-center gap-1.5 rounded-full bg-brand-green-light px-3 py-1 text-xs font-semibold text-brand-green-dark dark:text-brand-green">
                 <Sparkles className="h-3 w-3" />
                 {formatFreeSlotRange(resolved.start, resolved.end)} · Both free
               </span>
@@ -184,10 +184,10 @@ const ReserveSlotForm = ({ lobbies, slot, onClose, onReserved }: ReserveSlotForm
           <div className="flex items-center gap-2.5 rounded-lg bg-brand-green-light p-3">
             <span className="text-xl">{LOBBY_TYPE_ICONS[lobby.lobbyType]}</span>
             <div>
-              <div className="text-sm font-semibold text-brand-green-dark">
+              <div className="text-sm font-semibold text-brand-green-dark dark:text-brand-green">
                 {lobby.name} are both free
               </div>
-              <div className="mt-0.5 text-xs text-brand-green-dark">
+              <div className="mt-0.5 text-xs text-brand-green-dark dark:text-brand-green">
                 {formatFreeSlotRange(slot.start, slot.end)}
               </div>
             </div>

--- a/lined-web/src/features/calendar/events/ReserveSlotModal.tsx
+++ b/lined-web/src/features/calendar/events/ReserveSlotModal.tsx
@@ -48,7 +48,7 @@ export const ReserveSlotModal = ({ lobbies, initial, onClose, onReserved }: Rese
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="flex h-full w-full flex-col overflow-y-auto bg-white md:h-auto md:max-h-[90vh] md:w-[520px] md:max-w-[90vw] md:flex-none md:rounded-2xl md:shadow-[var(--shadow-lg)]">
+      <div className="flex h-full w-full flex-col overflow-y-auto bg-surface md:h-auto md:max-h-[90vh] md:w-[520px] md:max-w-[90vw] md:flex-none md:rounded-2xl md:shadow-[var(--shadow-lg)]">
         {/* Header */}
         <div className="flex items-start justify-between px-6 pt-5">
           <div>
@@ -248,7 +248,7 @@ const ReserveSlotForm = ({ lobbies, slot, onClose, onReserved }: ReserveSlotForm
           <div>
             <span className="mb-1.5 block text-xs font-medium text-text-secondary">Invite</span>
             {membersLoading ? (
-              <div className="h-12 w-full animate-pulse rounded-lg bg-gray-100" />
+              <div className="h-12 w-full animate-pulse rounded-lg bg-surface-hover" />
             ) : (
               <div className="flex flex-wrap items-center gap-2.5 rounded-lg border border-border bg-input-bg px-3 py-2.5">
                 {members.map((member) => (
@@ -283,7 +283,7 @@ const ReserveSlotForm = ({ lobbies, slot, onClose, onReserved }: ReserveSlotForm
         <button
           type="button"
           onClick={onClose}
-          className="h-10 rounded-lg border border-border bg-white px-4 text-sm text-text-secondary hover:bg-gray-50"
+          className="h-10 rounded-lg border border-border bg-surface px-4 text-sm text-text-secondary hover:bg-surface-hover"
         >
           Cancel
         </button>
@@ -313,7 +313,7 @@ const CandidatePicker = ({ candidates, isLoading, onPick, onClose }: CandidatePi
     return (
       <div className="space-y-2" data-testid="candidate-picker-loading">
         {[0, 1].map((i) => (
-          <div key={i} className="h-14 animate-pulse rounded-lg bg-gray-100" />
+          <div key={i} className="h-14 animate-pulse rounded-lg bg-surface-hover" />
         ))}
       </div>
     );
@@ -328,7 +328,7 @@ const CandidatePicker = ({ candidates, isLoading, onPick, onClose }: CandidatePi
         <button
           type="button"
           onClick={onClose}
-          className="h-10 w-full rounded-lg border border-border bg-white text-sm text-text-secondary hover:bg-gray-50"
+          className="h-10 w-full rounded-lg border border-border bg-surface text-sm text-text-secondary hover:bg-surface-hover"
         >
           Close
         </button>

--- a/lined-web/src/features/calendar/grid/CalendarLegend.tsx
+++ b/lined-web/src/features/calendar/grid/CalendarLegend.tsx
@@ -2,7 +2,7 @@ import { DEFAULT_LEGEND_ITEMS, type LegendItem } from '@/features/calendar/lib/c
 
 export const CalendarLegend = ({ items = DEFAULT_LEGEND_ITEMS }: { items?: LegendItem[] }) => {
   return (
-    <div className="flex flex-shrink-0 items-center gap-5 overflow-x-auto whitespace-nowrap border-t border-border bg-white px-4 py-2 md:px-8">
+    <div className="flex flex-shrink-0 items-center gap-5 overflow-x-auto whitespace-nowrap border-t border-border bg-surface px-4 py-2 md:px-8">
       {items.map(({ label, color }) => (
         <div key={label} className="flex flex-shrink-0 items-center gap-1.5 text-[11px] text-text-secondary">
           <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />

--- a/lined-web/src/features/calendar/grid/DayChipStrip.tsx
+++ b/lined-web/src/features/calendar/grid/DayChipStrip.tsx
@@ -15,7 +15,7 @@ export const DayChipStrip = ({ selectedDay, onSelectDay }: DayChipStripProps) =>
     <div
       role="tablist"
       aria-label="Select day"
-      className="flex flex-shrink-0 gap-2 overflow-x-auto border-b border-border bg-white px-3 py-2"
+      className="flex flex-shrink-0 gap-2 overflow-x-auto border-b border-border bg-surface px-3 py-2"
     >
       {days.map((day) => {
         const selected = isSameDay(day, selectedDay);

--- a/lined-web/src/features/calendar/grid/DayChipStrip.tsx
+++ b/lined-web/src/features/calendar/grid/DayChipStrip.tsx
@@ -31,7 +31,7 @@ export const DayChipStrip = ({ selectedDay, onSelectDay }: DayChipStripProps) =>
               selected
                 ? 'bg-brand-green text-white'
                 : today
-                  ? 'bg-brand-green-light text-brand-green-dark'
+                  ? 'bg-brand-green-light text-brand-green-dark dark:text-brand-green'
                   : 'text-text-secondary hover:bg-bg'
             }`}
           >

--- a/lined-web/src/features/calendar/grid/MonthGrid.tsx
+++ b/lined-web/src/features/calendar/grid/MonthGrid.tsx
@@ -27,8 +27,8 @@ const MonthDayCell = ({ day, monthAnchor, events, lobbyMap, onDayClick }: MonthD
       type="button"
       onClick={() => onDayClick(day)}
       className={`flex min-h-0 flex-col items-start gap-1 overflow-hidden border-b border-l border-border p-1.5 text-left ${
-        inCurrentMonth ? 'bg-white' : 'bg-gray-50'
-      } hover:bg-gray-50`}
+        inCurrentMonth ? 'bg-surface' : 'bg-surface-hover'
+      } hover:bg-surface-hover`}
     >
       <div
         className={`flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[11px] ${
@@ -95,9 +95,9 @@ export const MonthGrid = ({ monthAnchor, events, lobbies, onDayClick }: MonthGri
   const lobbyMap = new Map(lobbies.map((l) => [l.id, l]));
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden bg-white">
+    <div className="flex flex-1 flex-col overflow-hidden bg-surface">
       {/* Day-of-week header row */}
-      <div className="grid flex-shrink-0 grid-cols-7 border-b border-border bg-white">
+      <div className="grid flex-shrink-0 grid-cols-7 border-b border-border bg-surface">
         {DOW_LABELS.map((label) => (
           <div
             key={label}

--- a/lined-web/src/features/calendar/grid/WeekGrid.tsx
+++ b/lined-web/src/features/calendar/grid/WeekGrid.tsx
@@ -135,7 +135,7 @@ const FreeSlotBand = ({ startHour, endHour, onClick }: FreeSlotBandProps) => {
         type="button"
         onClick={onClick}
         aria-label="Reserve this free slot"
-        className="absolute left-[2px] right-[2px] flex cursor-pointer items-center justify-center rounded-[6px] text-[10px] font-semibold text-brand-green-dark hover:opacity-80"
+        className="absolute left-[2px] right-[2px] flex cursor-pointer items-center justify-center rounded-[6px] text-[10px] font-semibold text-brand-green-dark dark:text-brand-green hover:opacity-80"
         style={{ top, height, backgroundColor: 'var(--color-free-slot)', opacity: 0.6 }}
       >
         {height >= 40 && 'Free slot'}
@@ -145,7 +145,7 @@ const FreeSlotBand = ({ startHour, endHour, onClick }: FreeSlotBandProps) => {
 
   return (
     <div
-      className="pointer-events-none absolute left-[2px] right-[2px] rounded-[6px] flex items-center justify-center text-[10px] font-semibold text-brand-green-dark"
+      className="pointer-events-none absolute left-[2px] right-[2px] rounded-[6px] flex items-center justify-center text-[10px] font-semibold text-brand-green-dark dark:text-brand-green"
       style={{ top, height, backgroundColor: 'var(--color-free-slot)', opacity: 0.6 }}
     >
       {height >= 40 && 'Free slot'}
@@ -324,7 +324,7 @@ export const WeekGrid = ({
               }
               className={`relative flex-1 py-2 text-center text-xs select-none ${
                 today
-                  ? 'bg-brand-green-light font-semibold text-brand-green-dark'
+                  ? 'bg-brand-green-light font-semibold text-brand-green-dark dark:text-brand-green'
                   : 'text-text-secondary'
               } ${onDayClick ? 'cursor-pointer hover:bg-surface-hover' : ''}`}
             >

--- a/lined-web/src/features/calendar/grid/WeekGrid.tsx
+++ b/lined-web/src/features/calendar/grid/WeekGrid.tsx
@@ -303,9 +303,9 @@ export const WeekGrid = ({
   }, []);
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden bg-white">
+    <div className="flex flex-1 flex-col overflow-hidden bg-surface">
       {/* Day header row */}
-      <div className="flex flex-shrink-0 border-b border-border bg-white" style={{ paddingLeft: 56 }}>
+      <div className="flex flex-shrink-0 border-b border-border bg-surface" style={{ paddingLeft: 56 }}>
         {weekDays.map((day) => {
           const today = isToday(day);
           const dayEvents = events.filter((e) => eventTouchesDay(e, day));
@@ -326,7 +326,7 @@ export const WeekGrid = ({
                 today
                   ? 'bg-brand-green-light font-semibold text-brand-green-dark'
                   : 'text-text-secondary'
-              } ${onDayClick ? 'cursor-pointer hover:bg-gray-50' : ''}`}
+              } ${onDayClick ? 'cursor-pointer hover:bg-surface-hover' : ''}`}
             >
               {formatDayLabel(day)}
               {today && (
@@ -338,7 +338,7 @@ export const WeekGrid = ({
       </div>
 
       {/* Scrollable time grid */}
-      <div ref={gridRef} className="flex flex-1 overflow-y-auto bg-white">
+      <div ref={gridRef} className="flex flex-1 overflow-y-auto bg-surface">
         {/* Hour labels. self-start: without it, the flex row's default
             align-items:stretch sizes this box to the scroll container's
             *viewport* height rather than its own (taller) content, which

--- a/lined-web/src/features/calendar/grid/__tests__/MonthGrid.test.tsx
+++ b/lined-web/src/features/calendar/grid/__tests__/MonthGrid.test.tsx
@@ -51,7 +51,7 @@ describe('MonthGrid', () => {
 
     // Feb 23 2026 is the leading other-month cell for March's grid (first "23" in the grid).
     const otherMonthCell = screen.getAllByText('23')[0]!.closest('button');
-    expect(otherMonthCell?.className).toContain('bg-gray-50');
+    expect(otherMonthCell?.className).toContain('bg-surface-hover');
   });
 
   it('caps visible chips at 3 and shows a "+N more" label for the rest', () => {

--- a/lined-web/src/features/calendar/pages/CalendarPage.tsx
+++ b/lined-web/src/features/calendar/pages/CalendarPage.tsx
@@ -120,7 +120,7 @@ export const CalendarPage = () => {
     // h-full fills the flex-1 main area; overflow-hidden so the grid controls its own scroll
     <div className="relative flex h-full flex-col overflow-hidden">
       {isPhone ? (
-        <div className="flex h-14 flex-shrink-0 items-center justify-between border-b border-border bg-white px-4">
+        <div className="flex h-14 flex-shrink-0 items-center justify-between border-b border-border bg-surface px-4">
           <button
             type="button"
             onClick={goToPrevDay}

--- a/lined-web/src/features/calendar/panels/DayAgendaPanel.tsx
+++ b/lined-web/src/features/calendar/panels/DayAgendaPanel.tsx
@@ -25,7 +25,7 @@ export const DayAgendaPanel = ({
   const sorted = [...events].sort((a, b) => a.startAt.localeCompare(b.startAt));
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-30 max-h-[70vh] w-full overflow-y-auto rounded-t-2xl bg-white shadow-[var(--shadow-md)] md:relative md:inset-auto md:z-auto md:m-4 md:ml-0 md:max-h-none md:w-72 md:flex-shrink-0 md:self-start md:overflow-hidden md:rounded-xl">
+    <div className="fixed inset-x-0 bottom-0 z-30 max-h-[70vh] w-full overflow-y-auto rounded-t-2xl bg-surface shadow-[var(--shadow-md)] md:relative md:inset-auto md:z-auto md:m-4 md:ml-0 md:max-h-none md:w-72 md:flex-shrink-0 md:self-start md:overflow-hidden md:rounded-xl">
       <div className="flex items-center justify-between px-5 pt-4 pb-3">
         <h3 className="text-sm font-bold text-text-primary">{formatFullDate(day)}</h3>
         <button
@@ -50,7 +50,7 @@ export const DayAgendaPanel = ({
                   <button
                     type="button"
                     onClick={() => onEventClick(event.id)}
-                    className={`w-full rounded-lg border px-3.5 py-2.5 text-left transition-colors hover:bg-gray-50 ${
+                    className={`w-full rounded-lg border px-3.5 py-2.5 text-left transition-colors hover:bg-surface-hover ${
                       event.id === selectedEventId ? 'border-brand-green' : 'border-border'
                     }`}
                   >

--- a/lined-web/src/features/calendar/panels/EventDetailPanel.tsx
+++ b/lined-web/src/features/calendar/panels/EventDetailPanel.tsx
@@ -81,7 +81,7 @@ export const EventDetailPanel = ({
         <div className="my-3 h-px bg-border" />
 
         {deleteError && (
-          <p className="mb-2 text-xs font-medium text-red-500">{deleteError}</p>
+          <p className="mb-2 text-xs font-medium text-red-500 dark:text-red-400">{deleteError}</p>
         )}
 
         {/* Actions */}
@@ -94,7 +94,7 @@ export const EventDetailPanel = ({
           </button>
           <button
             onClick={onDelete}
-            className="flex-1 h-9 rounded-lg border border-red-500 bg-surface text-sm font-medium text-red-500 hover:bg-red-50 transition-colors"
+            className="flex-1 h-9 rounded-lg border border-red-500 bg-surface text-sm font-medium text-red-500 hover:bg-red-50 transition-colors dark:border-red-500/60 dark:text-red-400 dark:hover:bg-red-950/40"
           >
             Delete
           </button>

--- a/lined-web/src/features/calendar/panels/EventDetailPanel.tsx
+++ b/lined-web/src/features/calendar/panels/EventDetailPanel.tsx
@@ -24,7 +24,7 @@ export const EventDetailPanel = ({
   const accentColor = lobbyAccentColor(lobby.lobbyType);
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-30 max-h-[70vh] w-full overflow-y-auto rounded-t-2xl bg-white shadow-[var(--shadow-md)] md:relative md:inset-auto md:z-auto md:m-4 md:ml-0 md:max-h-none md:w-72 md:flex-shrink-0 md:self-start md:overflow-hidden md:rounded-xl">
+    <div className="fixed inset-x-0 bottom-0 z-30 max-h-[70vh] w-full overflow-y-auto rounded-t-2xl bg-surface shadow-[var(--shadow-md)] md:relative md:inset-auto md:z-auto md:m-4 md:ml-0 md:max-h-none md:w-72 md:flex-shrink-0 md:self-start md:overflow-hidden md:rounded-xl">
       {/* Coloured accent bar */}
       <div className="h-1" style={{ backgroundColor: accentColor }} />
 
@@ -94,7 +94,7 @@ export const EventDetailPanel = ({
           </button>
           <button
             onClick={onDelete}
-            className="flex-1 h-9 rounded-lg border border-red-500 bg-white text-sm font-medium text-red-500 hover:bg-red-50 transition-colors"
+            className="flex-1 h-9 rounded-lg border border-red-500 bg-surface text-sm font-medium text-red-500 hover:bg-red-50 transition-colors"
           >
             Delete
           </button>

--- a/lined-web/src/features/dashboard/CreateMenu.tsx
+++ b/lined-web/src/features/dashboard/CreateMenu.tsx
@@ -35,7 +35,7 @@ export const CreateMenu = () => {
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onClick={() => openReserveSlot()}
-          className="gap-2.5 bg-brand-green-light py-2 text-brand-green-dark focus:bg-brand-green-light/80 focus:text-brand-green-dark"
+          className="gap-2.5 bg-brand-green-light py-2 text-brand-green-dark focus:bg-brand-green-light/80 focus:text-brand-green-dark dark:text-brand-green dark:focus:text-brand-green"
         >
           <Sparkles className="h-4 w-4" />
           Reserve Free Slot

--- a/lined-web/src/features/dashboard/DashboardHero.tsx
+++ b/lined-web/src/features/dashboard/DashboardHero.tsx
@@ -9,7 +9,7 @@ export const DashboardHero = ({ username }: DashboardHeroProps) => {
   const openCreateLobby = useCreateMenuStore((s) => s.openCreateLobby);
 
   return (
-    <section className="flex flex-col items-center gap-5 rounded-2xl border-2 border-dashed border-border bg-white px-8 py-10 text-center">
+    <section className="flex flex-col items-center gap-5 rounded-2xl border-2 border-dashed border-border bg-surface px-8 py-10 text-center">
       <span className="text-4xl leading-none">🌱</span>
       <div>
         <h2 className="text-xl font-bold text-text-primary">Welcome to Lined, {username}!</h2>
@@ -25,7 +25,7 @@ export const DashboardHero = ({ username }: DashboardHeroProps) => {
             key={type}
             type="button"
             onClick={() => openCreateLobby(type)}
-            className="cursor-pointer rounded-lg border-2 border-border bg-white px-3 py-3.5 text-center transition-colors hover:bg-gray-50"
+            className="cursor-pointer rounded-lg border-2 border-border bg-surface px-3 py-3.5 text-center transition-colors hover:bg-surface-hover"
           >
             <div className="mb-1.5 text-xl leading-none">{LOBBY_TYPE_ICONS[type]}</div>
             <div className="text-sm font-semibold text-text-primary">

--- a/lined-web/src/features/dashboard/lobbies/LobbyCard.tsx
+++ b/lined-web/src/features/dashboard/lobbies/LobbyCard.tsx
@@ -13,7 +13,7 @@ export const LobbyCard = ({ lobby, eventCount, taskCount }: LobbyCardProps) => {
   return (
     <Link
       to={`/lobbies/${lobby.id}`}
-      className="flex w-56 flex-shrink-0 flex-col overflow-hidden rounded-xl bg-white shadow-[var(--shadow-sm)] transition-shadow hover:shadow-[var(--shadow-md)]"
+      className="flex w-56 flex-shrink-0 flex-col overflow-hidden rounded-xl bg-surface shadow-[var(--shadow-sm)] transition-shadow hover:shadow-[var(--shadow-md)]"
     >
       <div className={`h-1.5 w-full ${LOBBY_TYPE_COLORS[lobby.lobbyType]}`} />
       <div className="flex flex-col gap-2 p-4">

--- a/lined-web/src/features/dashboard/lobbies/LobbyCardGrid.tsx
+++ b/lined-web/src/features/dashboard/lobbies/LobbyCardGrid.tsx
@@ -32,7 +32,7 @@ export const LobbyCardGrid = ({
       {isLoading && (
         <div className="flex gap-4" data-testid="lobby-cards-loading">
           {[0, 1, 2].map((i) => (
-            <div key={i} className="h-24 w-56 flex-shrink-0 animate-pulse rounded-xl bg-white" />
+            <div key={i} className="h-24 w-56 flex-shrink-0 animate-pulse rounded-xl bg-surface" />
           ))}
         </div>
       )}

--- a/lined-web/src/features/dashboard/pages/DashboardPage.tsx
+++ b/lined-web/src/features/dashboard/pages/DashboardPage.tsx
@@ -31,7 +31,7 @@ export const DashboardPage = () => {
   return (
     <div className="flex-1 overflow-y-auto">
       {/* Greeting top bar */}
-      <div className="flex h-16 flex-shrink-0 items-center justify-between border-b border-border bg-white px-4 md:px-8">
+      <div className="flex h-16 flex-shrink-0 items-center justify-between border-b border-border bg-surface px-4 md:px-8">
         <div>
           <h1 className="text-base font-semibold text-text-primary md:text-lg">
             {getGreeting()}, {user?.username ?? 'there'} 👋

--- a/lined-web/src/features/dashboard/widgets/FreeSlotBanner.tsx
+++ b/lined-web/src/features/dashboard/widgets/FreeSlotBanner.tsx
@@ -13,10 +13,10 @@ export const FreeSlotBanner = ({ slot, isLoading, onPlan }: FreeSlotBannerProps)
 
   return (
     <div className="mt-4 flex items-center gap-3 rounded-xl bg-brand-green-light p-4">
-      <Sparkles className="h-5 w-5 flex-shrink-0 text-brand-green-dark" />
+      <Sparkles className="h-5 w-5 flex-shrink-0 text-brand-green-dark dark:text-brand-green" />
       <div className="min-w-0 flex-1">
-        <p className="text-sm font-semibold text-brand-green-dark">Free time found!</p>
-        <p className="text-xs text-brand-green-dark">
+        <p className="text-sm font-semibold text-brand-green-dark dark:text-brand-green">Free time found!</p>
+        <p className="text-xs text-brand-green-dark dark:text-brand-green">
           You &amp; {slot.otherUsername ?? slot.lobbyName} are both free{' '}
           {formatFreeSlotRange(slot.start, slot.end)}
         </p>
@@ -24,7 +24,7 @@ export const FreeSlotBanner = ({ slot, isLoading, onPlan }: FreeSlotBannerProps)
       <button
         type="button"
         onClick={() => onPlan?.(slot)}
-        className="flex-shrink-0 text-xs font-semibold text-brand-green-dark hover:underline"
+        className="flex-shrink-0 text-xs font-semibold text-brand-green-dark dark:text-brand-green hover:underline"
       >
         Plan something →
       </button>

--- a/lined-web/src/features/dashboard/widgets/MyTasksList.tsx
+++ b/lined-web/src/features/dashboard/widgets/MyTasksList.tsx
@@ -33,7 +33,7 @@ export const MyTasksList = ({ tasks, isLoading, isError }: MyTasksListProps) => 
       {isLoading && (
         <div className="flex flex-col gap-2" data-testid="my-tasks-loading">
           {[0, 1, 2].map((i) => (
-            <div key={i} className="h-12 animate-pulse rounded-lg bg-white" />
+            <div key={i} className="h-12 animate-pulse rounded-lg bg-surface" />
           ))}
         </div>
       )}
@@ -59,7 +59,7 @@ export const MyTasksList = ({ tasks, isLoading, isError }: MyTasksListProps) => 
             return (
               <div
                 key={task.id}
-                className="flex items-center gap-3 rounded-lg bg-white p-3 shadow-[var(--shadow-sm)]"
+                className="flex items-center gap-3 rounded-lg bg-surface p-3 shadow-[var(--shadow-sm)]"
               >
                 <span
                   className={`h-2 w-2 flex-shrink-0 rounded-full ${TASK_STATUS_COLORS[task.status]}`}

--- a/lined-web/src/features/dashboard/widgets/MyTasksList.tsx
+++ b/lined-web/src/features/dashboard/widgets/MyTasksList.tsx
@@ -77,7 +77,7 @@ export const MyTasksList = ({ tasks, isLoading, isError }: MyTasksListProps) => 
                 <span
                   className={`flex-shrink-0 text-xs ${
                     due.isUrgent
-                      ? 'font-semibold text-red-500'
+                      ? 'font-semibold text-red-500 dark:text-red-400'
                       : isDone
                         ? 'text-text-muted'
                         : 'text-text-secondary'

--- a/lined-web/src/features/dashboard/widgets/UpcomingEventsList.tsx
+++ b/lined-web/src/features/dashboard/widgets/UpcomingEventsList.tsx
@@ -32,7 +32,7 @@ export const UpcomingEventsList = ({
       {isLoading && (
         <div className="flex flex-col gap-2" data-testid="upcoming-events-loading">
           {[0, 1, 2].map((i) => (
-            <div key={i} className="h-14 animate-pulse rounded-lg bg-white" />
+            <div key={i} className="h-14 animate-pulse rounded-lg bg-surface" />
           ))}
         </div>
       )}
@@ -58,7 +58,7 @@ export const UpcomingEventsList = ({
             return (
               <div
                 key={event.id}
-                className="flex items-center gap-3 overflow-hidden rounded-lg bg-white p-3 shadow-[var(--shadow-sm)]"
+                className="flex items-center gap-3 overflow-hidden rounded-lg bg-surface p-3 shadow-[var(--shadow-sm)]"
               >
                 <span className={`h-8 w-1 flex-shrink-0 rounded-full ${LOBBY_TYPE_COLORS[lobbyType]}`} />
                 <div className="min-w-0 flex-1">

--- a/lined-web/src/features/layout/BottomTabBar.tsx
+++ b/lined-web/src/features/layout/BottomTabBar.tsx
@@ -5,7 +5,7 @@ import { NAV_ITEMS } from './navItems';
 export const BottomTabBar = () => (
   <nav
     aria-label="Primary"
-    className="fixed inset-x-0 bottom-0 z-30 flex h-16 flex-shrink-0 items-stretch border-t border-border bg-white md:hidden"
+    className="fixed inset-x-0 bottom-0 z-30 flex h-16 flex-shrink-0 items-stretch border-t border-border bg-surface md:hidden"
   >
     {NAV_ITEMS.map(({ to, icon: Icon, label }) => (
       <NavLink

--- a/lined-web/src/features/layout/TopBar.tsx
+++ b/lined-web/src/features/layout/TopBar.tsx
@@ -18,7 +18,7 @@ export const TopBar = () => {
     (location.pathname.startsWith('/lobbies/') ? 'Lobby' : 'Lined');
 
   return (
-    <header className="flex h-14 flex-shrink-0 items-center gap-3 border-b border-border bg-white px-4 md:h-16 md:px-6">
+    <header className="flex h-14 flex-shrink-0 items-center gap-3 border-b border-border bg-surface px-4 md:h-16 md:px-6">
       <button
         type="button"
         onClick={openSidebarDrawer}

--- a/lined-web/src/features/lobby/CreateLobbyModal.tsx
+++ b/lined-web/src/features/lobby/CreateLobbyModal.tsx
@@ -45,7 +45,7 @@ export const CreateLobbyModal = ({ onClose }: CreateLobbyModalProps) => {
       }}
     >
       {/* Dialog — full-screen sheet under md, centered card at md and above */}
-      <div className="flex h-full w-full flex-col overflow-y-auto bg-white md:h-auto md:max-h-[90vh] md:w-[460px] md:max-w-[90vw] md:flex-none md:rounded-2xl md:shadow-[var(--shadow-lg)]">
+      <div className="flex h-full w-full flex-col overflow-y-auto bg-surface md:h-auto md:max-h-[90vh] md:w-[460px] md:max-w-[90vw] md:flex-none md:rounded-2xl md:shadow-[var(--shadow-lg)]">
         {/* Header */}
         <div className="flex items-center justify-between px-6 pt-5">
           <h2 className="text-lg font-bold text-text-primary">New Lobby</h2>
@@ -95,7 +95,7 @@ export const CreateLobbyModal = ({ onClose }: CreateLobbyModalProps) => {
             <button
               type="button"
               onClick={onClose}
-              className="h-10 rounded-lg border border-border bg-white px-4 text-sm text-text-secondary hover:bg-gray-50"
+              className="h-10 rounded-lg border border-border bg-surface px-4 text-sm text-text-secondary hover:bg-surface-hover"
             >
               Cancel
             </button>

--- a/lined-web/src/features/lobby/calendar/DayAgendaModal.tsx
+++ b/lined-web/src/features/lobby/calendar/DayAgendaModal.tsx
@@ -35,7 +35,7 @@ export const DayAgendaModal = ({
       }}
     >
       {/* Dialog */}
-      <div className="flex max-h-[80vh] w-[420px] max-w-[90vw] flex-col overflow-hidden rounded-2xl bg-white shadow-[var(--shadow-lg)]">
+      <div className="flex max-h-[80vh] w-[420px] max-w-[90vw] flex-col overflow-hidden rounded-2xl bg-surface shadow-[var(--shadow-lg)]">
         {/* Header */}
         <div className="flex items-center justify-between px-6 pt-5 pb-3">
           <h2 className="text-base font-bold text-text-primary">{formatFullDate(day)}</h2>
@@ -58,7 +58,7 @@ export const DayAgendaModal = ({
                   <button
                     type="button"
                     onClick={() => onEventClick(event.id)}
-                    className={`w-full rounded-lg border px-3.5 py-2.5 text-left transition-colors hover:bg-gray-50 ${
+                    className={`w-full rounded-lg border px-3.5 py-2.5 text-left transition-colors hover:bg-surface-hover ${
                       event.id === selectedEventId ? 'border-brand-green' : 'border-border'
                     }`}
                   >

--- a/lined-web/src/features/lobby/calendar/DayAgendaModal.tsx
+++ b/lined-web/src/features/lobby/calendar/DayAgendaModal.tsx
@@ -94,7 +94,7 @@ export const DayAgendaModal = ({
                 {freeSlots.map((slot, i) => (
                   <li
                     key={i}
-                    className="flex items-center gap-1.5 rounded-lg px-3.5 py-2 text-sm text-brand-green-dark"
+                    className="flex items-center gap-1.5 rounded-lg px-3.5 py-2 text-sm text-brand-green-dark dark:text-brand-green"
                     style={{ backgroundColor: 'var(--color-free-slot)', opacity: 0.6 }}
                   >
                     <Sparkles className="h-3.5 w-3.5 flex-shrink-0" />

--- a/lined-web/src/features/lobby/header/LobbyHeader.tsx
+++ b/lined-web/src/features/lobby/header/LobbyHeader.tsx
@@ -18,10 +18,10 @@ export const LobbyHeader = ({ lobby }: LobbyHeaderProps) => {
   const [isAddMemberOpen, setIsAddMemberOpen] = useState(false);
 
   return (
-    <div className={`border-t-4 bg-white ${LOBBY_TYPE_BORDER_CLASSES[lobby.lobbyType]}`}>
+    <div className={`border-t-4 bg-surface ${LOBBY_TYPE_BORDER_CLASSES[lobby.lobbyType]}`}>
       <div className="flex flex-col items-start gap-4 p-4 md:flex-row md:items-center md:justify-between md:p-6">
         <div className="flex items-center gap-4">
-          <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-xl bg-gray-100 text-2xl">
+          <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-xl bg-surface-hover text-2xl">
             {LOBBY_TYPE_ICONS[lobby.lobbyType]}
           </div>
           <div>
@@ -29,9 +29,9 @@ export const LobbyHeader = ({ lobby }: LobbyHeaderProps) => {
             <div className="mt-1 flex items-center gap-2">
               <div className="flex -space-x-2" data-testid="lobby-member-avatars">
                 {shown.map((query, i) => (
-                  <Avatar key={lobby.memberIds[i]} size="sm" className="ring-2 ring-white">
+                  <Avatar key={lobby.memberIds[i]} size="sm" className="ring-2 ring-surface">
                     {query.isLoading && (
-                      <AvatarFallback className="animate-pulse bg-gray-200" />
+                      <AvatarFallback className="animate-pulse bg-muted" />
                     )}
                     {!query.isLoading && query.data && (
                       <AvatarFallback className="bg-brand-green text-xs font-semibold text-white">
@@ -39,7 +39,7 @@ export const LobbyHeader = ({ lobby }: LobbyHeaderProps) => {
                       </AvatarFallback>
                     )}
                     {!query.isLoading && !query.data && (
-                      <AvatarFallback className="bg-gray-300 text-xs font-semibold text-white">
+                      <AvatarFallback className="bg-muted-foreground text-xs font-semibold text-white">
                         ?
                       </AvatarFallback>
                     )}
@@ -61,13 +61,13 @@ export const LobbyHeader = ({ lobby }: LobbyHeaderProps) => {
           <button
             type="button"
             onClick={() => setIsAddMemberOpen(true)}
-            className="rounded-lg border border-border px-3 py-2 text-sm font-medium text-text-primary hover:bg-gray-50"
+            className="rounded-lg border border-border px-3 py-2 text-sm font-medium text-text-primary hover:bg-surface-hover"
           >
             + Add member
           </button>
           <Link
             to={`/lobbies/${lobby.id}/settings`}
-            className="rounded-lg border border-border px-3 py-2 text-sm font-medium text-text-primary hover:bg-gray-50"
+            className="rounded-lg border border-border px-3 py-2 text-sm font-medium text-text-primary hover:bg-surface-hover"
           >
             ⚙ Settings
           </Link>

--- a/lined-web/src/features/lobby/header/LobbyLoadStates.tsx
+++ b/lined-web/src/features/lobby/header/LobbyLoadStates.tsx
@@ -5,8 +5,8 @@ interface LobbyLoadStatesProps {
 export const LobbyLoadingState = ({ loadingTestId }: LobbyLoadStatesProps) => {
   return (
     <div className="flex-1 overflow-y-auto p-6">
-      <div className="h-24 animate-pulse rounded-xl bg-white" data-testid={loadingTestId} />
-      <div className="mt-4 h-10 w-64 animate-pulse rounded-lg bg-white" />
+      <div className="h-24 animate-pulse rounded-xl bg-surface" data-testid={loadingTestId} />
+      <div className="mt-4 h-10 w-64 animate-pulse rounded-lg bg-surface" />
     </div>
   );
 }

--- a/lined-web/src/features/lobby/header/LobbyTabBar.tsx
+++ b/lined-web/src/features/lobby/header/LobbyTabBar.tsx
@@ -17,7 +17,7 @@ interface LobbyTabBarProps {
 
 export const LobbyTabBar = ({ lobbyType, activeTab, onTabChange }: LobbyTabBarProps) => {
   return (
-    <div role="tablist" className="flex gap-6 overflow-x-auto border-b border-border bg-white px-4 md:px-6">
+    <div role="tablist" className="flex gap-6 overflow-x-auto border-b border-border bg-surface px-4 md:px-6">
       {TABS.map((tab) => {
         const isActive = tab.id === activeTab;
         return (

--- a/lined-web/src/features/lobby/members/AddMemberModal.tsx
+++ b/lined-web/src/features/lobby/members/AddMemberModal.tsx
@@ -50,7 +50,7 @@ export const AddMemberModal = ({ lobby, onClose }: AddMemberModalProps) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="max-h-[85vh] w-[460px] max-w-[90vw] overflow-hidden rounded-2xl bg-white shadow-[var(--shadow-lg)]">
+      <div className="max-h-[85vh] w-[460px] max-w-[90vw] overflow-hidden rounded-2xl bg-surface shadow-[var(--shadow-lg)]">
         <div className="flex items-center justify-between px-6 pt-5">
           <h2 className="text-lg font-bold text-text-primary">Add Member</h2>
           <button onClick={onClose} aria-label="Close" className="text-text-muted hover:text-text-secondary">
@@ -105,7 +105,7 @@ export const AddMemberModal = ({ lobby, onClose }: AddMemberModalProps) => {
           <button
             type="button"
             onClick={onClose}
-            className="h-10 rounded-lg border border-border bg-white px-4 text-sm text-text-secondary hover:bg-gray-50"
+            className="h-10 rounded-lg border border-border bg-surface px-4 text-sm text-text-secondary hover:bg-surface-hover"
           >
             Done
           </button>

--- a/lined-web/src/features/lobby/members/AssigneePicker.tsx
+++ b/lined-web/src/features/lobby/members/AssigneePicker.tsx
@@ -25,7 +25,7 @@ const AssigneeOption = ({ label, initial, isSelected, onClick }: AssigneeOptionP
   >
     <div
       className={`flex h-12 w-12 items-center justify-center rounded-full border-[3px] text-lg font-bold text-white ${
-        isSelected ? 'border-brand-green bg-brand-green' : 'border-border bg-gray-300'
+        isSelected ? 'border-brand-green bg-brand-green' : 'border-border bg-muted-foreground'
       }`}
     >
       {initial}
@@ -50,7 +50,7 @@ export const AssigneePicker = ({
     return (
       <div className="flex gap-2.5" data-testid="assignee-picker-loading">
         {[0, 1].map((i) => (
-          <div key={i} className="h-12 w-12 animate-pulse rounded-full bg-gray-200" />
+          <div key={i} className="h-12 w-12 animate-pulse rounded-full bg-muted" />
         ))}
       </div>
     );

--- a/lined-web/src/features/lobby/members/AssigneePicker.tsx
+++ b/lined-web/src/features/lobby/members/AssigneePicker.tsx
@@ -32,7 +32,7 @@ const AssigneeOption = ({ label, initial, isSelected, onClick }: AssigneeOptionP
     </div>
     <span
       className={`text-[11px] ${
-        isSelected ? 'font-semibold text-brand-green-dark' : 'text-text-secondary'
+        isSelected ? 'font-semibold text-brand-green-dark dark:text-brand-green' : 'text-text-secondary'
       }`}
     >
       {label}

--- a/lined-web/src/features/lobby/members/MemberCard.tsx
+++ b/lined-web/src/features/lobby/members/MemberCard.tsx
@@ -21,7 +21,7 @@ export const MemberCard = ({
   onRemove,
 }: MemberCardProps) => {
   return (
-    <div className="flex items-center gap-4 rounded-lg bg-white p-4 shadow-[var(--shadow-sm)]">
+    <div className="flex items-center gap-4 rounded-lg bg-surface p-4 shadow-[var(--shadow-sm)]">
       <Avatar size="lg">
         <AvatarFallback className="bg-brand-green text-sm font-semibold text-white">
           {member.username.charAt(0).toUpperCase()}
@@ -33,7 +33,7 @@ export const MemberCard = ({
           <p className="text-sm font-semibold text-text-primary">{member.username}</p>
           <span
             className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
-              isOwner ? 'bg-brand-green/10 text-brand-green' : 'bg-gray-100 text-text-secondary'
+              isOwner ? 'bg-brand-green/10 text-brand-green' : 'bg-surface-hover text-text-secondary'
             }`}
           >
             {isOwner ? 'Owner' : 'Member'}
@@ -53,7 +53,7 @@ export const MemberCard = ({
             <button
               type="button"
               onClick={onMakeOwner}
-              className="h-8 rounded-lg border border-border px-3 text-xs font-medium text-text-primary hover:bg-gray-50"
+              className="h-8 rounded-lg border border-border px-3 text-xs font-medium text-text-primary hover:bg-surface-hover"
             >
               Make owner
             </button>

--- a/lined-web/src/features/lobby/members/MemberCard.tsx
+++ b/lined-web/src/features/lobby/members/MemberCard.tsx
@@ -60,7 +60,7 @@ export const MemberCard = ({
             <button
               type="button"
               onClick={onRemove}
-              className="h-8 rounded-lg border border-red-200 px-3 text-xs font-medium text-red-600 hover:bg-red-50"
+              className="h-8 rounded-lg border border-red-200 px-3 text-xs font-medium text-red-600 hover:bg-red-50 dark:border-red-900/50 dark:text-red-400 dark:hover:bg-red-950/40"
             >
               Remove
             </button>

--- a/lined-web/src/features/lobby/members/MemberListContent.tsx
+++ b/lined-web/src/features/lobby/members/MemberListContent.tsx
@@ -24,7 +24,7 @@ export const MemberListContent = ({
     return (
       <div className="flex flex-col gap-2" data-testid="lobby-members-loading">
         {[0, 1].map((i) => (
-          <div key={i} className="h-20 animate-pulse rounded-lg bg-white" />
+          <div key={i} className="h-20 animate-pulse rounded-lg bg-surface" />
         ))}
       </div>
     );

--- a/lined-web/src/features/lobby/members/PendingInviteRow.tsx
+++ b/lined-web/src/features/lobby/members/PendingInviteRow.tsx
@@ -26,8 +26,8 @@ export const PendingInviteRow = ({
   });
 
   return (
-    <div className="flex items-center gap-3.5 rounded-xl bg-white p-4 shadow-[var(--shadow-sm)]">
-      <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-gray-200 text-lg text-text-secondary">
+    <div className="flex items-center gap-3.5 rounded-xl bg-surface p-4 shadow-[var(--shadow-sm)]">
+      <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-muted text-lg text-text-secondary">
         ?
       </div>
       <div className="min-w-0 flex-1">
@@ -41,7 +41,7 @@ export const PendingInviteRow = ({
         type="button"
         onClick={onResend}
         disabled={isResending || isCancelling}
-        className="h-8 flex-shrink-0 rounded-lg border border-border px-3 text-xs font-medium text-text-primary hover:bg-gray-50 disabled:opacity-60"
+        className="h-8 flex-shrink-0 rounded-lg border border-border px-3 text-xs font-medium text-text-primary hover:bg-surface-hover disabled:opacity-60"
       >
         {isResending ? 'Resending…' : 'Resend'}
       </button>

--- a/lined-web/src/features/lobby/members/PendingInviteRow.tsx
+++ b/lined-web/src/features/lobby/members/PendingInviteRow.tsx
@@ -35,7 +35,7 @@ export const PendingInviteRow = ({
           {isLoading ? 'Loading…' : (invitee?.username ?? `User #${invite.inviteeId}`)}
         </p>
         <p className="mt-0.5 text-xs text-text-secondary">Invite sent · {sentAt}</p>
-        {error && <p className="mt-0.5 text-xs text-red-600">{error}</p>}
+        {error && <p className="mt-0.5 text-xs text-red-600 dark:text-red-400">{error}</p>}
       </div>
       <button
         type="button"
@@ -49,7 +49,7 @@ export const PendingInviteRow = ({
         type="button"
         onClick={onCancel}
         disabled={isResending || isCancelling}
-        className="h-8 flex-shrink-0 rounded-lg border border-red-200 px-3 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-60"
+        className="h-8 flex-shrink-0 rounded-lg border border-red-200 px-3 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-60 dark:border-red-900/50 dark:text-red-400 dark:hover:bg-red-950/40"
       >
         {isCancelling ? 'Cancelling…' : 'Cancel'}
       </button>

--- a/lined-web/src/features/lobby/members/PendingInvitesSection.tsx
+++ b/lined-web/src/features/lobby/members/PendingInvitesSection.tsx
@@ -41,7 +41,7 @@ export const PendingInvitesSection = ({
       <h3 className="mb-3 text-sm font-semibold text-text-primary">Pending Invites</h3>
 
       {isLoading && (
-        <div className="h-16 animate-pulse rounded-xl bg-white" data-testid="pending-invites-loading" />
+        <div className="h-16 animate-pulse rounded-xl bg-surface" data-testid="pending-invites-loading" />
       )}
 
       {!isLoading && isError && (

--- a/lined-web/src/features/lobby/members/SearchResultRow.tsx
+++ b/lined-web/src/features/lobby/members/SearchResultRow.tsx
@@ -30,7 +30,7 @@ export const SearchResultRow = ({
           @{user.username}
           {isMember && ' · already in lobby'}
         </p>
-        {error && <p className="mt-0.5 text-xs text-red-600">{error}</p>}
+        {error && <p className="mt-0.5 text-xs text-red-600 dark:text-red-400">{error}</p>}
       </div>
       {isMember && <span className="text-lg text-task-done">✓</span>}
       {!isMember && (

--- a/lined-web/src/features/lobby/members/SearchResultsList.tsx
+++ b/lined-web/src/features/lobby/members/SearchResultsList.tsx
@@ -30,7 +30,7 @@ export const SearchResultsList = ({
     return (
       <div className="flex flex-col gap-2" data-testid="add-member-search-loading">
         {[0, 1].map((i) => (
-          <div key={i} className="h-12 animate-pulse rounded-lg bg-gray-100" />
+          <div key={i} className="h-12 animate-pulse rounded-lg bg-surface-hover" />
         ))}
       </div>
     );

--- a/lined-web/src/features/lobby/settings/LobbyDangerZoneCard.tsx
+++ b/lined-web/src/features/lobby/settings/LobbyDangerZoneCard.tsx
@@ -51,9 +51,9 @@ export const LobbyDangerZoneCard = ({ lobby, currentUserId }: LobbyDangerZoneCar
   return (
     <section
       id="danger-zone"
-      className="mb-5 scroll-mt-6 overflow-hidden rounded-xl border-[1.5px] border-red-200 bg-red-50"
+      className="mb-5 scroll-mt-6 overflow-hidden rounded-xl border-[1.5px] border-red-200 bg-red-50 dark:border-red-900/50 dark:bg-red-950/30"
     >
-      <div className="border-b border-red-200 px-6 py-3.5 text-sm font-bold text-red-600">
+      <div className="border-b border-red-200 px-6 py-3.5 text-sm font-bold text-red-600 dark:border-red-900/50 dark:text-red-400">
         ⚠ Danger Zone
       </div>
       <div className="flex items-center justify-between px-6 py-4">
@@ -66,13 +66,13 @@ export const LobbyDangerZoneCard = ({ lobby, currentUserId }: LobbyDangerZoneCar
         <button
           type="button"
           onClick={() => setPendingAction('leave')}
-          className="h-9 flex-shrink-0 rounded-lg border border-red-300 px-4 text-sm font-semibold text-red-600 transition-colors hover:bg-red-100"
+          className="h-9 flex-shrink-0 rounded-lg border border-red-300 px-4 text-sm font-semibold text-red-600 transition-colors hover:bg-red-100 dark:border-red-800/60 dark:text-red-400 dark:hover:bg-red-950/40"
         >
           Leave
         </button>
       </div>
       {isOwner && (
-        <div className="flex items-center justify-between border-t border-red-200 px-6 py-4">
+        <div className="flex items-center justify-between border-t border-red-200 px-6 py-4 dark:border-red-900/50">
           <div>
             <div className="text-sm font-semibold text-text-primary">Delete lobby</div>
             <div className="mt-0.5 text-xs text-text-secondary">

--- a/lined-web/src/features/lobby/settings/LobbyGeneralCard.tsx
+++ b/lined-web/src/features/lobby/settings/LobbyGeneralCard.tsx
@@ -88,7 +88,7 @@ export const LobbyGeneralCard = ({ lobby, isOwner }: LobbyGeneralCardProps) => {
       </form>
 
       {updateLobby.isError && (
-        <p role="alert" className="pb-4 text-xs text-red-600">
+        <p role="alert" className="pb-4 text-xs text-red-600 dark:text-red-400">
           {getLobbyUpdateErrorMessage(updateLobby.error)}
         </p>
       )}

--- a/lined-web/src/features/lobby/settings/LobbyNotificationsCard.tsx
+++ b/lined-web/src/features/lobby/settings/LobbyNotificationsCard.tsx
@@ -46,7 +46,7 @@ export const LobbyNotificationsCard = ({ lobbyId }: LobbyNotificationsCardProps)
         />
       ))}
       {updatePreferences.isError && (
-        <p role="alert" className="pb-4 pt-1 text-xs text-red-600">
+        <p role="alert" className="pb-4 pt-1 text-xs text-red-600 dark:text-red-400">
           Could not save that preference — please try again
         </p>
       )}

--- a/lined-web/src/features/lobby/settings/LobbyTypePicker.tsx
+++ b/lined-web/src/features/lobby/settings/LobbyTypePicker.tsx
@@ -21,7 +21,7 @@ export const LobbyTypePicker = ({ value, onChange }: LobbyTypePickerProps) => {
             className={`cursor-pointer rounded-lg border-2 px-3 py-3.5 text-center transition-colors ${
               selected
                 ? 'border-brand-green bg-brand-green-light'
-                : 'border-border bg-white hover:bg-gray-50'
+                : 'border-border bg-surface hover:bg-surface-hover'
             }`}
           >
             <div className="mb-1.5 text-xl leading-none">{LOBBY_TYPE_ICONS[type]}</div>

--- a/lined-web/src/features/lobby/tasks/LobbyTaskList.tsx
+++ b/lined-web/src/features/lobby/tasks/LobbyTaskList.tsx
@@ -48,7 +48,7 @@ const TaskListContent = ({
     return (
       <div className="flex flex-col gap-2" data-testid="lobby-tasks-loading">
         {[0, 1, 2].map((i) => (
-          <div key={i} className="h-16 animate-pulse rounded-lg bg-white" />
+          <div key={i} className="h-16 animate-pulse rounded-lg bg-surface" />
         ))}
       </div>
     );
@@ -143,7 +143,7 @@ export const LobbyTaskList = ({ lobbyId }: LobbyTaskListProps) => {
             className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
               filter === f.id
                 ? 'bg-brand-green text-white'
-                : 'bg-white text-text-secondary hover:bg-gray-50'
+                : 'bg-surface text-text-secondary hover:bg-surface-hover'
             }`}
           >
             {f.label} ({counts[f.id]})

--- a/lined-web/src/features/lobby/tasks/TaskRow.tsx
+++ b/lined-web/src/features/lobby/tasks/TaskRow.tsx
@@ -67,7 +67,7 @@ export const TaskRow = ({ task, assignee, onToggle, isUpdating, updateError, onO
         {task.description && (
           <p className="mt-0.5 truncate text-xs text-text-secondary">{task.description}</p>
         )}
-        {updateError && <p className="mt-0.5 text-xs text-red-500">{updateError}</p>}
+        {updateError && <p className="mt-0.5 text-xs text-red-500 dark:text-red-400">{updateError}</p>}
       </div>
 
       <div className="flex flex-shrink-0 items-center gap-3">
@@ -75,7 +75,7 @@ export const TaskRow = ({ task, assignee, onToggle, isUpdating, updateError, onO
         <AssigneeAvatar assignee={assignee} size="sm" />
         <span
           className={`w-16 text-right text-xs ${
-            due.isUrgent ? 'font-semibold text-red-500' : isDone ? 'text-text-muted' : 'text-text-secondary'
+            due.isUrgent ? 'font-semibold text-red-500 dark:text-red-400' : isDone ? 'text-text-muted' : 'text-text-secondary'
           }`}
         >
           {due.label}

--- a/lined-web/src/features/lobby/tasks/TaskRow.tsx
+++ b/lined-web/src/features/lobby/tasks/TaskRow.tsx
@@ -35,7 +35,7 @@ export const TaskRow = ({ task, assignee, onToggle, isUpdating, updateError, onO
             }
           : undefined
       }
-      className={`flex items-center gap-4 rounded-lg bg-white p-4 shadow-[var(--shadow-sm)] ${
+      className={`flex items-center gap-4 rounded-lg bg-surface p-4 shadow-[var(--shadow-sm)] ${
         isDone ? 'opacity-70' : ''
       } ${onOpen ? 'cursor-pointer hover:shadow-[var(--shadow-md)]' : ''}`}
     >
@@ -50,7 +50,7 @@ export const TaskRow = ({ task, assignee, onToggle, isUpdating, updateError, onO
           onToggle(task);
         }}
         className={`flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md border-2 text-xs text-white disabled:opacity-50 ${
-          isDone ? 'border-task-done bg-task-done' : 'border-border bg-white'
+          isDone ? 'border-task-done bg-task-done' : 'border-border bg-surface'
         }`}
       >
         {isDone && '✓'}

--- a/lined-web/src/features/notifications/InviteCard.tsx
+++ b/lined-web/src/features/notifications/InviteCard.tsx
@@ -50,7 +50,7 @@ export const InviteCard = ({
           {inviterName} invited you to <strong>{lobbyName}</strong>
         </p>
         <p className="mt-0.5 text-xs text-text-secondary">{subLine}</p>
-        {error && <p className="mt-0.5 text-xs text-red-600">{error}</p>}
+        {error && <p className="mt-0.5 text-xs text-red-600 dark:text-red-400">{error}</p>}
       </div>
       <div className="ml-auto flex flex-shrink-0 gap-2">
         <button
@@ -65,7 +65,7 @@ export const InviteCard = ({
           type="button"
           onClick={onDecline}
           disabled={isPending}
-          className="h-8 rounded-lg border border-red-300 px-3.5 text-xs font-semibold text-red-600 hover:bg-red-50 disabled:opacity-60"
+          className="h-8 rounded-lg border border-red-300 px-3.5 text-xs font-semibold text-red-600 hover:bg-red-50 disabled:opacity-60 dark:border-red-800/60 dark:text-red-400 dark:hover:bg-red-950/40"
         >
           {isDeclining ? 'Declining…' : 'Decline'}
         </button>

--- a/lined-web/src/features/notifications/InviteCard.tsx
+++ b/lined-web/src/features/notifications/InviteCard.tsx
@@ -37,7 +37,7 @@ export const InviteCard = ({
   return (
     <div
       data-testid="invite-card"
-      className="mb-3 flex flex-wrap items-center gap-3 rounded-xl border-[1.5px] border-brand-green bg-white p-3.5 shadow-[var(--shadow-sm)]"
+      className="mb-3 flex flex-wrap items-center gap-3 rounded-xl border-[1.5px] border-brand-green bg-surface p-3.5 shadow-[var(--shadow-sm)]"
     >
       <div
         className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full text-base font-semibold text-white"

--- a/lined-web/src/features/notifications/PendingInvitesBanner.tsx
+++ b/lined-web/src/features/notifications/PendingInvitesBanner.tsx
@@ -50,8 +50,8 @@ export const PendingInvitesBanner = () => {
   if (isLoading) {
     return (
       <section data-testid="pending-invites-loading">
-        <div className="mb-3 h-4 w-40 animate-pulse rounded bg-white" />
-        <div className="h-16 animate-pulse rounded-xl bg-white" />
+        <div className="mb-3 h-4 w-40 animate-pulse rounded bg-surface" />
+        <div className="h-16 animate-pulse rounded-xl bg-surface" />
       </section>
     );
   }

--- a/lined-web/src/features/notifications/bell/NotificationBell.tsx
+++ b/lined-web/src/features/notifications/bell/NotificationBell.tsx
@@ -78,7 +78,7 @@ export const NotificationBell = () => {
     <DropdownMenu>
       <DropdownMenuTrigger
         aria-label="Notifications"
-        className="relative flex h-9 w-9 items-center justify-center rounded-lg text-text-secondary hover:bg-gray-100"
+        className="relative flex h-9 w-9 items-center justify-center rounded-lg text-text-secondary hover:bg-surface-hover"
       >
         <Bell className="h-4 w-4" />
         {unreadCount > 0 && (

--- a/lined-web/src/features/notifications/bell/NotificationInbox.tsx
+++ b/lined-web/src/features/notifications/bell/NotificationInbox.tsx
@@ -104,7 +104,7 @@ export const NotificationInbox = ({
                   <button
                     type="button"
                     onClick={() => onRowClick(notification)}
-                    className={`flex w-full items-start gap-2.5 px-3 py-2.5 text-left hover:bg-gray-50 ${
+                    className={`flex w-full items-start gap-2.5 px-3 py-2.5 text-left hover:bg-surface-hover ${
                       isUnread ? 'bg-brand-green-light/40' : ''
                     }`}
                   >

--- a/lined-web/src/features/settings/SettingsCard.tsx
+++ b/lined-web/src/features/settings/SettingsCard.tsx
@@ -11,7 +11,7 @@ interface SettingsCardProps {
 export const SettingsCard = ({ id, title, children, footer }: SettingsCardProps) => (
   <section
     id={id}
-    className="mb-5 scroll-mt-6 overflow-hidden rounded-xl bg-white shadow-[var(--shadow-sm)]"
+    className="mb-5 scroll-mt-6 overflow-hidden rounded-xl bg-surface shadow-[var(--shadow-sm)]"
   >
     <div className="border-b border-border px-6 py-3.5 text-sm font-bold text-text-primary">
       {title}

--- a/lined-web/src/features/settings/SettingsMenu.tsx
+++ b/lined-web/src/features/settings/SettingsMenu.tsx
@@ -29,7 +29,7 @@ const SECTIONS: SettingsMenuSection[] = [
 
 const menuItemClass = (danger?: boolean): string => {
   return `block border-l-[3px] border-transparent px-5 py-2.5 text-sm ${
-    danger ? 'text-red-600' : 'text-text-secondary hover:text-text-primary'
+    danger ? 'text-red-600 dark:text-red-400' : 'text-text-secondary hover:text-text-primary'
   }`;
 }
 

--- a/lined-web/src/features/settings/SettingsMenu.tsx
+++ b/lined-web/src/features/settings/SettingsMenu.tsx
@@ -36,7 +36,7 @@ const menuItemClass = (danger?: boolean): string => {
 /** Left-hand jump list for the settings page — most items scroll-anchor within the
  * single-scroll page; items with a `route` navigate to a separate page instead. */
 export const SettingsMenu = () => (
-  <nav className="w-full flex-shrink-0 border-b border-border bg-white py-5 md:w-[220px] md:border-b-0 md:border-r">
+  <nav className="w-full flex-shrink-0 border-b border-border bg-surface py-5 md:w-[220px] md:border-b-0 md:border-r">
     {SECTIONS.map((section) => (
       <div key={section.label}>
         <div className="px-5 py-1.5 text-[11px] font-semibold tracking-wider text-text-muted">

--- a/lined-web/src/features/settings/cards/AppearanceCard.tsx
+++ b/lined-web/src/features/settings/cards/AppearanceCard.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useSettingsStore, type Theme } from '@/store/settings';
 import { SettingsCard } from '../SettingsCard';
 import { SettingsRow, SETTINGS_INPUT_CLASS } from '../SettingsRow';
@@ -9,24 +8,9 @@ const THEME_OPTIONS: { value: Theme; label: string }[] = [
   { value: 'system', label: 'System' },
 ];
 
-const resolvesToDark = (theme: Theme): boolean => {
-  if (theme === 'dark') return true;
-  if (theme === 'light') return false;
-  return window.matchMedia('(prefers-color-scheme: dark)').matches;
-}
-
 export const AppearanceCard = () => {
   const theme = useSettingsStore((s) => s.theme);
   const setTheme = useSettingsStore((s) => s.setTheme);
-
-  useEffect(() => {
-    document.documentElement.classList.toggle('dark', resolvesToDark(theme));
-    if (theme !== 'system') return;
-    const media = window.matchMedia('(prefers-color-scheme: dark)');
-    const listener = () => document.documentElement.classList.toggle('dark', media.matches);
-    media.addEventListener('change', listener);
-    return () => media.removeEventListener('change', listener);
-  }, [theme]);
 
   return (
     <SettingsCard id="appearance" title="Appearance">

--- a/lined-web/src/features/settings/cards/DangerZoneCard.tsx
+++ b/lined-web/src/features/settings/cards/DangerZoneCard.tsx
@@ -35,9 +35,9 @@ export const DangerZoneCard = ({ userId }: DangerZoneCardProps) => {
   return (
     <section
       id="danger-zone"
-      className="mb-5 scroll-mt-6 overflow-hidden rounded-xl border-[1.5px] border-red-200 bg-red-50"
+      className="mb-5 scroll-mt-6 overflow-hidden rounded-xl border-[1.5px] border-red-200 bg-red-50 dark:border-red-900/50 dark:bg-red-950/30"
     >
-      <div className="border-b border-red-200 px-6 py-3.5 text-sm font-bold text-red-600">
+      <div className="border-b border-red-200 px-6 py-3.5 text-sm font-bold text-red-600 dark:border-red-900/50 dark:text-red-400">
         ⚠ Danger Zone
       </div>
       <div className="flex items-center justify-between px-6 py-4">

--- a/lined-web/src/features/settings/cards/NotificationsCard.tsx
+++ b/lined-web/src/features/settings/cards/NotificationsCard.tsx
@@ -66,7 +66,7 @@ export const NotificationsCard = () => {
         />
       ))}
       {updatePreferences.isError && (
-        <p role="alert" className="pb-4 pt-1 text-xs text-red-600">
+        <p role="alert" className="pb-4 pt-1 text-xs text-red-600 dark:text-red-400">
           Could not save that preference — please try again
         </p>
       )}

--- a/lined-web/src/features/settings/cards/PasswordCard.tsx
+++ b/lined-web/src/features/settings/cards/PasswordCard.tsx
@@ -94,12 +94,12 @@ export const PasswordCard = ({ userId }: PasswordCardProps) => {
       </form>
 
       {touched && validationError && (
-        <p role="alert" className="pb-4 text-xs text-red-600">
+        <p role="alert" className="pb-4 text-xs text-red-600 dark:text-red-400">
           {validationError}
         </p>
       )}
       {updateUser.isError && (
-        <p role="alert" className="pb-4 text-xs text-red-600">
+        <p role="alert" className="pb-4 text-xs text-red-600 dark:text-red-400">
           {getPasswordErrorMessage(updateUser.error)}
         </p>
       )}

--- a/lined-web/src/features/settings/cards/ProfileCard.tsx
+++ b/lined-web/src/features/settings/cards/ProfileCard.tsx
@@ -112,7 +112,7 @@ export const ProfileCard = ({ user, isLoading }: ProfileCardProps) => {
       </form>
 
       {updateUser.isError && (
-        <p role="alert" className="pb-4 text-xs text-red-600">
+        <p role="alert" className="pb-4 text-xs text-red-600 dark:text-red-400">
           {getProfileErrorMessage(updateUser.error)}
         </p>
       )}

--- a/lined-web/src/features/settings/cards/__tests__/AppearanceCard.test.tsx
+++ b/lined-web/src/features/settings/cards/__tests__/AppearanceCard.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { renderWithProviders, screen, userEvent } from '@/test/utils';
 import { useSettingsStore } from '@/store/settings';
 import { AppearanceCard } from '../AppearanceCard';
@@ -6,11 +6,6 @@ import { AppearanceCard } from '../AppearanceCard';
 describe('AppearanceCard', () => {
   beforeEach(() => {
     useSettingsStore.setState({ theme: 'system' });
-    document.documentElement.classList.remove('dark');
-  });
-
-  afterEach(() => {
-    document.documentElement.classList.remove('dark');
   });
 
   it('defaults the theme select to the stored value', () => {
@@ -21,18 +16,17 @@ describe('AppearanceCard', () => {
     expect(screen.getByLabelText('Theme')).toHaveValue('light');
   });
 
-  it('persists the selected theme to the store and applies the dark class', async () => {
-    expect.assertions(2);
+  it('persists the selected theme to the store', async () => {
+    expect.assertions(1);
     const user = userEvent.setup();
     renderWithProviders(<AppearanceCard />);
 
     await user.selectOptions(screen.getByLabelText('Theme'), 'dark');
 
     expect(useSettingsStore.getState().theme).toBe('dark');
-    expect(document.documentElement.classList.contains('dark')).toBe(true);
   });
 
-  it('removes the dark class when switching to light', async () => {
+  it('reflects a switch back to light in the select value', async () => {
     expect.assertions(1);
     useSettingsStore.setState({ theme: 'dark' });
     const user = userEvent.setup();
@@ -40,6 +34,6 @@ describe('AppearanceCard', () => {
 
     await user.selectOptions(screen.getByLabelText('Theme'), 'light');
 
-    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(screen.getByLabelText('Theme')).toHaveValue('light');
   });
 });

--- a/lined-web/src/features/subscription/PlanCards.tsx
+++ b/lined-web/src/features/subscription/PlanCards.tsx
@@ -21,7 +21,7 @@ const getSubscribeErrorMessage = (error: unknown): string => {
 const PlanCardsSkeleton = () => (
   <div className="grid grid-cols-1 gap-4 md:grid-cols-3" data-testid="plan-cards-loading">
     {Array.from({ length: 3 }, (_, i) => (
-      <div key={i} className="h-40 animate-pulse rounded-xl bg-white" />
+      <div key={i} className="h-40 animate-pulse rounded-xl bg-surface" />
     ))}
   </div>
 );
@@ -39,7 +39,7 @@ export const PlanCards = ({ userId, plans, isLoading, currentPlanId }: PlanCards
           return (
             <div
               key={plan.id}
-              className={`relative rounded-xl border-[1.5px] bg-white p-5 ${
+              className={`relative rounded-xl border-[1.5px] bg-surface p-5 ${
                 isCurrent ? 'border-brand-green' : 'border-border'
               }`}
             >

--- a/lined-web/src/features/subscription/PlanCards.tsx
+++ b/lined-web/src/features/subscription/PlanCards.tsx
@@ -61,7 +61,7 @@ export const PlanCards = ({ userId, plans, isLoading, currentPlanId }: PlanCards
                 onClick={() => startSubscription.mutate(plan.id)}
                 className={`mt-4 h-9 w-full rounded-lg text-sm font-semibold transition-colors disabled:opacity-60 ${
                   isCurrent
-                    ? 'bg-brand-green-light text-brand-green-dark'
+                    ? 'bg-brand-green-light text-brand-green-dark dark:text-brand-green'
                     : 'bg-brand-green text-white hover:bg-brand-green-dark'
                 }`}
               >
@@ -72,7 +72,7 @@ export const PlanCards = ({ userId, plans, isLoading, currentPlanId }: PlanCards
         })}
       </div>
       {startSubscription.isError && (
-        <p className="mt-3 text-sm text-red-600">
+        <p className="mt-3 text-sm text-red-600 dark:text-red-400">
           {getSubscribeErrorMessage(startSubscription.error)}
         </p>
       )}

--- a/lined-web/src/features/tasks/TaskDrawer.tsx
+++ b/lined-web/src/features/tasks/TaskDrawer.tsx
@@ -240,7 +240,7 @@ export const TaskDrawer = ({
                     onChange={setDueDate}
                   />
                   {isPastDue && (
-                    <p className="mt-1.5 text-xs text-amber-600">
+                    <p className="mt-1.5 text-xs text-amber-600 dark:text-amber-400">
                       This date is in the past — the task will start off overdue.
                     </p>
                   )}
@@ -308,7 +308,7 @@ export const TaskDrawer = ({
                 <button
                   type="button"
                   onClick={() => setIsConfirmingDelete(true)}
-                  className="h-10 rounded-lg border border-red-200 px-4 text-sm font-medium text-red-600 hover:bg-red-50"
+                  className="h-10 rounded-lg border border-red-200 px-4 text-sm font-medium text-red-600 hover:bg-red-50 dark:border-red-900/50 dark:text-red-400 dark:hover:bg-red-950/40"
                 >
                   Delete
                 </button>

--- a/lined-web/src/features/tasks/TaskDrawer.tsx
+++ b/lined-web/src/features/tasks/TaskDrawer.tsx
@@ -316,7 +316,7 @@ export const TaskDrawer = ({
               <button
                 type="button"
                 onClick={onClose}
-                className={`h-10 rounded-lg border border-border bg-white px-4 text-sm text-text-secondary hover:bg-gray-50 ${
+                className={`h-10 rounded-lg border border-border bg-surface px-4 text-sm text-text-secondary hover:bg-surface-hover ${
                   isEditMode ? 'ml-auto' : 'flex-1'
                 }`}
               >

--- a/lined-web/src/features/tasks/kanban/KanbanBoard.tsx
+++ b/lined-web/src/features/tasks/kanban/KanbanBoard.tsx
@@ -24,9 +24,9 @@ const KanbanBoardSkeleton = () => (
   >
     {Array.from({ length: SKELETON_COLUMN_COUNT }, (_, columnIndex) => (
       <div key={columnIndex} className="flex min-w-full flex-col gap-2.5 snap-center md:min-w-0 md:flex-1 md:snap-align-none">
-        <div className="h-6 w-24 animate-pulse rounded bg-white" />
+        <div className="h-6 w-24 animate-pulse rounded bg-surface" />
         {Array.from({ length: SKELETON_CARDS_PER_COLUMN }, (_, cardIndex) => (
-          <div key={cardIndex} className="h-20 animate-pulse rounded-lg bg-white" />
+          <div key={cardIndex} className="h-20 animate-pulse rounded-lg bg-surface" />
         ))}
       </div>
     ))}

--- a/lined-web/src/features/tasks/kanban/KanbanCard.tsx
+++ b/lined-web/src/features/tasks/kanban/KanbanCard.tsx
@@ -87,7 +87,7 @@ export const KanbanCard = ({
       draggable
       onDragStart={handleDragStart}
       onDragEnd={() => setIsDragging(false)}
-      className={`flex cursor-grab gap-2.5 rounded-lg bg-white p-3 shadow-[var(--shadow-sm)] hover:shadow-[var(--shadow-md)] active:cursor-grabbing ${
+      className={`flex cursor-grab gap-2.5 rounded-lg bg-surface p-3 shadow-[var(--shadow-sm)] hover:shadow-[var(--shadow-md)] active:cursor-grabbing ${
         isDone ? 'opacity-75' : ''
       } ${isDragging ? 'opacity-40' : ''}`}
     >
@@ -124,7 +124,7 @@ export const KanbanCard = ({
                   e.stopPropagation();
                   onMove(task, 'prev');
                 }}
-                className="flex min-h-11 min-w-11 items-center justify-center rounded text-xs text-text-secondary hover:bg-gray-100 disabled:opacity-50 md:min-h-0 md:min-w-0 md:px-1"
+                className="flex min-h-11 min-w-11 items-center justify-center rounded text-xs text-text-secondary hover:bg-surface-hover disabled:opacity-50 md:min-h-0 md:min-w-0 md:px-1"
               >
                 ←
               </button>
@@ -139,7 +139,7 @@ export const KanbanCard = ({
                   e.stopPropagation();
                   onMove(task, 'next');
                 }}
-                className="flex min-h-11 min-w-11 items-center justify-center rounded text-xs text-text-secondary hover:bg-gray-100 disabled:opacity-50 md:min-h-0 md:min-w-0 md:px-1"
+                className="flex min-h-11 min-w-11 items-center justify-center rounded text-xs text-text-secondary hover:bg-surface-hover disabled:opacity-50 md:min-h-0 md:min-w-0 md:px-1"
               >
                 →
               </button>

--- a/lined-web/src/features/tasks/kanban/KanbanCard.tsx
+++ b/lined-web/src/features/tasks/kanban/KanbanCard.tsx
@@ -43,7 +43,7 @@ const DueDateOrDoneIndicator = ({ isDone, dueLabel, isUrgent }: DueDateOrDoneInd
   }
 
   return (
-    <span className={`text-xs ${isUrgent ? 'font-semibold text-red-500' : 'text-text-secondary'}`}>
+    <span className={`text-xs ${isUrgent ? 'font-semibold text-red-500 dark:text-red-400' : 'text-text-secondary'}`}>
       Due: {dueLabel}
     </span>
   );
@@ -155,14 +155,14 @@ export const KanbanCard = ({
                 e.stopPropagation();
                 onDelete(task);
               }}
-              className="rounded px-1 text-xs text-text-muted hover:bg-red-50 hover:text-red-500"
+              className="rounded px-1 text-xs text-text-muted hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-950/40 dark:hover:text-red-400"
             >
               ✕
             </button>
           </div>
         </div>
 
-        {moveError && <p className="mt-1.5 text-xs text-red-500">{moveError}</p>}
+        {moveError && <p className="mt-1.5 text-xs text-red-500 dark:text-red-400">{moveError}</p>}
       </div>
     </div>
   );

--- a/lined-web/src/features/tasks/kanban/KanbanFilters.tsx
+++ b/lined-web/src/features/tasks/kanban/KanbanFilters.tsx
@@ -12,7 +12,7 @@ const DATE_FILTER_LABELS: Record<TaskDateFilter, string> = {
 const DATE_FILTER_OPTIONS = Object.keys(DATE_FILTER_LABELS) as TaskDateFilter[];
 
 const selectClassName =
-  'h-9 rounded-lg border border-border bg-white px-3 text-xs font-medium text-text-secondary focus:border-brand-green focus:outline-none';
+  'h-9 rounded-lg border border-border bg-surface px-3 text-xs font-medium text-text-secondary focus:border-brand-green focus:outline-none';
 
 const renderMemberOptions = (members: UserDto[]) =>
   members.map((member) => (

--- a/lined-web/src/hooks/__tests__/useThemeSync.test.ts
+++ b/lined-web/src/hooks/__tests__/useThemeSync.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSettingsStore } from '@/store/settings';
+import { useThemeSync } from '../useThemeSync';
+
+type Listener = () => void;
+
+const createMatchMediaMock = (initialMatches: boolean) => {
+  let matches = initialMatches;
+  const listeners = new Set<Listener>();
+
+  const mql = {
+    get matches() {
+      return matches;
+    },
+    media: '',
+    addEventListener: (_: string, listener: Listener) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_: string, listener: Listener) => {
+      listeners.delete(listener);
+    },
+  };
+
+  return {
+    mql,
+    setMatches: (value: boolean) => {
+      matches = value;
+      listeners.forEach((listener) => listener());
+    },
+    listenerCount: () => listeners.size,
+  };
+};
+
+describe('useThemeSync', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ theme: 'system' });
+    document.documentElement.classList.remove('dark');
+    document.documentElement.style.colorScheme = '';
+  });
+
+  afterEach(() => {
+    document.documentElement.classList.remove('dark');
+    document.documentElement.style.colorScheme = '';
+    vi.restoreAllMocks();
+  });
+
+  it('applies the dark class and color-scheme when theme is dark', () => {
+    expect.assertions(2);
+    const { mql } = createMatchMediaMock(false);
+    vi.spyOn(window, 'matchMedia').mockReturnValue(mql as unknown as MediaQueryList);
+    useSettingsStore.setState({ theme: 'dark' });
+
+    renderHook(() => useThemeSync());
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.style.colorScheme).toBe('dark');
+  });
+
+  it('removes the dark class when theme is light', () => {
+    expect.assertions(1);
+    const { mql } = createMatchMediaMock(true);
+    vi.spyOn(window, 'matchMedia').mockReturnValue(mql as unknown as MediaQueryList);
+    useSettingsStore.setState({ theme: 'light' });
+    document.documentElement.classList.add('dark');
+
+    renderHook(() => useThemeSync());
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('reacts live to a matchMedia change event while theme is system', () => {
+    expect.assertions(2);
+    const { mql, setMatches } = createMatchMediaMock(false);
+    vi.spyOn(window, 'matchMedia').mockReturnValue(mql as unknown as MediaQueryList);
+    useSettingsStore.setState({ theme: 'system' });
+
+    renderHook(() => useThemeSync());
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+
+    act(() => {
+      setMatches(true);
+    });
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('does not subscribe to matchMedia changes when theme is not system', () => {
+    expect.assertions(1);
+    const { mql, listenerCount } = createMatchMediaMock(false);
+    vi.spyOn(window, 'matchMedia').mockReturnValue(mql as unknown as MediaQueryList);
+    useSettingsStore.setState({ theme: 'dark' });
+
+    renderHook(() => useThemeSync());
+
+    expect(listenerCount()).toBe(0);
+  });
+
+  it('updates the theme-color meta tag to match the resolved theme', () => {
+    expect.assertions(1);
+    const { mql } = createMatchMediaMock(false);
+    vi.spyOn(window, 'matchMedia').mockReturnValue(mql as unknown as MediaQueryList);
+    useSettingsStore.setState({ theme: 'dark' });
+
+    renderHook(() => useThemeSync());
+
+    const meta = document.querySelector('meta[name="theme-color"]');
+    expect(meta?.getAttribute('content')).toBe('#0B1310');
+  });
+});

--- a/lined-web/src/hooks/useThemeSync.ts
+++ b/lined-web/src/hooks/useThemeSync.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import { useSettingsStore, type Theme } from '@/store/settings';
+
+const DARK_META_COLOR = '#0B1310';
+const LIGHT_META_COLOR = '#F4F4F7';
+
+const resolvesToDark = (theme: Theme, media: MediaQueryList): boolean => {
+  if (theme === 'dark') return true;
+  if (theme === 'light') return false;
+  return media.matches;
+};
+
+const applyResolvedTheme = (isDark: boolean) => {
+  document.documentElement.classList.toggle('dark', isDark);
+  document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
+
+  let meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  if (!meta) {
+    meta = document.createElement('meta');
+    meta.name = 'theme-color';
+    document.head.appendChild(meta);
+  }
+  meta.content = isDark ? DARK_META_COLOR : LIGHT_META_COLOR;
+};
+
+/**
+ * Applies the persisted theme preference to `<html>` for the lifetime of the
+ * app (not just while Settings is mounted), and keeps "System" live-synced
+ * to OS theme changes via matchMedia.
+ */
+export const useThemeSync = () => {
+  const theme = useSettingsStore((s) => s.theme);
+
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    applyResolvedTheme(resolvesToDark(theme, media));
+
+    if (theme !== 'system') return;
+    const listener = () => applyResolvedTheme(media.matches);
+    media.addEventListener('change', listener);
+    return () => media.removeEventListener('change', listener);
+  }, [theme]);
+};

--- a/lined-web/src/index.css
+++ b/lined-web/src/index.css
@@ -182,6 +182,7 @@ body {
   --color-text-light: #4E6459;
   --color-brand-beige: #1C2E23;
   --color-brand-beige-dark: #24382C;
+  --color-brand-green-light: rgba(91, 155, 107, 0.18);
 }
 
 @layer base {

--- a/lined-web/src/index.css
+++ b/lined-web/src/index.css
@@ -45,6 +45,8 @@
   --color-border: #E5E7EB;
   --color-input-bg: #F9F9FB;
   --color-bg: #F4F4F7;
+  --color-surface: #FFFFFF;
+  --color-surface-hover: #F9FAFB;
 
   /* Shadows */
   --shadow-sm: 0 1px 4px rgba(0, 0, 0, 0.06);
@@ -168,6 +170,18 @@ body {
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+
+  /* Custom brand/surface/text tokens — dark equivalents */
+  --color-bg: #10231A;
+  --color-surface: #16281E;
+  --color-surface-hover: #1E3327;
+  --color-input-bg: #1C2E23;
+  --color-text-primary: #EAF3EC;
+  --color-text-secondary: #A9BDB0;
+  --color-text-muted: #7C9187;
+  --color-text-light: #4E6459;
+  --color-brand-beige: #1C2E23;
+  --color-brand-beige-dark: #24382C;
 }
 
 @layer base {
@@ -179,5 +193,9 @@ body {
   }
   html {
     @apply font-sans;
+    color-scheme: light;
+  }
+  html.dark {
+    color-scheme: dark;
   }
 }


### PR DESCRIPTION
## Summary

- Fixes a real bug: the theme-application effect lived inside `AppearanceCard` (Settings-page-only), so the `dark` class was never applied outside that page and the System `matchMedia` listener was torn down on navigating away. Moved to a `useThemeSync` hook mounted once at the app root, which also sets `color-scheme` and a `<meta name="theme-color">`.
- Adds a dark token layer in `lined-web/src/index.css` for every custom brand/surface/text token that had no dark value (`--color-bg`, new `--color-surface`/`--color-surface-hover`, `--color-input-bg`, text tiers, `--color-brand-beige*`, `--color-brand-green-light`), then sweeps `bg-white` → `bg-surface` and `bg-gray-50`/`bg-gray-100` → `bg-surface-hover` across ~45 files.
- Adds `dark:` variants at the call site for hard-coded red/amber danger/warning colors (Danger Zone cards, inline validation errors, the conflict-warning banner) and the brand-green tint/text pairing, since some of those same shades are also used on solid buttons/badges that must stay theme-invariant.
- Full mapping table added to `lined-web/docs/mockups.md` ("Dark mode (Task 23)" section).

## Audit checklist (all verified in dark mode via the local dev server)

- [x] Sign in / Sign up / error alert
- [x] Dashboard (pending invites, lobby cards, upcoming events, my tasks, notification bell dropdown)
- [x] Calendar week view (free-slot bands, now-line) + month view
- [x] Event detail panel + Create/Edit event modal
- [x] Lobby detail: Calendar / Tasks / Members tabs, Add Member modal
- [x] Task drawer (create + edit, priority select)
- [x] Global Tasks kanban board
- [x] User Settings (all cards incl. Danger Zone) + Lobby Settings (incl. Danger Zone)
- [x] Subscription & Plan page
- [x] Create Lobby modal + "+ Create" dropdown
- [x] ConfirmDialog (plain + type-to-confirm delete)

The only screens that were actually broken (bright, low-contrast light boxes) were the two Danger Zone cards; everything else needed only the token-layer/sweep changes to read correctly.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:run` (662/666 passing; the 4 failures are pre-existing, date-dependent MSW fixture issues unrelated to this change — confirmed failing identically on `main`)
- [x] `npm run build`
- [x] Manual: toggled Settings → Appearance → Dark while on the Dashboard (not Settings) and confirmed the page went dark immediately — regression test for the theme-sync bug fix