### PR TITLE
feature: clean up calendar and lobby styles

### DIFF
--- a/lined-web/docs/UI_TASKS.md
+++ b/lined-web/docs/UI_TASKS.md
@@ -244,7 +244,7 @@ dark-mode toggle shipped in Task 12 has never been audited screen-by-screen.
 | 30 | `feature/ui-30-calendar-sync` | Calendar Sync settings: ICS feed link (copy/regenerate/revoke) + .ics import | [tasks/UI-30-calendar-sync.md](tasks/UI-30-calendar-sync.md) | TODO |
 | 31 | `feature/ui-31-event-reminders` | Reminder select on event/reserve modals + EVENT_REMINDER / TASK_DUE inbox types | [tasks/UI-31-event-reminders.md](tasks/UI-31-event-reminders.md) | TODO |
 | 32 | `feature/ui-32-style-foundations` | Styling foundations: semantic task/lobby badges and shared `cn()` cleanup | [tasks/UI-32-style-foundations.md](tasks/UI-32-style-foundations.md) | DONE |
-| 33 | `feature/ui-33-calendar-lobby-style-cleanup` | Calendar/lobby selection styling cleanup and shared agenda event row | [tasks/UI-33-calendar-lobby-style-cleanup.md](tasks/UI-33-calendar-lobby-style-cleanup.md) | TODO |
+| 33 | `feature/ui-33-calendar-lobby-style-cleanup` | Calendar/lobby selection styling cleanup and shared agenda event row | [tasks/UI-33-calendar-lobby-style-cleanup.md](tasks/UI-33-calendar-lobby-style-cleanup.md) | DONE |
 | 34 | `feature/ui-34-feature-style-cleanup` | Feature-local conditional Tailwind cleanup across tasks, dashboard, subscription, notifications, and layout | [tasks/UI-34-feature-style-cleanup.md](tasks/UI-34-feature-style-cleanup.md) | TODO |
 
 ## Suggested order

--- a/lined-web/src/features/calendar/CalendarTopBar.tsx
+++ b/lined-web/src/features/calendar/CalendarTopBar.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuGroup,
 } from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
 
 interface CalendarTopBarProps {
   title: string;
@@ -72,19 +73,23 @@ export const CalendarTopBar = ({
 
       {/* Week / Month toggle */}
       <div className="flex overflow-hidden rounded-lg border border-border">
-        {(['week', 'month'] as const).map((mode) => (
-          <button
-            key={mode}
-            onClick={() => onViewModeChange(mode)}
-            className={`px-4 py-1.5 text-sm font-[inherit] capitalize transition-colors ${
-              viewMode === mode
-                ? 'bg-brand-green font-semibold text-white'
-                : 'bg-surface text-text-secondary hover:bg-surface-hover'
-            }`}
-          >
-            {mode.charAt(0).toUpperCase() + mode.slice(1)}
-          </button>
-        ))}
+        {(['week', 'month'] as const).map((mode) => {
+          const isSelected = viewMode === mode;
+          return (
+            <button
+              key={mode}
+              onClick={() => onViewModeChange(mode)}
+              className={cn(
+                'px-4 py-1.5 text-sm font-[inherit] capitalize transition-colors',
+                isSelected
+                  ? 'bg-brand-green font-semibold text-white'
+                  : 'bg-surface text-text-secondary hover:bg-surface-hover',
+              )}
+            >
+              {mode.charAt(0).toUpperCase() + mode.slice(1)}
+            </button>
+          );
+        })}
       </div>
 
       <div className="flex-1" />

--- a/lined-web/src/features/calendar/grid/DayChipStrip.tsx
+++ b/lined-web/src/features/calendar/grid/DayChipStrip.tsx
@@ -1,4 +1,5 @@
 import { addDays, getWeekStart, isSameDay, isToday } from '@/features/calendar/lib/calendarUtils';
+import { cn } from '@/lib/utils';
 
 interface DayChipStripProps {
   selectedDay: Date;
@@ -18,22 +19,23 @@ export const DayChipStrip = ({ selectedDay, onSelectDay }: DayChipStripProps) =>
       className="flex flex-shrink-0 gap-2 overflow-x-auto border-b border-border bg-surface px-3 py-2"
     >
       {days.map((day) => {
-        const selected = isSameDay(day, selectedDay);
-        const today = isToday(day);
+        const isSelected = isSameDay(day, selectedDay);
+        const isTodayDate = isToday(day);
         return (
           <button
             key={day.toISOString()}
             type="button"
             role="tab"
-            aria-selected={selected}
+            aria-selected={isSelected}
             onClick={() => onSelectDay(day)}
-            className={`flex flex-shrink-0 flex-col items-center gap-0.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
-              selected
+            className={cn(
+              'flex flex-shrink-0 flex-col items-center gap-0.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+              isSelected
                 ? 'bg-brand-green text-white'
-                : today
+                : isTodayDate
                   ? 'bg-brand-green-light text-brand-green-dark dark:text-brand-green'
-                  : 'text-text-secondary hover:bg-bg'
-            }`}
+                  : 'text-text-secondary hover:bg-bg',
+            )}
           >
             <span>{day.toLocaleDateString('en-US', { weekday: 'short' })}</span>
             <span className="text-sm font-semibold">{day.getDate()}</span>

--- a/lined-web/src/features/calendar/grid/MonthGrid.tsx
+++ b/lined-web/src/features/calendar/grid/MonthGrid.tsx
@@ -3,6 +3,7 @@ import type { LobbyDto } from '@/features/lobby/model';
 import { CalendarLegend } from './CalendarLegend';
 import { getMonthGridDays, isSameDay, isSameMonth, isToday } from '@/features/calendar/lib/calendarUtils';
 import { lobbyAccentColor } from '@/features/lobby/lib/constants';
+import { cn } from '@/lib/utils';
 
 const DOW_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const MAX_VISIBLE_CHIPS = 3;
@@ -26,18 +27,20 @@ const MonthDayCell = ({ day, monthAnchor, events, lobbyMap, onDayClick }: MonthD
     <button
       type="button"
       onClick={() => onDayClick(day)}
-      className={`flex min-h-0 flex-col items-start gap-1 overflow-hidden border-b border-l border-border p-1.5 text-left ${
-        inCurrentMonth ? 'bg-surface' : 'bg-surface-hover'
-      } hover:bg-surface-hover`}
+      className={cn(
+        'flex min-h-0 flex-col items-start gap-1 overflow-hidden border-b border-l border-border p-1.5 text-left hover:bg-surface-hover',
+        inCurrentMonth ? 'bg-surface' : 'bg-surface-hover',
+      )}
     >
       <div
-        className={`flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[11px] ${
+        className={cn(
+          'flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[11px]',
           today
             ? 'bg-brand-green font-semibold text-white'
             : inCurrentMonth
               ? 'text-text-primary'
-              : 'text-text-muted'
-        }`}
+              : 'text-text-muted',
+        )}
       >
         {day.getDate()}
       </div>

--- a/lined-web/src/features/calendar/grid/WeekGrid.tsx
+++ b/lined-web/src/features/calendar/grid/WeekGrid.tsx
@@ -22,6 +22,7 @@ import {
 import { CalendarLegend } from './CalendarLegend';
 import { DEFAULT_LEGEND_ITEMS, type LegendItem } from '@/features/calendar/lib/constants';
 import { lobbyAccentColor } from '@/features/lobby/lib/constants';
+import { cn } from '@/lib/utils';
 
 export type { LegendItem };
 
@@ -186,7 +187,7 @@ const DayColumn = ({
 }: DayColumnProps) => {
   return (
     <div
-      className={`relative flex-1 border-l border-border ${today ? 'bg-brand-green-light/25' : ''}`}
+      className={cn('relative flex-1 border-l border-border', today && 'bg-brand-green-light/25')}
     >
       {/* Hour grid lines — a single tiled background instead of GRID_HOURS.length
           separately-bordered divs, so every line renders identically regardless
@@ -322,11 +323,13 @@ export const WeekGrid = ({
                     }
                   : undefined
               }
-              className={`relative flex-1 py-2 text-center text-xs select-none ${
+              className={cn(
+                'relative flex-1 py-2 text-center text-xs select-none',
                 today
                   ? 'bg-brand-green-light font-semibold text-brand-green-dark dark:text-brand-green'
-                  : 'text-text-secondary'
-              } ${onDayClick ? 'cursor-pointer hover:bg-surface-hover' : ''}`}
+                  : 'text-text-secondary',
+                onDayClick && 'cursor-pointer hover:bg-surface-hover',
+              )}
             >
               {formatDayLabel(day)}
               {today && (

--- a/lined-web/src/features/calendar/panels/AgendaEventRow.tsx
+++ b/lined-web/src/features/calendar/panels/AgendaEventRow.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+import type { EventDto } from '@/features/calendar/model';
+import { formatClockTime } from '@/features/calendar/lib/calendarUtils';
+import { cn } from '@/lib/utils';
+
+interface AgendaEventRowProps {
+  event: EventDto;
+  accentColor: string;
+  isSelected: boolean;
+  secondaryContent?: ReactNode;
+  onClick: (eventId: number) => void;
+}
+
+/** Selectable event summary shared by calendar day-agenda surfaces. */
+export const AgendaEventRow = ({ event, accentColor, isSelected, secondaryContent, onClick }: AgendaEventRowProps) => {
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(event.id)}
+      className={cn(
+        'w-full rounded-lg border px-3.5 py-2.5 text-left transition-colors hover:bg-surface-hover',
+        isSelected ? 'border-brand-green' : 'border-border',
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <span className="h-2 w-2 flex-shrink-0 rounded-full" style={{ backgroundColor: accentColor }} />
+        <span className="text-sm font-semibold text-text-primary">
+          {formatClockTime(new Date(event.startAt))} – {formatClockTime(new Date(event.endAt))}
+        </span>
+      </div>
+      <div className="mt-1 text-sm text-text-primary">{event.title}</div>
+      {secondaryContent}
+    </button>
+  );
+};

--- a/lined-web/src/features/calendar/panels/DayAgendaPanel.tsx
+++ b/lined-web/src/features/calendar/panels/DayAgendaPanel.tsx
@@ -1,8 +1,9 @@
 import { X } from 'lucide-react';
 import type { EventDto } from '@/features/calendar/model';
 import type { LobbyDto } from '@/features/lobby/model';
-import { formatClockTime, formatFullDate } from '@/features/calendar/lib/calendarUtils';
+import { formatFullDate } from '@/features/calendar/lib/calendarUtils';
 import { lobbyAccentColor } from '@/features/lobby/lib/constants';
+import { AgendaEventRow } from './AgendaEventRow';
 
 interface DayAgendaPanelProps {
   day: Date;
@@ -47,28 +48,13 @@ export const DayAgendaPanel = ({
               const accentColor = lobby ? lobbyAccentColor(lobby.lobbyType) : 'var(--color-lobby-couple)';
               return (
                 <li key={event.id}>
-                  <button
-                    type="button"
-                    onClick={() => onEventClick(event.id)}
-                    className={`w-full rounded-lg border px-3.5 py-2.5 text-left transition-colors hover:bg-surface-hover ${
-                      event.id === selectedEventId ? 'border-brand-green' : 'border-border'
-                    }`}
-                  >
-                    <div className="flex items-center gap-2">
-                      <span
-                        className="h-2 w-2 flex-shrink-0 rounded-full"
-                        style={{ backgroundColor: accentColor }}
-                      />
-                      <span className="text-sm font-semibold text-text-primary">
-                        {formatClockTime(new Date(event.startAt))} –{' '}
-                        {formatClockTime(new Date(event.endAt))}
-                      </span>
-                    </div>
-                    <div className="mt-1 text-sm text-text-primary">{event.title}</div>
-                    {lobby && (
-                      <div className="mt-0.5 text-xs text-text-secondary">{lobby.name}</div>
-                    )}
-                  </button>
+                  <AgendaEventRow
+                    event={event}
+                    accentColor={accentColor}
+                    isSelected={event.id === selectedEventId}
+                    secondaryContent={lobby && <div className="mt-0.5 text-xs text-text-secondary">{lobby.name}</div>}
+                    onClick={onEventClick}
+                  />
                 </li>
               );
             })}

--- a/lined-web/src/features/calendar/panels/__tests__/AgendaEventRow.test.tsx
+++ b/lined-web/src/features/calendar/panels/__tests__/AgendaEventRow.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, screen, userEvent } from '@/test/utils';
+import type { EventDto } from '@/features/calendar/model';
+import { AgendaEventRow } from '../AgendaEventRow';
+
+const event: EventDto = {
+  id: 11,
+  title: 'Dinner reservation',
+  location: 'Bistro',
+  shared: true,
+  startAt: '2026-07-20T18:00:00Z',
+  endAt: '2026-07-20T19:00:00Z',
+  timezone: 'UTC',
+  lobbyId: 4,
+  ownerId: 1,
+  createdAt: '2026-07-19T10:00:00Z',
+};
+
+describe('AgendaEventRow', () => {
+  it('renders event details and invokes the owner callback', async () => {
+    expect.assertions(3);
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(
+      <AgendaEventRow
+        event={event}
+        accentColor="var(--color-lobby-couple)"
+        isSelected={false}
+        secondaryContent={<div>Bistro</div>}
+        onClick={onClick}
+      />,
+    );
+
+    expect(screen.getByText('Dinner reservation')).toBeInTheDocument();
+    expect(screen.getByText('Bistro')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /dinner reservation/i }));
+    expect(onClick).toHaveBeenCalledWith(11);
+  });
+
+  it('applies the selected border state', () => {
+    expect.assertions(1);
+    renderWithProviders(
+      <AgendaEventRow
+        event={event}
+        accentColor="var(--color-lobby-couple)"
+        isSelected
+        onClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /dinner reservation/i })).toHaveClass('border-brand-green');
+  });
+});

--- a/lined-web/src/features/lobby/calendar/DayAgendaModal.tsx
+++ b/lined-web/src/features/lobby/calendar/DayAgendaModal.tsx
@@ -1,8 +1,9 @@
 import { X, MapPin, Sparkles } from 'lucide-react';
 import type { EventDto } from '@/features/calendar/model';
 import type { LobbyDto } from '@/features/lobby/model';
-import { formatClockTime, formatFullDate, formatHourRange, type FreeSlot } from '@/features/calendar/lib/calendarUtils';
+import { formatFullDate, formatHourRange, type FreeSlot } from '@/features/calendar/lib/calendarUtils';
 import { lobbyAccentColor } from '@/features/lobby/lib/constants';
+import { AgendaEventRow } from '@/features/calendar/panels/AgendaEventRow';
 
 interface DayAgendaModalProps {
   day: Date;
@@ -55,31 +56,18 @@ export const DayAgendaModal = ({
             <ul className="flex flex-col gap-2">
               {sorted.map((event) => (
                 <li key={event.id}>
-                  <button
-                    type="button"
-                    onClick={() => onEventClick(event.id)}
-                    className={`w-full rounded-lg border px-3.5 py-2.5 text-left transition-colors hover:bg-surface-hover ${
-                      event.id === selectedEventId ? 'border-brand-green' : 'border-border'
-                    }`}
-                  >
-                    <div className="flex items-center gap-2">
-                      <span
-                        className="h-2 w-2 flex-shrink-0 rounded-full"
-                        style={{ backgroundColor: accentColor }}
-                      />
-                      <span className="text-sm font-semibold text-text-primary">
-                        {formatClockTime(new Date(event.startAt))} –{' '}
-                        {formatClockTime(new Date(event.endAt))}
-                      </span>
-                    </div>
-                    <div className="mt-1 text-sm text-text-primary">{event.title}</div>
-                    {event.location && (
+                  <AgendaEventRow
+                    event={event}
+                    accentColor={accentColor}
+                    isSelected={event.id === selectedEventId}
+                    secondaryContent={event.location && (
                       <div className="mt-0.5 flex items-center gap-1 text-xs text-text-secondary">
                         <MapPin className="h-3 w-3 flex-shrink-0" />
                         {event.location}
                       </div>
                     )}
-                  </button>
+                    onClick={onEventClick}
+                  />
                 </li>
               ))}
             </ul>

--- a/lined-web/src/features/lobby/header/LobbyTabBar.tsx
+++ b/lined-web/src/features/lobby/header/LobbyTabBar.tsx
@@ -1,5 +1,6 @@
 import type { LobbyType } from '@/features/lobby/model';
 import { LOBBY_TYPE_BORDER_CLASSES } from '@/features/lobby/lib/constants';
+import { cn } from '@/lib/utils';
 
 export type LobbyTab = 'calendar' | 'tasks' | 'members';
 
@@ -27,11 +28,12 @@ export const LobbyTabBar = ({ lobbyType, activeTab, onTabChange }: LobbyTabBarPr
             role="tab"
             aria-selected={isActive}
             onClick={() => onTabChange(tab.id)}
-            className={`border-b-2 px-1 py-3 text-sm font-medium transition-colors ${
+            className={cn(
+              'border-b-2 px-1 py-3 text-sm font-medium transition-colors',
               isActive
-                ? `${LOBBY_TYPE_BORDER_CLASSES[lobbyType]} text-text-primary`
-                : 'border-transparent text-text-secondary hover:text-text-primary'
-            }`}
+                ? [LOBBY_TYPE_BORDER_CLASSES[lobbyType], 'text-text-primary']
+                : 'border-transparent text-text-secondary hover:text-text-primary',
+            )}
           >
             {tab.emoji} {tab.label}
           </button>

--- a/lined-web/src/features/lobby/members/SearchResultRow.tsx
+++ b/lined-web/src/features/lobby/members/SearchResultRow.tsx
@@ -1,4 +1,5 @@
 import type { UserSearchResultDto } from '@/features/users/model';
+import { cn } from '@/lib/utils';
 
 interface SearchResultRowProps {
   user: UserSearchResultDto;
@@ -19,7 +20,7 @@ export const SearchResultRow = ({
 }: SearchResultRowProps) => {
   return (
     <div
-      className={`flex items-center gap-3 rounded-lg p-2.5 ${isMember ? 'bg-brand-green-light' : ''}`}
+      className={cn('flex items-center gap-3 rounded-lg p-2.5', isMember && 'bg-brand-green-light')}
     >
       <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-brand-green text-sm font-bold text-white">
         {user.username.charAt(0).toUpperCase()}

--- a/lined-web/src/features/lobby/settings/LobbyTypePicker.tsx
+++ b/lined-web/src/features/lobby/settings/LobbyTypePicker.tsx
@@ -1,5 +1,6 @@
 import type { LobbyType } from '@/features/lobby/model';
 import { LOBBY_TYPE_ICONS, LOBBY_TYPE_LABELS, LOBBY_TYPES } from '@/features/lobby/lib/constants';
+import { cn } from '@/lib/utils';
 
 interface LobbyTypePickerProps {
   value: LobbyType;
@@ -10,19 +11,20 @@ export const LobbyTypePicker = ({ value, onChange }: LobbyTypePickerProps) => {
   return (
     <div role="radiogroup" aria-label="Lobby type" className="grid grid-cols-2 gap-2.5">
       {LOBBY_TYPES.map((type) => {
-        const selected = type === value;
+        const isSelected = type === value;
         return (
           <button
             key={type}
             type="button"
             role="radio"
-            aria-checked={selected}
+            aria-checked={isSelected}
             onClick={() => onChange(type)}
-            className={`cursor-pointer rounded-lg border-2 px-3 py-3.5 text-center transition-colors ${
-              selected
+            className={cn(
+              'cursor-pointer rounded-lg border-2 px-3 py-3.5 text-center transition-colors',
+              isSelected
                 ? 'border-brand-green bg-brand-green-light'
-                : 'border-border bg-surface hover:bg-surface-hover'
-            }`}
+                : 'border-border bg-surface hover:bg-surface-hover',
+            )}
           >
             <div className="mb-1.5 text-xl leading-none">{LOBBY_TYPE_ICONS[type]}</div>
             <div className="text-xs font-semibold text-text-primary">


### PR DESCRIPTION
## Summary
- extract the shared calendar agenda event row
- simplify calendar and lobby selected-state styling with cn()
- preserve existing ARIA and interaction behavior

## How to use and test
```bash
npm run typecheck
npm run lint
npm run test:run -- src/features/calendar/panels/__tests__/AgendaEventRow.test.tsx
npm run build
```

Focused regression tests and the production build pass. The full suite retains pre-existing CalendarPage and DashboardPage failures.