### PR TITLE
feature: simplify feature style conditions

### DIFF
--- a/lined-web/docs/UI_TASKS.md
+++ b/lined-web/docs/UI_TASKS.md
@@ -245,7 +245,7 @@ dark-mode toggle shipped in Task 12 has never been audited screen-by-screen.
 | 31 | `feature/ui-31-event-reminders` | Reminder select on event/reserve modals + EVENT_REMINDER / TASK_DUE inbox types | [tasks/UI-31-event-reminders.md](tasks/UI-31-event-reminders.md) | TODO |
 | 32 | `feature/ui-32-style-foundations` | Styling foundations: semantic task/lobby badges and shared `cn()` cleanup | [tasks/UI-32-style-foundations.md](tasks/UI-32-style-foundations.md) | DONE |
 | 33 | `feature/ui-33-calendar-lobby-style-cleanup` | Calendar/lobby selection styling cleanup and shared agenda event row | [tasks/UI-33-calendar-lobby-style-cleanup.md](tasks/UI-33-calendar-lobby-style-cleanup.md) | DONE |
-| 34 | `feature/ui-34-feature-style-cleanup` | Feature-local conditional Tailwind cleanup across tasks, dashboard, subscription, notifications, and layout | [tasks/UI-34-feature-style-cleanup.md](tasks/UI-34-feature-style-cleanup.md) | TODO |
+| 34 | `feature/ui-34-feature-style-cleanup` | Feature-local conditional Tailwind cleanup across tasks, dashboard, subscription, notifications, and layout | [tasks/UI-34-feature-style-cleanup.md](tasks/UI-34-feature-style-cleanup.md) | DONE |
 
 ## Suggested order
 

--- a/lined-web/src/features/dashboard/lobbies/LobbyCard.tsx
+++ b/lined-web/src/features/dashboard/lobbies/LobbyCard.tsx
@@ -3,6 +3,7 @@ import { Users, Calendar, CheckSquare } from 'lucide-react';
 import type { LobbyDto } from '@/features/lobby/model';
 import { LOBBY_TYPE_COLORS } from '@/features/lobby/lib/constants';
 import { LobbyTypeBadge } from '@/features/lobby/LobbyTypeBadge';
+import { cn } from '@/lib/utils';
 
 interface LobbyCardProps {
   lobby: LobbyDto;
@@ -16,7 +17,7 @@ export const LobbyCard = ({ lobby, eventCount, taskCount }: LobbyCardProps) => {
       to={`/lobbies/${lobby.id}`}
       className="flex w-56 flex-shrink-0 flex-col overflow-hidden rounded-xl bg-surface shadow-[var(--shadow-sm)] transition-shadow hover:shadow-[var(--shadow-md)]"
     >
-      <div className={`h-1.5 w-full ${LOBBY_TYPE_COLORS[lobby.lobbyType]}`} />
+      <div className={cn('h-1.5 w-full', LOBBY_TYPE_COLORS[lobby.lobbyType])} />
       <div className="flex flex-col gap-2 p-4">
         <LobbyTypeBadge type={lobby.lobbyType} />
         <p className="truncate text-sm font-semibold text-text-primary">{lobby.name}</p>

--- a/lined-web/src/features/dashboard/widgets/MyTasksList.tsx
+++ b/lined-web/src/features/dashboard/widgets/MyTasksList.tsx
@@ -5,6 +5,7 @@ import { formatTaskDueDate } from '@/features/calendar/lib/calendarUtils';
 import { sortTasksByDueDate } from '@/features/tasks/lib/taskUtils';
 import { EmptyState } from '@/components/EmptyState';
 import { TaskStatusBadge } from '@/features/tasks/TaskStatusBadge';
+import { cn } from '@/lib/utils';
 
 const MAX_TASKS_SHOWN = 5;
 
@@ -62,26 +63,28 @@ export const MyTasksList = ({ tasks, isLoading, isError }: MyTasksListProps) => 
                 className="flex items-center gap-3 rounded-lg bg-surface p-3 shadow-[var(--shadow-sm)]"
               >
                 <span
-                  className={`h-2 w-2 flex-shrink-0 rounded-full ${TASK_STATUS_COLORS[task.status]}`}
+                  className={cn('h-2 w-2 flex-shrink-0 rounded-full', TASK_STATUS_COLORS[task.status])}
                 />
                 <div className="min-w-0 flex-1">
                   <p
-                    className={`truncate text-sm font-medium ${
-                      isDone ? 'text-text-muted line-through' : 'text-text-primary'
-                    }`}
+                    className={cn(
+                      'truncate text-sm font-medium',
+                      isDone ? 'text-text-muted line-through' : 'text-text-primary',
+                    )}
                   >
                     {task.title}
                   </p>
                   <TaskStatusBadge status={task.status} />
                 </div>
                 <span
-                  className={`flex-shrink-0 text-xs ${
+                  className={cn(
+                    'flex-shrink-0 text-xs',
                     due.isUrgent
                       ? 'font-semibold text-red-500 dark:text-red-400'
                       : isDone
                         ? 'text-text-muted'
-                        : 'text-text-secondary'
-                  }`}
+                        : 'text-text-secondary',
+                  )}
                 >
                   {due.label}
                 </span>

--- a/lined-web/src/features/dashboard/widgets/UpcomingEventsList.tsx
+++ b/lined-web/src/features/dashboard/widgets/UpcomingEventsList.tsx
@@ -5,6 +5,7 @@ import { LOBBY_TYPE_COLORS } from '@/features/lobby/lib/constants';
 import { LobbyTypeBadge } from '@/features/lobby/LobbyTypeBadge';
 import { formatRelativeEventTime } from '@/features/calendar/lib/calendarUtils';
 import { EmptyState } from '@/components/EmptyState';
+import { cn } from '@/lib/utils';
 
 interface UpcomingEventsListProps {
   events: EventDto[] | undefined;
@@ -61,7 +62,7 @@ export const UpcomingEventsList = ({
                 key={event.id}
                 className="flex items-center gap-3 overflow-hidden rounded-lg bg-surface p-3 shadow-[var(--shadow-sm)]"
               >
-                <span className={`h-8 w-1 flex-shrink-0 rounded-full ${LOBBY_TYPE_COLORS[lobbyType]}`} />
+                <span className={cn('h-8 w-1 flex-shrink-0 rounded-full', LOBBY_TYPE_COLORS[lobbyType])} />
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-sm font-medium text-text-primary">
                     {event.title}

--- a/lined-web/src/features/layout/Sidebar.tsx
+++ b/lined-web/src/features/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import { useAuthStore } from '@/store/auth';
 import { useCreateMenuStore } from '@/store/createMenu';
 import { LOBBY_TYPE_COLORS } from '@/features/lobby/lib/constants';
 import { EmptyState } from '@/components/EmptyState';
+import { cn } from '@/lib/utils';
 import { NAV_ITEMS } from './navItems';
 
 interface SidebarProps {
@@ -110,7 +111,7 @@ export const Sidebar = ({ onNavigate }: SidebarProps = {}) => {
               }
             >
               <span
-                className={`h-2.5 w-2.5 rounded-full ${LOBBY_TYPE_COLORS[lobby.lobbyType]}`}
+                className={cn('h-2.5 w-2.5 rounded-full', LOBBY_TYPE_COLORS[lobby.lobbyType])}
               />
               {lobby.name}
             </NavLink>

--- a/lined-web/src/features/lobby/header/LobbyHeader.tsx
+++ b/lined-web/src/features/lobby/header/LobbyHeader.tsx
@@ -6,6 +6,7 @@ import { LOBBY_TYPE_BORDER_CLASSES, LOBBY_TYPE_ICONS } from '@/features/lobby/li
 import { LobbyTypeBadge } from '@/features/lobby/LobbyTypeBadge';
 import { useUsers } from '@/features/users/hooks/useUsers';
 import { AddMemberModal } from '../members/AddMemberModal';
+import { cn } from '@/lib/utils';
 
 const MAX_AVATARS_SHOWN = 4;
 
@@ -19,7 +20,7 @@ export const LobbyHeader = ({ lobby }: LobbyHeaderProps) => {
   const [isAddMemberOpen, setIsAddMemberOpen] = useState(false);
 
   return (
-    <div className={`border-t-4 bg-surface ${LOBBY_TYPE_BORDER_CLASSES[lobby.lobbyType]}`}>
+    <div className={cn('border-t-4 bg-surface', LOBBY_TYPE_BORDER_CLASSES[lobby.lobbyType])}>
       <div className="flex flex-col items-start gap-4 p-4 md:flex-row md:items-center md:justify-between md:p-6">
         <div className="flex items-center gap-4">
           <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-xl bg-surface-hover text-2xl">

--- a/lined-web/src/features/lobby/members/AssigneePicker.tsx
+++ b/lined-web/src/features/lobby/members/AssigneePicker.tsx
@@ -1,4 +1,5 @@
 import type { UserDto } from '@/features/users/model';
+import { cn } from '@/lib/utils';
 
 interface AssigneePickerProps {
   members: UserDto[];
@@ -24,16 +25,18 @@ const AssigneeOption = ({ label, initial, isSelected, onClick }: AssigneeOptionP
     className="flex flex-col items-center gap-1"
   >
     <div
-      className={`flex h-12 w-12 items-center justify-center rounded-full border-[3px] text-lg font-bold text-white ${
-        isSelected ? 'border-brand-green bg-brand-green' : 'border-border bg-muted-foreground'
-      }`}
+      className={cn(
+        'flex h-12 w-12 items-center justify-center rounded-full border-[3px] text-lg font-bold text-white',
+        isSelected ? 'border-brand-green bg-brand-green' : 'border-border bg-muted-foreground',
+      )}
     >
       {initial}
     </div>
     <span
-      className={`text-[11px] ${
-        isSelected ? 'font-semibold text-brand-green-dark dark:text-brand-green' : 'text-text-secondary'
-      }`}
+      className={cn(
+        'text-[11px]',
+        isSelected ? 'font-semibold text-brand-green-dark dark:text-brand-green' : 'text-text-secondary',
+      )}
     >
       {label}
     </span>

--- a/lined-web/src/features/lobby/members/MemberCard.tsx
+++ b/lined-web/src/features/lobby/members/MemberCard.tsx
@@ -1,6 +1,7 @@
 import type { UserDto } from '@/features/users/model';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { formatMonthYear } from '@/features/calendar/lib/calendarUtils';
+import { cn } from '@/lib/utils';
 
 interface MemberCardProps {
   member: UserDto;
@@ -32,9 +33,10 @@ export const MemberCard = ({
         <div className="flex items-center gap-2">
           <p className="text-sm font-semibold text-text-primary">{member.username}</p>
           <span
-            className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
-              isOwner ? 'bg-brand-green/10 text-brand-green' : 'bg-surface-hover text-text-secondary'
-            }`}
+            className={cn(
+              'rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
+              isOwner ? 'bg-brand-green/10 text-brand-green' : 'bg-surface-hover text-text-secondary',
+            )}
           >
             {isOwner ? 'Owner' : 'Member'}
           </span>

--- a/lined-web/src/features/lobby/tasks/LobbyTaskList.tsx
+++ b/lined-web/src/features/lobby/tasks/LobbyTaskList.tsx
@@ -8,6 +8,7 @@ import { useCreateMenuStore } from '@/store/createMenu';
 import { TASK_STATUS_LABELS } from '@/features/tasks/lib/constants';
 import { sortTasksByDueDate } from '@/features/tasks/lib/taskUtils';
 import { EmptyState } from '@/components/EmptyState';
+import { cn } from '@/lib/utils';
 import { TaskRow } from './TaskRow';
 
 type FilterId = 'ALL' | TaskStatus;
@@ -134,21 +135,25 @@ export const LobbyTaskList = ({ lobbyId }: LobbyTaskListProps) => {
   return (
     <div className="p-6">
       <div className="mb-4 flex flex-wrap items-center gap-2">
-        {FILTERS.map((f) => (
-          <button
-            key={f.id}
-            type="button"
-            onClick={() => setFilter(f.id)}
-            aria-pressed={filter === f.id}
-            className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
-              filter === f.id
-                ? 'bg-brand-green text-white'
-                : 'bg-surface text-text-secondary hover:bg-surface-hover'
-            }`}
-          >
-            {f.label} ({counts[f.id]})
-          </button>
-        ))}
+        {FILTERS.map((filterOption) => {
+          const isSelected = filter === filterOption.id;
+          return (
+            <button
+              key={filterOption.id}
+              type="button"
+              onClick={() => setFilter(filterOption.id)}
+              aria-pressed={isSelected}
+              className={cn(
+                'rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
+                isSelected
+                  ? 'bg-brand-green text-white'
+                  : 'bg-surface text-text-secondary hover:bg-surface-hover',
+              )}
+            >
+              {filterOption.label} ({counts[filterOption.id]})
+            </button>
+          );
+        })}
         <span className="ml-auto text-xs text-text-secondary">Sort: Due date</span>
       </div>
 

--- a/lined-web/src/features/lobby/tasks/TaskRow.tsx
+++ b/lined-web/src/features/lobby/tasks/TaskRow.tsx
@@ -4,6 +4,7 @@ import { formatTaskDueDate } from '@/features/calendar/lib/calendarUtils';
 import { taskDetailsLabel } from '@/features/tasks/lib/taskUtils';
 import { TaskStatusBadge } from '@/features/tasks/TaskStatusBadge';
 import { AssigneeAvatar } from '@/components/AssigneeAvatar';
+import { cn } from '@/lib/utils';
 
 interface TaskRowProps {
   task: TaskDto;
@@ -35,9 +36,11 @@ export const TaskRow = ({ task, assignee, onToggle, isUpdating, updateError, onO
             }
           : undefined
       }
-      className={`flex items-center gap-4 rounded-lg bg-surface p-4 shadow-[var(--shadow-sm)] ${
-        isDone ? 'opacity-70' : ''
-      } ${onOpen ? 'cursor-pointer hover:shadow-[var(--shadow-md)]' : ''}`}
+      className={cn(
+        'flex items-center gap-4 rounded-lg bg-surface p-4 shadow-[var(--shadow-sm)]',
+        isDone && 'opacity-70',
+        onOpen && 'cursor-pointer hover:shadow-[var(--shadow-md)]',
+      )}
     >
       <button
         type="button"
@@ -49,18 +52,17 @@ export const TaskRow = ({ task, assignee, onToggle, isUpdating, updateError, onO
           e.stopPropagation();
           onToggle(task);
         }}
-        className={`flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md border-2 text-xs text-white disabled:opacity-50 ${
-          isDone ? 'border-task-done bg-task-done' : 'border-border bg-surface'
-        }`}
+        className={cn(
+          'flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md border-2 text-xs text-white disabled:opacity-50',
+          isDone ? 'border-task-done bg-task-done' : 'border-border bg-surface',
+        )}
       >
         {isDone && '✓'}
       </button>
 
       <div className="min-w-0 flex-1">
         <p
-          className={`text-sm font-medium ${
-            isDone ? 'text-text-muted line-through' : 'text-text-primary'
-          }`}
+          className={cn('text-sm font-medium', isDone ? 'text-text-muted line-through' : 'text-text-primary')}
         >
           {task.title}
         </p>
@@ -74,9 +76,10 @@ export const TaskRow = ({ task, assignee, onToggle, isUpdating, updateError, onO
         <TaskStatusBadge status={task.status} />
         <AssigneeAvatar assignee={assignee} size="sm" />
         <span
-          className={`w-16 text-right text-xs ${
-            due.isUrgent ? 'font-semibold text-red-500 dark:text-red-400' : isDone ? 'text-text-muted' : 'text-text-secondary'
-          }`}
+          className={cn(
+            'w-16 text-right text-xs',
+            due.isUrgent ? 'font-semibold text-red-500 dark:text-red-400' : isDone ? 'text-text-muted' : 'text-text-secondary',
+          )}
         >
           {due.label}
         </span>

--- a/lined-web/src/features/notifications/bell/NotificationInbox.tsx
+++ b/lined-web/src/features/notifications/bell/NotificationInbox.tsx
@@ -2,6 +2,7 @@ import { CheckCircle2, CalendarPlus, Bell as BellIcon } from 'lucide-react';
 import type { LobbyDto, LobbyInviteDto } from '@/features/lobby/model';
 import type { NotificationDto, NotificationType } from '@/features/notifications/model';
 import { formatRelativeTimeAgo } from '@/features/calendar/lib/calendarUtils';
+import { cn } from '@/lib/utils';
 import { InviteCard } from '../InviteCard';
 
 const TYPE_ICONS: Record<NotificationType, typeof CheckCircle2> = {
@@ -104,9 +105,10 @@ export const NotificationInbox = ({
                   <button
                     type="button"
                     onClick={() => onRowClick(notification)}
-                    className={`flex w-full items-start gap-2.5 px-3 py-2.5 text-left hover:bg-surface-hover ${
-                      isUnread ? 'bg-brand-green-light/40' : ''
-                    }`}
+                    className={cn(
+                      'flex w-full items-start gap-2.5 px-3 py-2.5 text-left hover:bg-surface-hover',
+                      isUnread && 'bg-brand-green-light/40',
+                    )}
                   >
                     <Icon className="mt-0.5 h-4 w-4 flex-shrink-0 text-text-secondary" />
                     <div className="min-w-0 flex-1">

--- a/lined-web/src/features/subscription/PlanCards.tsx
+++ b/lined-web/src/features/subscription/PlanCards.tsx
@@ -2,6 +2,7 @@ import type { PlanDto } from '@/features/subscription/model';
 import { useStartSubscription } from '@/features/subscription/hooks/useSubscriptions';
 import { getApiErrorMessage } from '@/lib/apiErrors';
 import { formatPlanPrice } from '@/features/subscription/lib/subscriptionUtils';
+import { cn } from '@/lib/utils';
 
 interface PlanCardsProps {
   userId: number;
@@ -39,9 +40,10 @@ export const PlanCards = ({ userId, plans, isLoading, currentPlanId }: PlanCards
           return (
             <div
               key={plan.id}
-              className={`relative rounded-xl border-[1.5px] bg-surface p-5 ${
-                isCurrent ? 'border-brand-green' : 'border-border'
-              }`}
+              className={cn(
+                'relative rounded-xl border-[1.5px] bg-surface p-5',
+                isCurrent ? 'border-brand-green' : 'border-border',
+              )}
             >
               {isCurrent && (
                 <span className="absolute right-4 top-4 rounded-full bg-brand-green px-2 py-0.5 text-[10px] font-bold text-white">
@@ -59,11 +61,12 @@ export const PlanCards = ({ userId, plans, isLoading, currentPlanId }: PlanCards
                 type="button"
                 disabled={isCurrent || startSubscription.isPending}
                 onClick={() => startSubscription.mutate(plan.id)}
-                className={`mt-4 h-9 w-full rounded-lg text-sm font-semibold transition-colors disabled:opacity-60 ${
+                className={cn(
+                  'mt-4 h-9 w-full rounded-lg text-sm font-semibold transition-colors disabled:opacity-60',
                   isCurrent
                     ? 'bg-brand-green-light text-brand-green-dark dark:text-brand-green'
-                    : 'bg-brand-green text-white hover:bg-brand-green-dark'
-                }`}
+                    : 'bg-brand-green text-white hover:bg-brand-green-dark',
+                )}
               >
                 {isCurrent ? 'Your plan' : 'Subscribe'}
               </button>

--- a/lined-web/src/features/subscription/SubscriptionHistoryCard.tsx
+++ b/lined-web/src/features/subscription/SubscriptionHistoryCard.tsx
@@ -1,6 +1,7 @@
 import type { SubscriptionDto } from '@/features/subscription/model';
 import { formatPlanPrice, formatShortDate } from '@/features/subscription/lib/subscriptionUtils';
 import { SettingsCard } from '@/features/settings/SettingsCard';
+import { cn } from '@/lib/utils';
 
 interface SubscriptionHistoryCardProps {
   history: SubscriptionDto[] | undefined;
@@ -42,9 +43,10 @@ export const SubscriptionHistoryCard = ({
               </div>
             </div>
             <span
-              className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${
-                sub.active ? 'bg-task-done/10 text-task-done' : 'bg-task-todo/10 text-task-todo'
-              }`}
+              className={cn(
+                'rounded-full px-2.5 py-1 text-[11px] font-semibold',
+                sub.active ? 'bg-task-done/10 text-task-done' : 'bg-task-todo/10 text-task-todo',
+              )}
             >
               {sub.active ? 'ACTIVE' : 'ENDED'}
             </span>

--- a/lined-web/src/features/tasks/TaskDrawer.tsx
+++ b/lined-web/src/features/tasks/TaskDrawer.tsx
@@ -7,6 +7,7 @@ import { useCreateTask, useUpdateTask, useDeleteTask } from '@/features/tasks/ho
 import { useUser, useUsers } from '@/features/users/hooks/useUsers';
 import { TASK_STATUS_LABELS, TASK_PRIORITY_LABELS, TASK_PRIORITY_OPTIONS } from '@/features/tasks/lib/constants';
 import { getApiErrorMessage } from '@/lib/apiErrors';
+import { cn } from '@/lib/utils';
 import { formatShortDate } from '@/features/calendar/lib/calendarUtils';
 import { AuthAlert } from '@/features/auth/AuthAlert';
 import { FormField } from '@/components/FormField';
@@ -316,18 +317,20 @@ export const TaskDrawer = ({
               <button
                 type="button"
                 onClick={onClose}
-                className={`h-10 rounded-lg border border-border bg-surface px-4 text-sm text-text-secondary hover:bg-surface-hover ${
-                  isEditMode ? 'ml-auto' : 'flex-1'
-                }`}
+                className={cn(
+                  'h-10 rounded-lg border border-border bg-surface px-4 text-sm text-text-secondary hover:bg-surface-hover',
+                  isEditMode ? 'ml-auto' : 'flex-1',
+                )}
               >
                 Cancel
               </button>
               <button
                 type="submit"
                 disabled={mutation.isPending}
-                className={`h-10 rounded-lg bg-brand-green px-6 text-sm font-semibold text-white hover:bg-brand-green-dark disabled:opacity-60 transition-colors ${
-                  isEditMode ? '' : 'flex-[2]'
-                }`}
+                className={cn(
+                  'h-10 rounded-lg bg-brand-green px-6 text-sm font-semibold text-white hover:bg-brand-green-dark disabled:opacity-60 transition-colors',
+                  !isEditMode && 'flex-[2]',
+                )}
               >
                 {isEditMode
                   ? mutation.isPending

--- a/lined-web/src/features/tasks/kanban/KanbanCard.tsx
+++ b/lined-web/src/features/tasks/kanban/KanbanCard.tsx
@@ -9,6 +9,7 @@ import { LobbyTypeBadge } from '@/features/lobby/LobbyTypeBadge';
 import { TASK_PRIORITY_COLORS } from '@/features/tasks/lib/constants';
 import { AssigneeAvatar } from '@/components/AssigneeAvatar';
 import { KANBAN_LABELS, KANBAN_TEST_IDS } from './kanbanConstants';
+import { cn } from '@/lib/utils';
 
 export const TASK_DRAG_DATA_FORMAT = 'application/x-lined-task-id';
 
@@ -43,7 +44,7 @@ const DueDateOrDoneIndicator = ({ isDone, dueLabel, isUrgent }: DueDateOrDoneInd
   }
 
   return (
-    <span className={`text-xs ${isUrgent ? 'font-semibold text-red-500 dark:text-red-400' : 'text-text-secondary'}`}>
+    <span className={cn('text-xs', isUrgent ? 'font-semibold text-red-500 dark:text-red-400' : 'text-text-secondary')}>
       Due: {dueLabel}
     </span>
   );
@@ -87,20 +88,20 @@ export const KanbanCard = ({
       draggable
       onDragStart={handleDragStart}
       onDragEnd={() => setIsDragging(false)}
-      className={`flex cursor-grab gap-2.5 rounded-lg bg-surface p-3 shadow-[var(--shadow-sm)] hover:shadow-[var(--shadow-md)] active:cursor-grabbing ${
-        isDone ? 'opacity-75' : ''
-      } ${isDragging ? 'opacity-40' : ''}`}
+      className={cn(
+        'flex cursor-grab gap-2.5 rounded-lg bg-surface p-3 shadow-[var(--shadow-sm)] hover:shadow-[var(--shadow-md)] active:cursor-grabbing',
+        isDone && 'opacity-75',
+        isDragging && 'opacity-40',
+      )}
     >
       <span
-        className={`w-1 self-stretch rounded-full ${TASK_PRIORITY_COLORS[task.priority]}`}
+        className={cn('w-1 self-stretch rounded-full', TASK_PRIORITY_COLORS[task.priority])}
         aria-hidden="true"
       />
 
       <div className="min-w-0 flex-1">
         <p
-          className={`text-sm font-medium ${
-            isDone ? 'text-text-muted line-through' : 'text-text-primary'
-          }`}
+          className={cn('text-sm font-medium', isDone ? 'text-text-muted line-through' : 'text-text-primary')}
         >
           {task.title}
         </p>

--- a/lined-web/src/features/tasks/kanban/KanbanColumn.tsx
+++ b/lined-web/src/features/tasks/kanban/KanbanColumn.tsx
@@ -8,6 +8,7 @@ import { TaskStatusBadge } from '@/features/tasks/TaskStatusBadge';
 import { EmptyState } from '@/components/EmptyState';
 import { KanbanCard, TASK_DRAG_DATA_FORMAT } from './KanbanCard';
 import { KANBAN_LABELS, KANBAN_TEST_IDS, KANBAN_TEXT } from './kanbanConstants';
+import { cn } from '@/lib/utils';
 
 export interface KanbanMoveState {
   movingTaskId: number | null;
@@ -98,16 +99,17 @@ export const KanbanColumn = ({
 
   return (
     <div
-      className={`flex min-w-full flex-1 flex-col snap-center rounded-lg transition-colors md:min-w-[280px] md:snap-align-none ${
-        isDragOver ? 'bg-brand-green-light/60' : ''
-      }`}
+      className={cn(
+        'flex min-w-full flex-1 flex-col snap-center rounded-lg transition-colors md:min-w-[280px] md:snap-align-none',
+        isDragOver && 'bg-brand-green-light/60',
+      )}
       data-testid={KANBAN_TEST_IDS.column(status)}
       onDragOver={handleDragOver}
       onDragLeave={() => setIsDragOver(false)}
       onDrop={handleDrop}
     >
       <div className="mb-3 flex items-center gap-2">
-        <span className={`h-2.5 w-2.5 rounded-full ${TASK_STATUS_COLORS[status]}`} />
+        <span className={cn('h-2.5 w-2.5 rounded-full', TASK_STATUS_COLORS[status])} />
         <span className="text-sm font-semibold text-text-primary">{TASK_STATUS_LABELS[status]}</span>
         <TaskStatusBadge status={status} size="count">{tasks.length}</TaskStatusBadge>
         <button


### PR DESCRIPTION
## Summary
- replace remaining production conditional className templates with cn()
- keep feature logic separate from presentation state
- preserve static Tailwind tokens and existing behavior

## How to use and test
```bash
npm run typecheck
npm run lint
npm run test:run -- src/features/notifications/bell/__tests__/NotificationInbox.test.tsx src/features/tasks/__tests__/TaskDrawer.test.tsx
npm run build
```

Focused regression tests and the production build pass. The full suite retains pre-existing CalendarPage and DashboardPage failures.