### PR TITLE
Make invitation acceptance atomic

### DIFF
--- a/backend/lined/build.gradle
+++ b/backend/lined/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:postgresql'
     testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/backend/lined/docs/api.md
+++ b/backend/lined/docs/api.md
@@ -251,6 +251,10 @@ Only the invitee may accept or decline an invite.
 
 Response: `200 OK` with `LobbyInviteDto`.
 
+Accepting a `PENDING` invite adds the invitee to the lobby and returns an `ACCEPTED` invite.
+Concurrent or sequential retries by the same invitee return `200 OK` with the accepted invite.
+Accepting an invite that has been cancelled or declined returns `409 Conflict`.
+
 ## Tasks
 
 ### `POST /api/tasks`

--- a/backend/lined/src/main/java/io/backend/lined/lobby/invite/domain/LobbyInviteRepository.java
+++ b/backend/lined/src/main/java/io/backend/lined/lobby/invite/domain/LobbyInviteRepository.java
@@ -1,8 +1,12 @@
 package io.backend.lined.lobby.invite.domain;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,4 +20,18 @@ public interface LobbyInviteRepository extends JpaRepository<LobbyInviteEntity, 
 
   List<LobbyInviteEntity> findAllByInvitee_IdAndStatusOrderBySentAtDesc(
       Long inviteeId, LobbyInviteStatus status);
+
+  @Modifying(flushAutomatically = true)
+  @Query("""
+      update LobbyInviteEntity invite
+         set invite.status = io.backend.lined.lobby.invite.domain.LobbyInviteStatus.ACCEPTED,
+             invite.updatedAt = :updatedAt
+       where invite.id = :inviteId
+         and invite.invitee.id = :inviteeId
+         and invite.status = io.backend.lined.lobby.invite.domain.LobbyInviteStatus.PENDING
+      """)
+  int acceptPending(
+      @Param("inviteId") Long inviteId,
+      @Param("inviteeId") Long inviteeId,
+      @Param("updatedAt") OffsetDateTime updatedAt);
 }

--- a/backend/lined/src/main/java/io/backend/lined/lobby/invite/service/LobbyInviteServiceImpl.java
+++ b/backend/lined/src/main/java/io/backend/lined/lobby/invite/service/LobbyInviteServiceImpl.java
@@ -15,6 +15,7 @@ import io.backend.lined.lobby.invite.domain.LobbyInviteStatus;
 import io.backend.lined.lobby.service.LobbyAccessPolicy;
 import io.backend.lined.user.domain.UserEntity;
 import io.backend.lined.user.domain.UserRepository;
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -36,6 +37,7 @@ public class LobbyInviteServiceImpl implements LobbyInviteService {
   private final LobbyInviteRepository inviteRepo;
   private final LobbyInviteMapper mapper;
   private final LobbyAccessPolicy accessPolicy;
+  private final EntityManager entityManager;
 
   @Override
   public LobbyInviteDto create(
@@ -89,10 +91,21 @@ public class LobbyInviteServiceImpl implements LobbyInviteService {
   @Override
   public LobbyInviteDto accept(Long inviteId, Long requesterId) {
     var invite = inviteForInvitee(inviteId, requesterId);
+    if (invite.getStatus() == LobbyInviteStatus.ACCEPTED) {
+      return mapper.toDto(invite);
+    }
     requirePending(invite);
     ensureNotMember(invite.getLobby(), requesterId);
+
+    var now = OffsetDateTime.now();
+    int claimed = inviteRepo.acceptPending(inviteId, requesterId, now);
+    if (claimed == 0) {
+      return resolveConcurrentAcceptance(inviteId);
+    }
+
     invite.getLobby().getMembers().add(invite.getInvitee());
-    transition(invite, LobbyInviteStatus.ACCEPTED);
+    invite.setStatus(LobbyInviteStatus.ACCEPTED);
+    invite.setUpdatedAt(now);
     return mapper.toDto(invite);
   }
 
@@ -145,6 +158,15 @@ public class LobbyInviteServiceImpl implements LobbyInviteService {
     requirePending(invite);
     invite.setStatus(status);
     invite.setUpdatedAt(OffsetDateTime.now());
+  }
+
+  private LobbyInviteDto resolveConcurrentAcceptance(Long inviteId) {
+    entityManager.clear();
+    var latestInvite = mustInvite(inviteId);
+    if (latestInvite.getStatus() == LobbyInviteStatus.ACCEPTED) {
+      return mapper.toDto(latestInvite);
+    }
+    throw new ConflictException("Lobby invite is no longer pending");
   }
 
   private UserEntity resolveInvitee(Long inviteeId, String inviteeEmail) {

--- a/backend/lined/src/test/java/io/backend/lined/lobby/invite/api/LobbyInviteControllerTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/lobby/invite/api/LobbyInviteControllerTest.java
@@ -4,8 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.backend.lined.common.exception.ForbiddenException;
+import io.backend.lined.config.GlobalExceptionHandler;
 import io.backend.lined.lobby.invite.domain.LobbyInviteStatus;
 import io.backend.lined.lobby.invite.service.LobbyInviteService;
 import java.time.OffsetDateTime;
@@ -15,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 @ExtendWith(MockitoExtension.class)
 class LobbyInviteControllerTest {
@@ -23,11 +29,15 @@ class LobbyInviteControllerTest {
   private LobbyInviteService inviteService;
 
   private LobbyInviteController controller;
+  private MockMvc mockMvc;
   private LobbyInviteDto invite;
 
   @BeforeEach
   void setUp() {
     controller = new LobbyInviteController(inviteService);
+    mockMvc = MockMvcBuilders.standaloneSetup(controller)
+        .setControllerAdvice(new GlobalExceptionHandler())
+        .build();
     var now = OffsetDateTime.parse("2026-07-16T10:00:00Z");
     invite = new LobbyInviteDto(501L, 101L, 1L, 2L, LobbyInviteStatus.PENDING,
         now, now, now);
@@ -74,6 +84,18 @@ class LobbyInviteControllerTest {
     when(inviteService.accept(501L, 2L)).thenReturn(invite);
 
     assertThat(controller.accept(501L, 2L)).isEqualTo(invite);
+  }
+
+  @Test
+  void accept_returnsAcceptedInviteForSequentialRetryContract() throws Exception {
+    var accepted = new LobbyInviteDto(501L, 101L, 1L, 2L, LobbyInviteStatus.ACCEPTED,
+        invite.sentAt(), invite.createdAt(), invite.updatedAt());
+    when(inviteService.accept(501L, 2L)).thenReturn(accepted);
+
+    mockMvc.perform(post("/api/lobby-invites/501/accept").header("X-User-Id", "2"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(501))
+        .andExpect(jsonPath("$.status").value("ACCEPTED"));
   }
 
   @Test

--- a/backend/lined/src/test/java/io/backend/lined/lobby/invite/service/LobbyInviteServiceConcurrencyTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/lobby/invite/service/LobbyInviteServiceConcurrencyTest.java
@@ -1,0 +1,157 @@
+package io.backend.lined.lobby.invite.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.backend.lined.lobby.invite.api.LobbyInviteDto;
+import io.backend.lined.lobby.invite.domain.LobbyInviteStatus;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers(disabledWithoutDocker = true)
+class LobbyInviteServiceConcurrencyTest {
+
+  @Container
+  private static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:16-alpine");
+
+  @DynamicPropertySource
+  static void postgresProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+    registry.add("spring.datasource.username", POSTGRES::getUsername);
+    registry.add("spring.datasource.password", POSTGRES::getPassword);
+  }
+
+  @Autowired
+  private LobbyInviteService inviteService;
+
+  @Autowired
+  private PlatformTransactionManager transactionManager;
+
+  @Autowired
+  private JdbcTemplate jdbcTemplate;
+
+  @BeforeEach
+  void setUp() {
+    truncateTables();
+    insertFixtures();
+  }
+
+  @AfterEach
+  void tearDown() {
+    truncateTables();
+  }
+
+  @Test
+  void accept_acceptsExactlyOnce_andReturnsAcceptedInviteToConcurrentRetry() throws Exception {
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      CountDownLatch ready = new CountDownLatch(2);
+      CountDownLatch release = new CountDownLatch(1);
+
+      Callable<LobbyInviteDto> attempt = () -> inTransaction(() -> {
+        ready.countDown();
+        await(ready);
+        await(release);
+        return inviteService.accept(501L, 2L);
+      });
+
+      Future<LobbyInviteDto> first = executor.submit(attempt);
+      Future<LobbyInviteDto> second = executor.submit(attempt);
+
+      assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+      release.countDown();
+
+      LobbyInviteDto firstResult = first.get(10, TimeUnit.SECONDS);
+      LobbyInviteDto secondResult = second.get(10, TimeUnit.SECONDS);
+
+      assertThat(firstResult.status()).isEqualTo(LobbyInviteStatus.ACCEPTED);
+      assertThat(secondResult.status()).isEqualTo(LobbyInviteStatus.ACCEPTED);
+      assertThat(firstResult.id()).isEqualTo(501L);
+      assertThat(secondResult.id()).isEqualTo(501L);
+      assertThat(memberCount()).isEqualTo(2);
+      assertThat(inviteStatus()).isEqualTo("ACCEPTED");
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private <T> T inTransaction(Callable<T> callback) {
+    return new TransactionTemplate(transactionManager).execute(status -> {
+      try {
+        return callback.call();
+      } catch (Exception ex) {
+        throw new IllegalStateException(ex);
+      }
+    });
+  }
+
+  private void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("Timed out waiting for concurrent test latch");
+      }
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted while waiting for concurrent test latch", ex);
+    }
+  }
+
+  private void insertFixtures() {
+    jdbcTemplate.update("""
+        insert into users (id, username, email, password, version, created_at)
+        values (1, 'owner', 'owner@example.com', 'pw', 0, now()),
+               (2, 'invitee', 'invitee@example.com', 'pw', 0, now())
+        """);
+    jdbcTemplate.update("""
+        insert into lobbies (id, name, lobby_type, owner_id, version)
+        values (101, 'Home', 'COUPLE', 1, 0)
+        """);
+    jdbcTemplate.update("insert into lobby_members (lobby_id, user_id) values (101, 1)");
+    jdbcTemplate.update("""
+        insert into lobby_invites
+          (id, lobby_id, inviter_id, invitee_id, status, sent_at, created_at, updated_at)
+        values
+          (501, 101, 1, 2, 'PENDING', now(), now(), now())
+        """);
+  }
+
+  private void truncateTables() {
+    jdbcTemplate.execute("""
+        truncate table
+          lobby_invites,
+          lobby_members,
+          lobbies,
+          users
+        restart identity cascade
+        """);
+  }
+
+  private int memberCount() {
+    Integer count = jdbcTemplate.queryForObject(
+        "select count(*) from lobby_members where lobby_id = 101", Integer.class);
+    return count == null ? 0 : count;
+  }
+
+  private String inviteStatus() {
+    return jdbcTemplate.queryForObject(
+        "select status from lobby_invites where id = 501", String.class);
+  }
+}

--- a/backend/lined/src/test/java/io/backend/lined/lobby/invite/service/LobbyInviteServiceImplTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/lobby/invite/service/LobbyInviteServiceImplTest.java
@@ -20,6 +20,7 @@ import io.backend.lined.lobby.invite.domain.LobbyInviteStatus;
 import io.backend.lined.lobby.service.LobbyAccessPolicy;
 import io.backend.lined.user.domain.UserEntity;
 import io.backend.lined.user.domain.UserRepository;
+import jakarta.persistence.EntityManager;
 import java.time.OffsetDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -45,6 +46,8 @@ class LobbyInviteServiceImplTest {
   private LobbyInviteRepository inviteRepo;
   @Mock
   private LobbyInviteMapper mapper;
+  @Mock
+  private EntityManager entityManager;
   @Spy
   private LobbyAccessPolicy accessPolicy;
 
@@ -202,12 +205,53 @@ class LobbyInviteServiceImplTest {
   @Test
   void accept_addsInviteeAndMarksInviteAccepted() {
     when(inviteRepo.findById(501L)).thenReturn(Optional.of(invite));
+    when(inviteRepo.acceptPending(
+        org.mockito.ArgumentMatchers.eq(501L),
+        org.mockito.ArgumentMatchers.eq(2L),
+        org.mockito.ArgumentMatchers.any(OffsetDateTime.class))).thenReturn(1);
     when(mapper.toDto(invite)).thenReturn(inviteDto);
 
     inviteService.accept(501L, 2L);
 
     assertThat(lobby.getMembers()).contains(owner, invitee);
     assertThat(invite.getStatus()).isEqualTo(LobbyInviteStatus.ACCEPTED);
+  }
+
+  @Test
+  void accept_returnsAcceptedInvite_whenConcurrentRequestAlreadyClaimedIt() {
+    var acceptedInvite = LobbyInviteEntity.builder()
+        .id(501L)
+        .lobby(lobby)
+        .inviter(owner)
+        .invitee(invitee)
+        .status(LobbyInviteStatus.ACCEPTED)
+        .sentAt(invite.getSentAt())
+        .createdAt(invite.getCreatedAt())
+        .updatedAt(invite.getUpdatedAt().plusMinutes(1))
+        .build();
+    var acceptedDto = new LobbyInviteDto(501L, 101L, 1L, 2L, LobbyInviteStatus.ACCEPTED,
+        acceptedInvite.getSentAt(), acceptedInvite.getCreatedAt(), acceptedInvite.getUpdatedAt());
+    when(inviteRepo.findById(501L)).thenReturn(Optional.of(invite), Optional.of(acceptedInvite));
+    when(inviteRepo.acceptPending(
+        org.mockito.ArgumentMatchers.eq(501L),
+        org.mockito.ArgumentMatchers.eq(2L),
+        org.mockito.ArgumentMatchers.any(OffsetDateTime.class))).thenReturn(0);
+    when(mapper.toDto(acceptedInvite)).thenReturn(acceptedDto);
+
+    assertThat(inviteService.accept(501L, 2L)).isEqualTo(acceptedDto);
+    verify(entityManager).clear();
+  }
+
+  @Test
+  void accept_returnsAcceptedInvite_whenAlreadyAcceptedBySameInvitee() {
+    invite.setStatus(LobbyInviteStatus.ACCEPTED);
+    var acceptedDto = new LobbyInviteDto(501L, 101L, 1L, 2L, LobbyInviteStatus.ACCEPTED,
+        invite.getSentAt(), invite.getCreatedAt(), invite.getUpdatedAt());
+    when(inviteRepo.findById(501L)).thenReturn(Optional.of(invite));
+    when(mapper.toDto(invite)).thenReturn(acceptedDto);
+
+    assertThat(inviteService.accept(501L, 2L)).isEqualTo(acceptedDto);
+    verify(inviteRepo, never()).acceptPending(any(), any(), any());
   }
 
   @Test


### PR DESCRIPTION
## Purpose

Make lobby-invitation acceptance an atomic state transition so concurrent accepts cannot both claim a pending invite.

## Type

- [x] 🐛 Bug fix

## Changes

- Atomically claim an invite with a conditional `PENDING -> ACCEPTED` repository update.
- Add membership only after the claim succeeds, in the same transaction.
- Treat concurrent and sequential accepts by the invitee as idempotent `200 OK` retries.
- Document retry and terminal-state behavior in the API reference.
- Add service, endpoint, and PostgreSQL/Testcontainers concurrency regression coverage.

## Files changed

| File | Change |
|------|--------|
| `LobbyInviteRepository` | Added affected-row conditional invite claim. |
| `LobbyInviteServiceImpl` | Added idempotent accept handling and persistence-context refresh for the concurrent loser. |
| Invite tests | Added retry contract and two-transaction PostgreSQL race coverage. |
| `docs/api.md` | Documented repeat-accept semantics. |

## Expected result

Exactly one pending-invite claim and one membership row are persisted. Both same-invitee retries return the accepted invite.

| Metric | Baseline (main) | Branch | Direction |
|--------|----------------|--------|-----------|
| checkstyle_violations | not measured | 0 local violations | neutral |
| spotbugs_total | not measured | existing non-fatal findings | neutral |
| line_coverage | not measured | not measured | unknown |
| critical_violations | not measured | not measured | unknown |
| code_smells | not measured | not measured | unknown |
| duplicated_lines_density | not measured | not measured | unknown |
| **F score** | not measured | not measured | unknown |
| **SonarQube QG** | not measured | not measured | unknown |

## How to use and test

```bash
./gradlew test --tests io.backend.lined.lobby.invite.service.LobbyInviteServiceImplTest --tests io.backend.lined.lobby.invite.api.LobbyInviteControllerTest --tests io.backend.lined.lobby.invite.service.LobbyInviteServiceConcurrencyTest
./gradlew check
```

The Testcontainers race test self-skips when Docker is unavailable. Start Docker and run its focused command to execute the PostgreSQL two-transaction proof.

## Checklist

- [x] `./gradlew check` passes locally
- [x] Focused invitation tests pass locally
- [x] No unintended main business-logic changes
- [x] Branch name matches the scoped bug fix
