### PR TITLE
Prevent stale invitation terminal transitions

### DIFF
--- a/backend/lined/src/main/java/io/backend/lined/lobby/invite/domain/LobbyInviteRepository.java
+++ b/backend/lined/src/main/java/io/backend/lined/lobby/invite/domain/LobbyInviteRepository.java
@@ -34,4 +34,17 @@ public interface LobbyInviteRepository extends JpaRepository<LobbyInviteEntity, 
       @Param("inviteId") Long inviteId,
       @Param("inviteeId") Long inviteeId,
       @Param("updatedAt") OffsetDateTime updatedAt);
+
+  @Modifying(flushAutomatically = true)
+  @Query("""
+      update LobbyInviteEntity invite
+         set invite.status = :status,
+             invite.updatedAt = :updatedAt
+       where invite.id = :inviteId
+         and invite.status = io.backend.lined.lobby.invite.domain.LobbyInviteStatus.PENDING
+      """)
+  int transitionPending(
+      @Param("inviteId") Long inviteId,
+      @Param("status") LobbyInviteStatus status,
+      @Param("updatedAt") OffsetDateTime updatedAt);
 }

--- a/backend/lined/src/main/java/io/backend/lined/lobby/invite/service/LobbyInviteServiceImpl.java
+++ b/backend/lined/src/main/java/io/backend/lined/lobby/invite/service/LobbyInviteServiceImpl.java
@@ -18,6 +18,7 @@ import io.backend.lined.user.domain.UserRepository;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -156,8 +157,12 @@ public class LobbyInviteServiceImpl implements LobbyInviteService {
 
   private void transition(LobbyInviteEntity invite, LobbyInviteStatus status) {
     requirePending(invite);
+    var now = OffsetDateTime.now(ZoneOffset.UTC);
+    if (inviteRepo.transitionPending(invite.getId(), status, now) == 0) {
+      throw new ConflictException("Lobby invite is no longer pending");
+    }
     invite.setStatus(status);
-    invite.setUpdatedAt(OffsetDateTime.now());
+    invite.setUpdatedAt(now);
   }
 
   private LobbyInviteDto resolveConcurrentAcceptance(Long inviteId) {

--- a/backend/lined/src/test/java/io/backend/lined/lobby/invite/service/LobbyInviteServiceConcurrencyTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/lobby/invite/service/LobbyInviteServiceConcurrencyTest.java
@@ -2,8 +2,10 @@ package io.backend.lined.lobby.invite.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.backend.lined.common.exception.ConflictException;
 import io.backend.lined.lobby.invite.api.LobbyInviteDto;
 import io.backend.lined.lobby.invite.domain.LobbyInviteStatus;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -93,10 +95,51 @@ class LobbyInviteServiceConcurrencyTest {
     }
   }
 
+  @Test
+  void accept_andDecline_leaveOneTerminalState_withMembershipMatchingAcceptance() throws Exception {
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      CountDownLatch ready = new CountDownLatch(2);
+      CountDownLatch release = new CountDownLatch(1);
+
+      Future<TransitionResult> acceptance = executor.submit(
+          () -> runTransition(ready, release, () -> inviteService.accept(501L, 2L)));
+      Future<TransitionResult> decline = executor.submit(
+          () -> runTransition(ready, release, () -> inviteService.decline(501L, 2L)));
+
+      assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+      release.countDown();
+
+      assertThat(List.of(acceptance.get(10, TimeUnit.SECONDS), decline.get(10, TimeUnit.SECONDS)))
+          .filteredOn(TransitionResult::succeeded)
+          .hasSize(1);
+      assertThat(inviteStatus()).isIn("ACCEPTED", "DECLINED");
+      assertThat(memberCount()).isEqualTo(inviteStatus().equals("ACCEPTED") ? 2 : 1);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private TransitionResult runTransition(
+      CountDownLatch ready, CountDownLatch release, Callable<LobbyInviteDto> callback) {
+    try {
+      return inTransaction(() -> {
+        ready.countDown();
+        await(ready);
+        await(release);
+        return new TransitionResult(callback.call(), false);
+      });
+    } catch (ConflictException ex) {
+      return new TransitionResult(null, true);
+    }
+  }
+
   private <T> T inTransaction(Callable<T> callback) {
     return new TransactionTemplate(transactionManager).execute(status -> {
       try {
         return callback.call();
+      } catch (RuntimeException ex) {
+        throw ex;
       } catch (Exception ex) {
         throw new IllegalStateException(ex);
       }
@@ -153,5 +196,12 @@ class LobbyInviteServiceConcurrencyTest {
   private String inviteStatus() {
     return jdbcTemplate.queryForObject(
         "select status from lobby_invites where id = 501", String.class);
+  }
+
+  private record TransitionResult(LobbyInviteDto invite, boolean conflicted) {
+
+    private boolean succeeded() {
+      return !conflicted;
+    }
   }
 }

--- a/backend/lined/src/test/java/io/backend/lined/lobby/invite/service/LobbyInviteServiceImplTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/lobby/invite/service/LobbyInviteServiceImplTest.java
@@ -194,12 +194,30 @@ class LobbyInviteServiceImplTest {
   void cancel_marksPendingInviteCancelled() {
     when(lobbyRepo.findById(101L)).thenReturn(Optional.of(lobby));
     when(inviteRepo.findById(501L)).thenReturn(Optional.of(invite));
+    when(inviteRepo.transitionPending(
+        org.mockito.ArgumentMatchers.eq(501L),
+        org.mockito.ArgumentMatchers.eq(LobbyInviteStatus.CANCELLED),
+        any(OffsetDateTime.class))).thenReturn(1);
     when(mapper.toDto(invite)).thenReturn(inviteDto);
 
     inviteService.cancel(101L, 501L, 1L);
 
     assertThat(invite.getStatus()).isEqualTo(LobbyInviteStatus.CANCELLED);
     assertThat(invite.getUpdatedAt()).isAfter(OffsetDateTime.parse("2026-07-16T10:00:00Z"));
+  }
+
+  @Test
+  void cancel_throwsConflict_whenConcurrentAcceptanceAlreadyClaimedInvite() {
+    when(lobbyRepo.findById(101L)).thenReturn(Optional.of(lobby));
+    when(inviteRepo.findById(501L)).thenReturn(Optional.of(invite));
+    when(inviteRepo.transitionPending(
+        org.mockito.ArgumentMatchers.eq(501L),
+        org.mockito.ArgumentMatchers.eq(LobbyInviteStatus.CANCELLED),
+        any(OffsetDateTime.class))).thenReturn(0);
+
+    assertThatThrownBy(() -> inviteService.cancel(101L, 501L, 1L))
+        .isInstanceOf(ConflictException.class)
+        .hasMessageContaining("no longer pending");
   }
 
   @Test
@@ -266,12 +284,29 @@ class LobbyInviteServiceImplTest {
   @Test
   void decline_marksPendingInviteDeclined() {
     when(inviteRepo.findById(501L)).thenReturn(Optional.of(invite));
+    when(inviteRepo.transitionPending(
+        org.mockito.ArgumentMatchers.eq(501L),
+        org.mockito.ArgumentMatchers.eq(LobbyInviteStatus.DECLINED),
+        any(OffsetDateTime.class))).thenReturn(1);
     when(mapper.toDto(invite)).thenReturn(inviteDto);
 
     inviteService.decline(501L, 2L);
 
     assertThat(invite.getStatus()).isEqualTo(LobbyInviteStatus.DECLINED);
     assertThat(lobby.getMembers()).containsExactly(owner);
+  }
+
+  @Test
+  void decline_throwsConflict_whenConcurrentAcceptanceAlreadyClaimedInvite() {
+    when(inviteRepo.findById(501L)).thenReturn(Optional.of(invite));
+    when(inviteRepo.transitionPending(
+        org.mockito.ArgumentMatchers.eq(501L),
+        org.mockito.ArgumentMatchers.eq(LobbyInviteStatus.DECLINED),
+        any(OffsetDateTime.class))).thenReturn(0);
+
+    assertThatThrownBy(() -> inviteService.decline(501L, 2L))
+        .isInstanceOf(ConflictException.class)
+        .hasMessageContaining("no longer pending");
   }
 
   @Test


### PR DESCRIPTION
## Purpose

Fix the remaining invitation lifecycle race discovered while validating `bug/invitation-acceptance-race`. A stale cancellation or decline could overwrite an accepted invite after membership had been committed.

## Type

- [x] 🐛 Bug fix
- [ ] 🧪 Experiment (fitness function research)
- [ ] ✨ Feature (new business logic)
- [ ] ♻️ Refactor / neutral change
- [ ] 📝 Documentation only

## Changes

- Guard cancel and decline with a conditional `PENDING → terminal` update.
- Return `409 Conflict` when another terminal transition has already claimed the invite.
- Add unit coverage for stale cancellation/decline and a PostgreSQL accept-versus-decline race test.

## Files changed

| File | Change |
|------|--------|
| `LobbyInviteRepository` | Added conditional terminal-transition update. |
| `LobbyInviteServiceImpl` | Converts zero-row transition claims into a conflict. |
| Invitation service tests | Covers conflict behavior and atomic terminal outcomes. |

## Expected result

Exactly one terminal invitation transition wins. Membership exists only when acceptance wins; same-invite acceptance retries remain idempotent.

| Metric | Baseline (main) | Branch | Direction |
|--------|----------------|--------|-----------|
| checkstyle_violations | not measured | 0 from passing check | neutral |
| spotbugs_total | not measured | not measured | unknown |
| line_coverage | not measured | not measured | unknown |
| critical_violations | not measured | not measured | unknown |
| code_smells | not measured | not measured | unknown |
| duplicated_lines_density | not measured | not measured | unknown |
| **F score** | not measured | not measured | neutral |
| **SonarQube QG** | not measured | not measured | unknown |

## How to use and test

- Run `./gradlew check`.
- With Docker available, run `./gradlew test --tests io.backend.lined.lobby.invite.service.LobbyInviteServiceConcurrencyTest` to execute the PostgreSQL/Testcontainers race tests. This environment skipped that class because Docker is unavailable.

## Checklist

- [x] ./gradlew check passes locally
- [ ] ./gradlew jacocoTestReport passes locally
- [x] No unintended changes to main business logic
- [x] Branch is scoped to the invitation terminal-transition remediation
