### PR TITLE
docs: plan subscription-billing subsystem as 15 BE + 13 UI tasks

### DIFF
--- a/backend/lined/docs/billing/BILLING_TASKS.md
+++ b/backend/lined/docs/billing/BILLING_TASKS.md
@@ -1,0 +1,169 @@
+# Billing Implementation Task Plan
+
+This plan turns the target architecture defined in
+[`subscription-billing-system-design.md`](../../../..//Downloads/subscription-billing-system-design.md)
+(the design doc, 60 sections) into concrete backend work. It splits the MVP
+into 15 deliverable slices that follow §58 "Recommended Implementation Order"
+of the design.
+
+**For AI agents (Claude Code, Codex, Gemini, etc.):** read the root
+`AGENTS.md` and `backend/lined/CLAUDE.md` first — every rule in there
+applies. Summary: one task per branch/PR using the branch name below; read
+the linked task file fully before coding; respect dependencies; update the
+Status column (`TODO` → `IN PROGRESS` → `DONE`) in the same PR; don't
+expand scope beyond the task file.
+
+## Current state (before this plan)
+
+- `plan/` module: mutable `PlanEntity` + public `POST /api/plans` CRUD
+- `subscription/` module: `POST /api/subscriptions { userId, planId, … }`
+  (trusts client), `POST /api/subscriptions/{userId}/cancel-active`,
+  `GET /api/subscriptions/{userId}/{active|history}`
+- Registration seeds FREE via `AccountApplicationServiceImpl.registerUser`
+- `BuiltInPlan { FREE, PRO, FAMILY }`; `BuiltInRole { USER, ADMIN }` — the
+  ADMIN role is never gate-checked in code
+- Auth is `@RequestHeader("X-User-Id") Long currentUserId` on each
+  controller — no Spring Security filter chain
+- Schema is a single `resources/database/schema.sql` applied by Spring
+  `sql.init` — no Flyway/Liquibase
+- Lobbies have owner + members but **no** archived/read-only fields, and
+  **no** lobby-count or member-count limits are enforced
+
+The design doc's §2 has the same summary with more detail.
+
+## Target module map
+
+```text
+io.backend.lined
+├── billing                  (new)
+│   ├── api          — web / admin / webhook controllers
+│   ├── application  — checkout, subscription, refund, reconciliation, event
+│   ├── domain       — account, plan, price, subscription, transaction, refund, event
+│   ├── port         — provider ports (checkout, subscription, refund, portal, pricing, reconciliation)
+│   └── infrastructure/provider/{sandbox,…}
+├── entitlement              (new)
+│   ├── api          — effective-plan API surface for other modules
+│   ├── application  — resolver, capability checks, limit evaluation
+│   └── domain       — PlanEntitlements, EntitlementCode enum
+├── lobby            (extended)
+│   ├── domain       — lifecycle status, access mode, restriction reason
+│   └── application  — reduction workflow, archive job
+├── user             (touched)   — permission model, BillingAccount owner_user_id back-ref
+├── notification     (touched)   — billing/lobby-lifecycle templates
+└── admin            (extended)  — admin billing operations, audit log
+```
+
+## Conventions for every backend task
+
+- **Layering:** Controller → Service → Repository → Entity. No cross-layer
+  shortcuts. Cross-module calls use explicit contracts or domain events;
+  provider DTOs never leak out of `billing.infrastructure.provider`.
+- **Transactions:** `@Transactional` from `jakarta.transaction`, not
+  Spring's. Never keep a DB transaction open across an external provider
+  call — persist local intent, call provider with idempotency, treat
+  webhook/reconciliation as authoritative correction.
+- **Lookups:** `common.EntityFinder.getOrThrow(...)`; never bare
+  `Optional.get()`.
+- **Exceptions:** `common.exception.NotFoundException` (404),
+  `ConflictException` (409), `BadRequestException` (400),
+  `ForbiddenException` (403), `PreconditionRequiredException` (428).
+  Stable error codes from design §46 must be surfaced by
+  `GlobalExceptionHandler` where the design specifies them.
+- **Persistence:** JPA `FetchType.LAZY` always; enums as
+  `EnumType.STRING`; timestamps as `OffsetDateTime` (UTC in DB) —
+  billing domain-internal timestamps are `java.time.Instant` per design
+  §45, converted at the persistence boundary.
+- **Schema:** append idempotent `CREATE TABLE IF NOT EXISTS` +
+  `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` to
+  `src/main/resources/database/schema.sql` for now (matches project
+  convention). If Flyway/Liquibase is adopted mid-flight, the outstanding
+  billing tasks must be migrated to that tool in one PR — do not mix.
+- **Auth:** every user-facing endpoint reads `X-User-Id` and resolves the
+  BillingAccount from the authenticated principal — never accept a
+  `{userId}` path segment or body field. Admin endpoints additionally
+  require role/permission checks introduced by BE-14.
+- **Idempotency & concurrency:** subscription writes use optimistic
+  locking with a `version` column; webhook processing is deduplicated by
+  `(provider, provider_event_id)`; checkout creation is scoped by
+  `Idempotency-Key`.
+- **Time source:** provider timestamps are canonical for `currentPeriodStart`,
+  `currentPeriodEnd`, refund `occurredAt`. Never compute `plusDays(30)`
+  for a monthly period.
+- **Tests:** every service behaviour has a JUnit 5 unit test; every new
+  table has a Testcontainers-backed repository test; controllers have a
+  `@SpringBootTest`/`@WebMvcTest` counterpart. Do not delete tests to
+  raise coverage; do not suppress SpotBugs without a comment.
+- **Checkstyle:** methods ≤ 50 lines, 2-space indent, braces required.
+- **Sensitive data:** never log card data, raw secret headers, full
+  provider payloads with secrets, or access tokens. Provider event
+  payloads are stored as `JSONB` but logs must be sanitized.
+
+## Task table
+
+| # | Branch name | Task description | Reference | Status |
+|---|---|---|---|---|
+| BE-01 | `feature/be-01-billing-account-effective-plan` | Introduce `BillingAccount` (Personal), backfill for existing users, `EffectivePlanResolver` returning implicit FREE | [tasks/BE-01-billing-account-effective-plan.md](tasks/BE-01-billing-account-effective-plan.md) | TODO |
+| BE-02 | `feature/be-02-entitlement-module-free-limits` | `entitlement` module: `PlanEntitlements` (Free 1×4, Pro 10×20), capability checks, enforce Free limits in lobby create + invite accept | [tasks/BE-02-entitlement-module-free-limits.md](tasks/BE-02-entitlement-module-free-limits.md) | TODO |
+| BE-03 | `feature/be-03-lobby-lifecycle-access-mode` | Lobby lifecycle status + access mode + restriction reason + `archiveAt`; select-as-free / restore / archived-list endpoints | [tasks/BE-03-lobby-lifecycle-access-mode.md](tasks/BE-03-lobby-lifecycle-access-mode.md) | TODO |
+| BE-04 | `feature/be-04-remove-legacy-billing-endpoints` | Remove unsafe prototype endpoints; add secured `GET /api/billing/me` derived from the authenticated principal | [tasks/BE-04-remove-legacy-billing-endpoints.md](tasks/BE-04-remove-legacy-billing-endpoints.md) | TODO |
+| BE-05 | `feature/be-05-billing-catalog-plans-prices` | New `billing_plans` + `billing_prices` catalog with server-side `PriceCode` → `providerPriceId` mapping | [tasks/BE-05-billing-catalog-plans-prices.md](tasks/BE-05-billing-catalog-plans-prices.md) | TODO |
+| BE-06 | `feature/be-06-subscription-schema-state-machine` | `billing_subscriptions` + `billing_provider_customers` tables, entity, optimistic locking, state machine helper | [tasks/BE-06-subscription-schema-state-machine.md](tasks/BE-06-subscription-schema-state-machine.md) | TODO |
+| BE-07 | `feature/be-07-provider-port-abstraction` | Provider port interfaces + canonical DTOs + `BillingProviderCapabilities`; ArchUnit rule blocks provider DTO leakage | [tasks/BE-07-provider-port-abstraction.md](tasks/BE-07-provider-port-abstraction.md) | TODO |
+| BE-08 | `feature/be-08-sandbox-stub-provider-adapter` | Deterministic in-memory sandbox adapter satisfying every port; provider selection matrix (§19.5) documented as TBD | [tasks/BE-08-sandbox-stub-provider-adapter.md](tasks/BE-08-sandbox-stub-provider-adapter.md) | TODO |
+| BE-09 | `feature/be-09-webhook-inbox-signature` | `billing_provider_events` table + `POST /api/billing/webhooks/{provider}` with signature verification, idempotent insert, async processor | [tasks/BE-09-webhook-inbox-signature.md](tasks/BE-09-webhook-inbox-signature.md) | TODO |
+| BE-10 | `feature/be-10-checkout-endpoint-pricing-preview` | `billing_checkout_attempts` + `POST /api/billing/checkout` + `GET /api/billing/prices` + lazy provider-customer creation | [tasks/BE-10-checkout-endpoint-pricing-preview.md](tasks/BE-10-checkout-endpoint-pricing-preview.md) | TODO |
+| BE-11 | `feature/be-11-subscription-lifecycle` | Activation from webhook + cancel/resume/change-price endpoints + PAST_DUE grace/expiration lifecycle | [tasks/BE-11-subscription-lifecycle.md](tasks/BE-11-subscription-lifecycle.md) | TODO |
+| BE-12 | `feature/be-12-downgrade-archive-workflow` | Pro→Free downgrade: excess lobbies READ_ONLY + 30d archive scheduled job + reduction-write whitelist + restore | [tasks/BE-12-downgrade-archive-workflow.md](tasks/BE-12-downgrade-archive-workflow.md) | TODO |
+| BE-13 | `feature/be-13-transactions-refunds-admin` | `billing_transactions` + `billing_refunds` + admin refund preview/issue + `BILLING_REFUND` permission | [tasks/BE-13-transactions-refunds-admin.md](tasks/BE-13-transactions-refunds-admin.md) | TODO |
+| BE-14 | `feature/be-14-admin-billing-api-audit` | Admin search/view/resync/retry-event + `billing_audit_log` + minimal permission model with `@RequiresPermission` interceptor | [tasks/BE-14-admin-billing-api-audit.md](tasks/BE-14-admin-billing-api-audit.md) | TODO |
+| BE-15 | `feature/be-15-reconciliation-outbox-notifications-rollout` | Daily reconciliation + outbox events + notification templates + feature-flag rollout modes + Micrometer metrics + ArchUnit slice test | [tasks/BE-15-reconciliation-outbox-notifications-rollout.md](tasks/BE-15-reconciliation-outbox-notifications-rollout.md) | TODO |
+
+## Suggested implementation order
+
+Following design §58, the safe sequence is:
+
+1. **Foundation (BE-01 → BE-04):** BillingAccount + entitlements + lobby
+   lifecycle + remove the unsafe legacy prototype APIs. Ship each in its
+   own PR; nothing paid exists yet, and after BE-04 the surface is
+   provider-neutral and safe.
+2. **Catalog + subscription domain (BE-05 → BE-06):** persistence for
+   plans, prices, subscriptions, provider mappings.
+3. **Provider seam (BE-07 → BE-08):** define the ports first, then ship a
+   sandbox adapter so BE-09..BE-13 can be developed and tested without a
+   real provider account.
+4. **Money-adjacent surface (BE-09 → BE-11):** webhooks, checkout,
+   pricing preview, subscription lifecycle. Nothing here should be
+   customer-visible until BE-15 flips the rollout flag.
+5. **Consequences (BE-12 → BE-13):** downgrade/archive + refunds.
+6. **Operations (BE-14 → BE-15):** admin surface + reconciliation +
+   observability + rollout. BE-15 gates the whole subsystem behind
+   `billing.rollout.mode`.
+
+## Provider selection
+
+Provider is deliberately **TBD** — see design §5, §19, §56 open decision
+#1. BE-07 defines a provider-agnostic port surface; BE-08 ships an
+in-memory sandbox adapter so every subsequent task is testable without
+provider credentials. The production adapter (Paddle / Stripe / Mono /
+other) is a follow-up task not scheduled here: it re-implements the
+sandbox contract and passes the same test suite from BE-07.
+
+## Definition of Done for the billing MVP
+
+Mirrors design §57. The MVP is complete only when:
+
+- every user has a Personal BillingAccount
+- Free is implicit; Free limits are enforced
+- Pro prices support monthly and yearly
+- checkout is provider-controlled
+- Pro activation requires a verified webhook
+- webhook events are idempotent and auditable
+- cancel/resume/change-price all apply at `currentPeriodEnd`
+- PAST_DUE + 3-day grace + expiration to implicit Free
+- over-limit lobbies are read-only, then archived after 30 days
+- refund administration requires `BILLING_REFUND`
+- daily reconciliation runs; manual resync is available
+- public APIs use authenticated ownership; admin APIs are protected
+- provider contract tests, security tests, and concurrency tests pass
+- audit logs and operational metrics exist
+- legacy direct subscription activation is removed; Family plan is out

--- a/backend/lined/docs/billing/tasks/BE-01-billing-account-effective-plan.md
+++ b/backend/lined/docs/billing/tasks/BE-01-billing-account-effective-plan.md
@@ -1,0 +1,121 @@
+# Task BE-01 — BillingAccount + Effective-Plan Resolver
+
+**Branch:** `feature/be-01-billing-account-effective-plan`
+
+*No dependencies. Foundation task — everything else builds on
+BillingAccount ownership and the resolver's implicit Free fallback.*
+
+## Detailed description
+
+Introduce the `BillingAccount` aggregate so paid billing state is owned by
+a commercial account, not directly by `UserEntity`. Add an
+`EffectivePlanResolver` that returns `PlanCode.FREE` whenever no valid
+paid subscription exists (implicit Free — the design's ADR-002). Do not
+persist a Free subscription row.
+
+Scope:
+
+1. New `billing/domain/account/` package with `BillingAccountEntity`
+   (`id`, `owner_user_id`, `type=PERSONAL`, `status=ACTIVE`, `version`,
+   `createdAt`, `updatedAt`).
+2. Unique constraint on `(owner_user_id, type)` — one Personal account
+   per user.
+3. New `billing/domain/plan/PlanCode` enum: `FREE`, `PRO` (no `FAMILY`).
+4. New `billing/application/EffectivePlanResolver` returning `PlanCode`
+   from a `BillingAccountId` + `Instant now`. Consult the subscription
+   repository added in BE-06 through a repository port that is
+   temporarily backed by a stub returning empty until BE-06 lands — this
+   task delivers the resolver contract and its unit tests.
+5. Registration: `AccountApplicationServiceImpl.registerUser` also
+   creates a Personal BillingAccount for the new user (idempotent by
+   `(owner_user_id, PERSONAL)`).
+6. Backfill: a one-time idempotent migration seed (SQL block in
+   `schema.sql`) creates a Personal BillingAccount for every existing
+   user that lacks one — `INSERT ... SELECT ... WHERE NOT EXISTS`.
+7. No public REST endpoint is added; `GET /api/billing/me` lands in
+   BE-04.
+
+## Design references
+
+- §5 Confirmed Product Decisions — owner is BillingAccount, initial type
+  Personal
+- §6.2 Domain Language — BillingAccount
+- §11 Core Domain Model — BillingAccount + User relations
+- §12.1 `billing_accounts` schema
+- §16 Effective Plan Resolution
+- §48 Migration from the Prototype (backfill)
+- ADR-001, ADR-002
+
+## Idea of this task
+
+Every commercial concept in the system attaches to `BillingAccount`.
+Getting that entity — with its uniqueness invariant and its resolver
+that treats absence as Free — right and shipped first means BE-02..BE-15
+can plug into a stable boundary. Backfilling existing users idempotently
+lets subsequent tasks assume `BillingAccount` always exists for any
+authenticated user.
+
+## Development steps
+
+1. Append the `billing_accounts` table to
+   `src/main/resources/database/schema.sql` (idempotent
+   `CREATE TABLE IF NOT EXISTS`, unique index on `(owner_user_id, type)`).
+2. Append the backfill `INSERT ... SELECT ... WHERE NOT EXISTS` block.
+3. Add package `io.backend.lined.billing.domain.account`:
+   `BillingAccountEntity`, `BillingAccountRepository`,
+   `BillingAccountType`, `BillingAccountStatus`.
+4. Add package `io.backend.lined.billing.domain.plan`: `PlanCode` enum.
+5. Add package `io.backend.lined.billing.application`:
+   `EffectivePlanResolver`, `PaidSubscriptionLookupPort` (interface),
+   `NoOpPaidSubscriptionLookup` (default implementation returning
+   `Optional.empty()` until BE-06).
+6. Wire `AccountApplicationServiceImpl.registerUser` to also call
+   `BillingAccountService.ensurePersonalAccount(userId)` inside the same
+   `@Transactional` boundary.
+7. Add `BillingAccountService.getByOwnerUserId(userId)` for future
+   callers (BE-04).
+8. Tests (see "Tests to add" below).
+9. Run `./gradlew test checkstyleMain spotbugsMain`.
+
+## Final / expected result
+
+- Every existing user has exactly one Personal BillingAccount after
+  application startup.
+- Registering a new user creates their Personal BillingAccount in the
+  same transaction as the user row; no partial state on failure.
+- `EffectivePlanResolver.resolve(accountId, now)` returns `FREE` for
+  every account today (BE-06 will change the underlying lookup).
+- No new HTTP surface added; no user-visible change.
+- `./gradlew test`, `./gradlew checkstyleMain`, `./gradlew spotbugsMain`
+  pass.
+
+## REST API added / changed
+
+None — see BE-04 for `GET /api/billing/me`.
+
+## Tests to add
+
+- **Unit — `EffectivePlanResolverTest`**: given the stub lookup returns
+  empty → resolves to `FREE`; given a stub with a subscription whose
+  `currentPeriodEnd` is in the past → resolves to `FREE`; given an
+  active subscription with `currentPeriodEnd > now` → resolves to `PRO`
+  (uses a synthetic `PaidSubscription` DTO exposed by the port).
+- **Unit — `BillingAccountServiceTest`**: `ensurePersonalAccount` is
+  idempotent (second call returns the existing account, does not throw
+  on unique-index conflict).
+- **Integration (Testcontainers) — `BillingAccountRepositoryIT`**:
+  unique constraint on `(owner_user_id, PERSONAL)` blocks duplicate
+  inserts; backfill SQL produces exactly one row per user.
+- **Integration — `AccountApplicationServiceRegistrationIT`**:
+  registration creates the user and the Personal BillingAccount
+  atomically; when the account insert fails, the user row is rolled
+  back.
+
+## Risk & follow-ups
+
+- Backfill is written as raw SQL in `schema.sql`; if/when Flyway or
+  Liquibase is introduced, migrate this block first.
+- BE-06 replaces `NoOpPaidSubscriptionLookup` with a real
+  `SubscriptionRepository`-backed implementation. Until then the
+  resolver still ships and everyone is on Free — which matches production
+  reality until checkout goes live.

--- a/backend/lined/docs/billing/tasks/BE-02-entitlement-module-free-limits.md
+++ b/backend/lined/docs/billing/tasks/BE-02-entitlement-module-free-limits.md
@@ -1,0 +1,123 @@
+# Task BE-02 — Entitlement Module + Free Limit Enforcement
+
+**Branch:** `feature/be-02-entitlement-module-free-limits`
+
+*Depends on BE-01 (BillingAccount + EffectivePlanResolver). Before
+BE-04 removes the legacy endpoints, so that any new authenticated
+principals immediately land on the enforced Free tier.*
+
+## Detailed description
+
+Create the `entitlement` module (as its own top-level package,
+`io.backend.lined.entitlement`) and enforce the Free/Pro capability
+matrix from design §17 across the lobby module.
+
+Scope:
+
+1. `entitlement/domain/PlanEntitlements` record: `lobbiesMax`,
+   `lobbyMembersMax`, `calendarIntegrationEnabled`,
+   `remindersEnabled`, `freeSlotDetectionEnabled`.
+2. `entitlement/domain/EntitlementCode` enum: `LOBBIES_MAX`,
+   `LOBBY_MEMBERS_MAX`, `CALENDAR_INTEGRATION_ENABLED`,
+   `REMINDERS_ENABLED`, `FREE_SLOT_DETECTION_ENABLED`.
+3. `entitlement/application/EntitlementService` with a
+   version-controlled config object:
+   - `FREE = new PlanEntitlements(1, 4, false, true, true)`
+   - `PRO  = new PlanEntitlements(10, 20, true, true, true)`
+4. `entitlement/application/EntitlementService.getEntitlements(BillingAccountId)`
+   composes with `EffectivePlanResolver` from BE-01.
+5. `entitlement/application/LimitEvaluator`:
+   `assertCanCreateLobby(ownerUserId)` counts owned active lobbies and
+   throws `ConflictException` with code `LOBBY_LIMIT_EXCEEDED` when
+   `count >= entitlements.lobbiesMax()`.
+6. `LimitEvaluator.assertCanAcceptInvite(lobbyId)` counts current
+   members and throws `ConflictException` with code
+   `LOBBY_MEMBER_LIMIT_EXCEEDED` when
+   `count >= ownerEntitlements.lobbyMembersMax()`.
+7. Wire `assertCanCreateLobby` into `LobbyServiceImpl.create` (before
+   persisting the new lobby) and `assertCanAcceptInvite` into
+   `LobbyInviteServiceImpl.accept`.
+8. Stable error codes surfaced via `GlobalExceptionHandler` from design
+   §46 — extend the exception body to include the `code` field on
+   `ConflictException`.
+
+## Design references
+
+- §7.3 Entitlement Module responsibilities
+- §17 Plan and Entitlement Model (matrix, `PlanEntitlements` record,
+  entitlement vs. flag vs. authorization vs. usage distinction)
+- §29 Read-Only Lobby Operations (limits are the trigger)
+- §46 Error Model (`LOBBY_LIMIT_EXCEEDED`,
+  `LOBBY_MEMBER_LIMIT_EXCEEDED`)
+
+## Idea of this task
+
+Free must actually restrict what a user can do — otherwise there is no
+value in Pro. Centralizing the matrix in one module means later product
+changes (a new Pro capability, a limit change) touch one file, not
+scattered `if` statements in the lobby/task/notification modules. It
+also means BE-15's feature-flag gate can only ever add restrictions on
+top of a coherent baseline.
+
+## Development steps
+
+1. Create the `entitlement` package tree.
+2. Define `PlanEntitlements` and static `FREE` / `PRO` constants.
+3. Implement `EntitlementService` and `LimitEvaluator`; the evaluator
+   depends on `LobbyRepository.countActiveOwnedBy(userId)` — add that
+   method if it doesn't exist (return owned lobbies with
+   `lifecycleStatus = ACTIVE`, which BE-03 introduces; for now count all
+   owned lobbies).
+4. Extend `common.exception.ConflictException` (and the base
+   `BaseAppException`) with an optional `errorCode` string; wire
+   `GlobalExceptionHandler` to include it in the response body.
+5. Wire `LobbyServiceImpl.create` to call
+   `limitEvaluator.assertCanCreateLobby(currentUserId)` before persist.
+6. Wire `LobbyInviteServiceImpl.accept` to call
+   `limitEvaluator.assertCanAcceptInvite(lobbyId)` before the invite is
+   marked accepted / member is added.
+7. Tests.
+8. Run `./gradlew test checkstyleMain spotbugsMain`.
+
+## Final / expected result
+
+- A Free user cannot own more than 1 lobby; the 2nd create returns
+  `409 LOBBY_LIMIT_EXCEEDED`.
+- A Free-owned lobby cannot exceed 4 members; the 5th accepted invite
+  returns `409 LOBBY_MEMBER_LIMIT_EXCEEDED`.
+- Pro-owned entitlements allow 10 / 20 respectively.
+- No change to any existing test's happy-path fixtures whose lobbies
+  stay under the Free limits.
+- `./gradlew test`, `./gradlew checkstyleMain`, `./gradlew spotbugsMain`
+  pass.
+
+## REST API added / changed
+
+None. This task changes the semantics of two existing endpoints
+(`POST /api/lobbies`, `POST /api/lobby-invites/{id}/accept`) — the
+error-code surface is documented for UI-45.
+
+## Tests to add
+
+- **Unit — `EntitlementServiceTest`**: returns FREE matrix when
+  `EffectivePlanResolver` returns FREE; returns PRO matrix when it
+  returns PRO.
+- **Unit — `LimitEvaluatorTest`**: allows 1st lobby on Free, rejects
+  2nd; allows 4-member invite accept on Free, rejects 5th; allows 10th
+  lobby / 20th member on Pro; rejects 11th / 21st.
+- **Integration — `LobbyServiceCreateLimitIT`** (Testcontainers): user
+  owning 1 lobby cannot create a 2nd (409 with code).
+- **Integration — `LobbyInviteAcceptLimitIT`**: 5th accept against a
+  Free-owned 4-member lobby returns 409 with code.
+- **Controller — `LobbyControllerLimitTest`**: end-to-end 409 body
+  shape includes `code` field.
+
+## Risk & follow-ups
+
+- BE-01's resolver still returns FREE for everyone until BE-06 wires
+  real subscriptions in. That means when BE-02 lands, existing users
+  who own >1 lobby will not be forced to reduce — the check only fires
+  on **new** creates. The 30-day reduction workflow is BE-12; do not
+  retroactively reduce here.
+- Pro entitlements list matches design §17.1; if product changes limits
+  before checkout goes live, update the constants in one place.

--- a/backend/lined/docs/billing/tasks/BE-03-lobby-lifecycle-access-mode.md
+++ b/backend/lined/docs/billing/tasks/BE-03-lobby-lifecycle-access-mode.md
@@ -1,0 +1,154 @@
+# Task BE-03 — Lobby Lifecycle Status + Access Mode
+
+**Branch:** `feature/be-03-lobby-lifecycle-access-mode`
+
+*Depends on BE-02 (entitlement module). Prepares the lobby domain for
+the downgrade/archive workflow in BE-12; ships the endpoints the UI
+(UI-44, UI-45, UI-46) will call.*
+
+## Detailed description
+
+Extend `LobbyEntity` with the lifecycle + access-mode fields required by
+design §28 and add the three lobby endpoints from §38. Enforce read-only
+in every write path with a stable error code.
+
+Scope:
+
+1. Add columns to `lobbies`:
+   - `lifecycle_status VARCHAR NOT NULL DEFAULT 'ACTIVE'` — enum
+     `ACTIVE`, `ARCHIVED`, `DELETED`
+   - `access_mode VARCHAR NOT NULL DEFAULT 'READ_WRITE'` — enum
+     `READ_WRITE`, `READ_ONLY`
+   - `restriction_reason VARCHAR NOT NULL DEFAULT 'NONE'` — enum
+     `NONE`, `OWNER_PLAN_LIMIT_EXCEEDED`, `MEMBER_LIMIT_EXCEEDED`,
+     `BILLING_GRACE_EXPIRED`
+   - `archive_at TIMESTAMPTZ NULL`
+   - `selected_as_free_at TIMESTAMPTZ NULL`
+2. Corresponding Java enums under
+   `lobby/domain/{LobbyLifecycleStatus,LobbyAccessMode,LobbyRestrictionReason}`.
+3. `LobbyServiceImpl` write paths (`update`, `removeMember` for non-owner
+   uses, task/event mutations, invite creation, etc.) call a new
+   `LobbyWritePolicy.assertWritable(lobby, WriteAction)` helper that
+   throws `ConflictException` with code
+   `LOBBY_READ_ONLY_DUE_TO_PLAN` when
+   `accessMode == READ_ONLY` unless the action is on the reduction
+   whitelist (see step 4).
+4. `WriteAction` enum whitelist (allowed on read-only lobbies):
+   `REMOVE_MEMBER`, `DELETE_LOBBY`, `LEAVE_LOBBY`,
+   `SELECT_AS_FREE_LOBBY`.
+5. New endpoint `POST /api/lobbies/{lobbyId}/select-as-free`:
+   - requires ownership (`LobbyAccessPolicy.ensureOwner`)
+   - requires current effective plan is Free
+     (`EntitlementService.getEntitlements(...).lobbiesMax() == 1`)
+   - requires `memberCount ≤ 4`; otherwise 409
+     `LOBBY_MEMBER_LIMIT_EXCEEDED` with a hint to remove members
+   - clears any other lobby previously flagged
+     `selected_as_free_at` for this owner
+   - flips the target lobby's `access_mode` to `READ_WRITE`,
+     `restriction_reason=NONE`, sets `selected_as_free_at=now`,
+     `archive_at=NULL`
+6. New endpoint `POST /api/lobbies/{lobbyId}/restore`:
+   - requires ownership
+   - requires `lifecycle_status = ARCHIVED`
+   - runs `EntitlementService`/`LimitEvaluator` capacity check
+   - on success: `lifecycle_status=ACTIVE`, `access_mode=READ_WRITE`,
+     `restriction_reason=NONE`, `archive_at=NULL`
+   - on capacity failure: 409 `LOBBY_LIMIT_EXCEEDED`
+7. Extend `GET /api/lobbies/mine` and `GET /api/lobbies/{id}` to include
+   the new fields in the DTO.
+8. New query: `GET /api/lobbies?lifecycleStatus=ARCHIVED` returns
+   archived lobbies where the caller is a member or the owner (owner
+   sees all their own; non-owner members see ones they belong to).
+
+## Design references
+
+- §28 Downgrade and Over-Limit Resource Policy
+- §28.3 Lobby state model (enums)
+- §29 Read-Only Lobby Operations (whitelist)
+- §29.4 API error `LOBBY_READ_ONLY_DUE_TO_PLAN`
+- §30 Archived Lobby Policy
+- §38 Lobby API Additions
+- §46 Error Model
+
+## Idea of this task
+
+BE-12 is the workflow; BE-03 is the vocabulary. Landing the columns,
+enums, endpoints, and read-only guard first means BE-12 can focus on
+the reduction/archival mechanics without touching the entity model.
+Every UI billing task that touches lobbies (UI-44/45/46) depends on
+this shape being live.
+
+## Development steps
+
+1. Append `ALTER TABLE lobbies ADD COLUMN IF NOT EXISTS ...` for each of
+   the five columns to `schema.sql`.
+2. Add the three enums under `lobby/domain/`.
+3. Extend `LobbyEntity` (fields, getters, protected setters); update
+   `LobbyMapper` DTOs.
+4. Add `LobbyWriteAction` enum + `LobbyWritePolicy` helper; wire into
+   every mutating service method (create is skipped — new lobbies are
+   always READ_WRITE).
+5. Update the existing invite-flow, task, and event write paths that
+   currently call the lobby to also pass through
+   `LobbyWritePolicy.assertWritable` (this only affects lobbies that
+   BE-12 will later flip to READ_ONLY; nothing changes for today's
+   ACTIVE READ_WRITE lobbies).
+6. Add `LobbyController` endpoints for `select-as-free`, `restore`, and
+   the archived-list query.
+7. Update `LobbyRepository` with a `findByOwnerAndSelectedAsFree` helper
+   used by `select-as-free` to clear the previous selection.
+8. Tests.
+9. Run `./gradlew test checkstyleMain spotbugsMain`.
+
+## Final / expected result
+
+- Existing lobbies migrate cleanly: every row lands with
+  `lifecycle_status=ACTIVE`, `access_mode=READ_WRITE`,
+  `restriction_reason=NONE`, `archive_at=NULL`. No behavior change for
+  users whose plan is Pro-equivalent or under Free limits.
+- Read-only lobbies (which nothing yet creates) reject normal writes
+  with 409 `LOBBY_READ_ONLY_DUE_TO_PLAN` but accept the 4 reduction
+  actions.
+- `select-as-free` and `restore` endpoints work as specified and 409
+  with stable codes on validation failure.
+- Archived list query respects membership boundaries.
+- `./gradlew test`, `./gradlew checkstyleMain`, `./gradlew spotbugsMain`
+  pass.
+
+## REST API added / changed
+
+| Purpose | Method + Path |
+|---|---|
+| Select the Free lobby after downgrade | `POST /api/lobbies/{lobbyId}/select-as-free` |
+| Restore an archived lobby | `POST /api/lobbies/{lobbyId}/restore` |
+| List archived lobbies | `GET /api/lobbies?lifecycleStatus=ARCHIVED` |
+| DTO change | `GET /api/lobbies/mine`, `GET /api/lobbies/{id}` now include `lifecycleStatus`, `accessMode`, `restrictionReason`, `archiveAt`, `selectedAsFreeAt` |
+
+## Tests to add
+
+- **Unit — `LobbyWritePolicyTest`**: READ_WRITE allows every action;
+  READ_ONLY blocks non-whitelist writes with
+  `LOBBY_READ_ONLY_DUE_TO_PLAN`; READ_ONLY allows all four whitelist
+  actions.
+- **Unit — `SelectAsFreeServiceTest`**: rejects when effective plan is
+  Pro; rejects when the target has 5+ members; clears the previous
+  selection; success flips fields.
+- **Integration — `LobbyLifecycleMigrationIT`**: existing lobbies get
+  the correct defaults; new columns are non-null after migration.
+- **Controller — `LobbyControllerSelectAsFreeTest`**: 200 on happy path;
+  409 (`LOBBY_MEMBER_LIMIT_EXCEEDED`) when too many members; 403 when
+  caller is not owner; 404 when lobby not found.
+- **Controller — `LobbyControllerRestoreTest`**: 200 on happy path; 409
+  (`LOBBY_LIMIT_EXCEEDED`) when Pro capacity would be exceeded.
+- **Controller — `ArchivedLobbiesListTest`**: owner sees all their
+  archived; a member sees only their own.
+
+## Risk & follow-ups
+
+- BE-12 owns the code that actually **sets** `access_mode=READ_ONLY` on
+  downgrade and the daily job that archives. Until BE-12 lands, the
+  read-only path exists but is only reachable via a manual DB update
+  during testing.
+- Coordinate with any in-flight lobby PR: the DTO shape changes are
+  additive but every consumer must be updated in the same PR that
+  ships.

--- a/backend/lined/docs/billing/tasks/BE-04-remove-legacy-billing-endpoints.md
+++ b/backend/lined/docs/billing/tasks/BE-04-remove-legacy-billing-endpoints.md
@@ -1,0 +1,138 @@
+# Task BE-04 — Remove Legacy Billing Endpoints + `GET /api/billing/me`
+
+**Branch:** `feature/be-04-remove-legacy-billing-endpoints`
+
+*Depends on BE-01 (BillingAccount + resolver) and BE-02 (entitlement
+module). Blocks UI-38 (which reads `/api/billing/me`).*
+
+## Detailed description
+
+The prototype APIs let the client name any `userId` and activate any
+plan locally without a payment. Design §41.1 forbids this. This task
+removes the unsafe surface and replaces it with a single authenticated
+`GET /api/billing/me` derived from `X-User-Id`.
+
+Scope:
+
+1. Delete or gate as ADMIN-only the following endpoints in
+   `PlanController`:
+   - `POST /api/plans` — deleted (catalog moves under BE-05, admin-only)
+   - `PUT /api/plans/{id}` — deleted
+   - `DELETE /api/plans/{id}` — deleted
+   - `GET /api/plans` — **kept for now** but returns nothing paid-related
+     (drops price / duration fields from the DTO); UI-38 will stop
+     calling it. Fully removed by BE-05.
+2. Delete the following endpoints in `SubscriptionController`:
+   - `POST /api/subscriptions`
+   - `POST /api/subscriptions/{userId}/cancel-active`
+   - `GET /api/subscriptions/{userId}/active`
+   - `GET /api/subscriptions/{userId}/history`
+3. Delete `SubscriptionServiceImpl` local-activation logic (the code
+   that persists a `user_subscriptions` row on POST). Keep the entity +
+   repository for now so existing FREE rows created at registration are
+   still readable; BE-15's migration report will drop the table.
+4. Update `AccountApplicationServiceImpl.registerUser` to stop creating
+   a `user_subscriptions` FREE row on new registrations. BillingAccount
+   creation (from BE-01) remains; Free is implicit.
+5. Add `billing/api/web/BillingController` exposing:
+   - `GET /api/billing/me` → response body:
+     ```json
+     {
+       "billingAccountId": "<uuid|long>",
+       "effectivePlan": "FREE" | "PRO",
+       "subscription": null,
+       "limits": {
+         "lobbiesMax": 1,
+         "lobbyMembersMax": 4
+       }
+     }
+     ```
+   - The `subscription` field stays `null` in this task — BE-11 fills
+     it in once real subscriptions exist. The response object shape is
+     fixed now so UI-38 can render against a stable contract.
+6. Response body is derived only from the authenticated principal —
+   never from a query/path/body field.
+
+## Design references
+
+- §37.1 `GET /api/billing/me`
+- §41.1 User ownership
+- §46 Error Model
+- §48.2 Phase 4: Remove unsafe APIs
+- §48.2 Phase 3: Switch access logic to `EffectivePlanResolver`
+- ADR-004
+
+## Idea of this task
+
+Every subsequent billing endpoint (checkout, cancel, resume, …) will
+follow the same "authenticated principal → BillingAccount → domain
+action" pattern. Landing `/api/billing/me` first — with the legacy
+holes closed in the same PR — means UI-38 has a real endpoint to render
+and no other task has to work around the legacy `userId`-in-path
+pattern.
+
+## Development steps
+
+1. Add `BillingController` under `billing/api/web/` with a single
+   `@GetMapping("/api/billing/me")` method returning `BillingMeDto`.
+   Body derived via
+   `billingAccountService.getByOwnerUserId(currentUserId)` +
+   `entitlementService.getEntitlements(...)` +
+   `effectivePlanResolver.resolve(...)`.
+2. Add `BillingMeDto`, `BillingSubscriptionDto` (nullable),
+   `BillingLimitsDto` records under `billing/api/web/dto/`.
+3. Delete the four `SubscriptionController` endpoints and the local
+   activation code they call. Keep `UserSubscriptionRepository` and
+   the entity temporarily.
+4. Delete the three write endpoints on `PlanController`; slim its DTO
+   (drop `priceUsd`, `durationDays`) — BE-05 replaces the whole
+   endpoint.
+5. Remove the `subscriptionService.start(...)` call from
+   `AccountApplicationServiceImpl.registerUser`; keep the
+   `billingAccountService.ensurePersonalAccount(...)` call from BE-01.
+6. Update any existing test whose fixture relied on the legacy
+   endpoints — most will just drop the pre-condition setup.
+7. Tests.
+8. Run `./gradlew test checkstyleMain spotbugsMain`.
+
+## Final / expected result
+
+- `GET /api/billing/me` returns `effectivePlan=FREE` and Free limits
+  for every existing and newly-registered user.
+- The four legacy subscription endpoints and three plan write
+  endpoints return `404` (unmapped) — not `500`.
+- Registering a new user does not touch `user_subscriptions`.
+- Every existing integration test either passes unchanged or has its
+  legacy fixture removed with no functional impact.
+- `./gradlew test`, `./gradlew checkstyleMain`, `./gradlew spotbugsMain`
+  pass.
+
+## REST API added / changed
+
+| Purpose | Method + Path |
+|---|---|
+| Current billing state | `GET /api/billing/me` (new; derives everything from `X-User-Id`) |
+| Removed | `POST /api/subscriptions`, `POST /api/subscriptions/{userId}/cancel-active`, `GET /api/subscriptions/{userId}/active`, `GET /api/subscriptions/{userId}/history` |
+| Removed | `POST /api/plans`, `PUT /api/plans/{id}`, `DELETE /api/plans/{id}` |
+
+## Tests to add
+
+- **Controller — `BillingControllerMeTest`**:
+  - 200 with `effectivePlan=FREE`, `subscription=null`, Free limits for
+    a user with no paid subscription
+  - 401/403 (whichever the app returns) when `X-User-Id` header is
+    missing
+  - Response never echoes an incoming query/body `userId` — attempt to
+    pass one is ignored
+- **Controller — `LegacyBillingEndpointsRemovedTest`**: 404 for each
+  removed path (using `MockMvc`).
+- **Integration — `RegistrationNoSubscriptionRowIT`**: after
+  registration, `user_subscriptions` has 0 rows for the new user.
+
+## Risk & follow-ups
+
+- Anything else (mobile, scripts) calling the old endpoints will 404.
+  Coordinate the deploy with the UI-38 rollout so the web app is
+  updated at the same time.
+- `user_subscriptions` table stays for one release for rollback
+  investigation, then BE-15 drops it as part of the migration cleanup.

--- a/backend/lined/docs/billing/tasks/BE-05-billing-catalog-plans-prices.md
+++ b/backend/lined/docs/billing/tasks/BE-05-billing-catalog-plans-prices.md
@@ -1,0 +1,116 @@
+# Task BE-05 — Billing Catalog (Plans + Prices)
+
+**Branch:** `feature/be-05-billing-catalog-plans-prices`
+
+*Depends on BE-04 (legacy endpoints removed). Precedes BE-06
+(subscription references `price_code`) and BE-10 (checkout resolves
+`PriceCode` → `providerPriceId` server-side).*
+
+## Detailed description
+
+Introduce the target catalog schema and enforce a server-side
+`PriceCode` → `providerPriceId` mapping so the frontend can never
+influence the amount, currency, or provider price identifier.
+
+Scope:
+
+1. New tables:
+   - `billing_plans` (`code` PK, `display_name`, `active`,
+     `created_at`, `updated_at`) — seed rows `FREE`, `PRO`
+   - `billing_prices` (`code` PK, `plan_code` FK,
+     `billing_interval` enum `MONTH|YEAR`, `provider`, `provider_price_id`,
+     `active`, `created_at`, `updated_at`) — seed rows `PRO_MONTHLY`,
+     `PRO_YEARLY` with `provider='sandbox'` and stub
+     `provider_price_id` values so BE-08 can hand them out
+2. Enums under `billing/domain/plan/`: `PlanCode` (already added in
+   BE-01), `BillingInterval`, `PriceCode`.
+3. Entities + repositories: `PlanCatalogEntity`, `PriceCatalogEntity`,
+   `PlanCatalogRepository`, `PriceCatalogRepository`.
+4. `PricingCatalogService`:
+   - `getActivePrices(PlanCode)` — returns active `PriceCatalogEntity`
+     rows for that plan
+   - `requireProviderPriceId(PriceCode)` — throws
+     `ConflictException("PRICE_NOT_AVAILABLE")` if `active=false` or
+     missing
+5. Delete the old `PlanController` and `PlanServiceImpl` completely;
+   remove the `plans` table from `schema.sql` (add a `DROP TABLE IF
+   EXISTS plans` in the migration section — old table was already
+   effectively dead after BE-04).
+6. Remove `plan/` module.
+7. No public endpoint added here — pricing preview lives in BE-10.
+
+## Design references
+
+- §12.3 `billing_plans`
+- §12.4 `billing_prices`
+- §41.2 Price integrity
+- §48.2 Phase 5 Remove legacy data
+
+## Idea of this task
+
+The frontend must never send an amount, currency, or provider price
+identifier. Keeping the catalog server-side with a small, admin-managed
+allowlist means checkout requests take only a stable internal `PriceCode`
+that maps to something the provider recognizes. Deleting the old
+mutable `plans` table + `PlanController` in the same PR ensures no path
+back to the prototype.
+
+## Development steps
+
+1. Append DDL for `billing_plans` and `billing_prices` +
+   `INSERT ... ON CONFLICT DO NOTHING` seed rows to `schema.sql`.
+2. Append `DROP TABLE IF EXISTS plans` to `schema.sql` after the new
+   tables are created and seeded.
+3. Add the enums under `billing/domain/plan/`.
+4. Add entities + repositories.
+5. Add `PricingCatalogService` with the two methods above.
+6. Delete the `plan/` module (`PlanEntity`, `PlanRepository`,
+   `PlanController`, `PlanServiceImpl`, `PlanMapper`, DTOs). Update
+   `AccountProvisioningPolicy` / `AccountProvisioningSpec` to stop
+   referencing plan names — BE-01 already made BillingAccount
+   creation independent of plan lookup, but the properties block may
+   still name a plan; drop that.
+7. Tests.
+8. Run `./gradlew test checkstyleMain spotbugsMain`.
+
+## Final / expected result
+
+- `billing_plans` seeded with `FREE`, `PRO` rows; `billing_prices`
+  seeded with `PRO_MONTHLY`, `PRO_YEARLY`.
+- Old `plans` table dropped; `plan/` module absent from the source tree.
+- `PricingCatalogService.requireProviderPriceId(PRO_MONTHLY)` returns
+  the seeded stub id; setting a row to `active=false` makes it throw
+  `PRICE_NOT_AVAILABLE`.
+- No public REST change (UI still reads no prices — BE-10 will add
+  `GET /api/billing/prices`).
+- `./gradlew test`, `./gradlew checkstyleMain`, `./gradlew spotbugsMain`
+  pass.
+
+## REST API added / changed
+
+None in this task. `POST/PUT/DELETE /api/plans` and `GET /api/plans`
+were already removed in BE-04; the tables backing them are dropped
+here.
+
+## Tests to add
+
+- **Integration — `BillingCatalogSchemaIT`** (Testcontainers): seed
+  rows exist; `plans` table absent; unique constraints on `code`
+  columns.
+- **Unit — `PricingCatalogServiceTest`**:
+  `requireProviderPriceId(PRO_YEARLY)` returns the sandbox id; when
+  `active=false` throws `ConflictException("PRICE_NOT_AVAILABLE")`;
+  when the row is missing throws `NotFoundException`.
+- **Unit — `PricingCatalogServiceInactivePlanTest`**: requesting a
+  price whose parent plan is `active=false` throws
+  `PRICE_NOT_AVAILABLE`.
+
+## Risk & follow-ups
+
+- Sandbox `provider_price_id` values are placeholders. When the real
+  provider is chosen, update the seed via an `UPDATE ... WHERE
+  provider='sandbox'` migration or via a new admin endpoint added in
+  BE-14.
+- Old `PlanDto` was consumed by UI-14 (`GET /api/plans`). UI-38 in the
+  same release cycle stops calling it; verify no test still hits the
+  old endpoint before dropping the endpoint definition.

--- a/backend/lined/docs/billing/tasks/BE-06-subscription-schema-state-machine.md
+++ b/backend/lined/docs/billing/tasks/BE-06-subscription-schema-state-machine.md
@@ -1,0 +1,133 @@
+# Task BE-06 — Subscription Schema + State Machine
+
+**Branch:** `feature/be-06-subscription-schema-state-machine`
+
+*Depends on BE-01 (BillingAccount), BE-05 (PriceCode). Blocks BE-10
+(checkout creates a `PENDING` subscription), BE-11 (state transitions),
+and BE-13 (transactions FK to subscription).*
+
+## Detailed description
+
+Persist the target `billing_subscriptions` model plus provider-customer
+mapping, wire it into `EffectivePlanResolver`, and ship the state-machine
+helper used by BE-11.
+
+Scope:
+
+1. New table `billing_subscriptions` per design §12.5:
+   `id`, `billing_account_id` FK, `provider`, `provider_subscription_id`
+   (unique), `plan_code`, `current_price_code`, `status`,
+   `current_period_start`, `current_period_end`, `cancel_at_period_end`
+   (bool), `scheduled_price_code` (nullable), `scheduled_change_at`
+   (nullable), `past_due_since` (nullable), `grace_ends_at` (nullable),
+   `provider_updated_at`, `last_synced_at`, `version` (bigint,
+   optimistic locking), `created_at`, `updated_at`.
+2. Constraints:
+   - unique on `provider_subscription_id`
+   - partial index enforcing "at most one non-terminal subscription per
+     billing account" — non-terminal = status in
+     `PENDING|ACTIVE|PAST_DUE`
+   - `current_period_end >= current_period_start`
+   - scheduled fields must be consistent (both null or both non-null)
+   - `grace_ends_at`/`past_due_since` only valid when `status=PAST_DUE`
+3. New table `billing_provider_customers`:
+   `id`, `billing_account_id` FK, `provider`, `provider_customer_id`
+   (unique), timestamps. Unique on `(billing_account_id, provider)`.
+4. Enum `SubscriptionStatus`: `PENDING`, `ACTIVE`, `PAST_DUE`,
+   `CANCELED`, `EXPIRED`.
+5. Entities + repositories under `billing/domain/subscription/`,
+   `billing/domain/account/` (add `ProviderCustomerEntity` +
+   `ProviderCustomerRepository`).
+6. `SubscriptionStateMachine` helper (pure function class):
+   - `assertTransition(from, event) → to` for the transitions in §15
+   - throws `ConflictException("PROVIDER_STATE_CONFLICT")` on illegal
+     transitions
+7. Replace BE-01's `NoOpPaidSubscriptionLookup` with
+   `SubscriptionRepositoryLookup` — returns the current non-terminal
+   subscription for the account, if any.
+8. `EffectivePlanResolver.grantsPaidAccess(subscription, now)` policy
+   table (design §16.1):
+   - `ACTIVE` and `now < currentPeriodEnd` → paid
+   - `ACTIVE` and cancel scheduled, `now < currentPeriodEnd` → paid
+   - `PAST_DUE` and `now < graceEndsAt` → paid
+   - all others → not paid (returns FREE)
+
+## Design references
+
+- §12.5 `billing_subscriptions`
+- §14 Subscription Status Model
+- §15 Subscription State Machine
+- §16 Effective Plan Resolution (policy)
+- §42.3 Optimistic locking
+- §44 Source-of-Truth Rules
+- §45 Time Handling
+
+## Idea of this task
+
+The subscription table is the projection all product-access decisions
+read from. Getting the columns, constraints, and state-machine helper
+right here — separately from the endpoints that mutate it — makes BE-11
+a thin wiring layer instead of a mixed schema+behavior change.
+
+## Development steps
+
+1. Append `CREATE TABLE IF NOT EXISTS billing_subscriptions ...` and
+   `CREATE UNIQUE INDEX IF NOT EXISTS ...` (partial) to `schema.sql`.
+2. Append `CREATE TABLE IF NOT EXISTS billing_provider_customers ...`.
+3. Add `SubscriptionStatus`, `SubscriptionEntity`,
+   `SubscriptionRepository`.
+4. Add `ProviderCustomerEntity`, `ProviderCustomerRepository`.
+5. Add `SubscriptionStateMachine`: static `TRANSITIONS` map + `assert`
+   method + typed `SubscriptionEvent` enum
+   (`PAYMENT_CONFIRMED`, `PAYMENT_FAILED`, `PAYMENT_RECOVERED`,
+   `CANCELLATION_SCHEDULED`, `CANCELLATION_RESUMED`,
+   `PRICE_CHANGE_SCHEDULED`, `PERIOD_ELAPSED`,
+   `PROVIDER_EXPIRED`, `NEW_CHECKOUT`).
+6. Replace `NoOpPaidSubscriptionLookup` binding with
+   `SubscriptionRepositoryLookup`.
+7. Update `EffectivePlanResolver` with the `grantsPaidAccess` policy.
+8. Tests.
+9. Run `./gradlew test checkstyleMain spotbugsMain`.
+
+## Final / expected result
+
+- Schema migrates cleanly; partial-index guarantees one non-terminal
+  subscription per account (concurrent insert attempt → constraint
+  violation).
+- `SubscriptionStateMachine.assertTransition(ACTIVE, PAYMENT_FAILED)`
+  returns `PAST_DUE`; illegal transition throws.
+- `EffectivePlanResolver` now returns `PRO` for an account with an
+  `ACTIVE` subscription and `currentPeriodEnd > now`.
+- `GET /api/billing/me` still works (BE-04); the `subscription` field
+  remains `null` because no endpoint yet creates rows — BE-10/BE-11 do.
+- `./gradlew test`, `./gradlew checkstyleMain`, `./gradlew spotbugsMain`
+  pass.
+
+## REST API added / changed
+
+None. Data-model + resolver-behavior only.
+
+## Tests to add
+
+- **Unit — `SubscriptionStateMachineTest`**: every valid transition in
+  §15 returns the expected next state; illegal transitions throw
+  `PROVIDER_STATE_CONFLICT`.
+- **Unit — `EffectivePlanResolverPolicyTest`**: matrix from §16.1
+  covered row-by-row.
+- **Integration — `SubscriptionRepositoryIT`** (Testcontainers):
+  - unique `provider_subscription_id` blocks duplicates
+  - partial unique index blocks a 2nd non-terminal subscription for
+    the same account, allows terminal + non-terminal coexistence
+  - optimistic lock: two concurrent updates → one wins,
+    `OptimisticLockException` on the other
+- **Integration — `ProviderCustomerRepositoryIT`**: unique constraint
+  on `(billing_account_id, provider)`.
+
+## Risk & follow-ups
+
+- The partial unique index must be added with a name (e.g.
+  `uq_billing_subscriptions_active`) so BE-15's reconciliation report
+  can hunt for violations by name.
+- If the chosen production provider allows two active subscriptions for
+  the same customer (add-ons, seat expansions), the partial index will
+  need to relax — flag in the ADR for BE-15.

--- a/backend/lined/docs/billing/tasks/BE-07-provider-port-abstraction.md
+++ b/backend/lined/docs/billing/tasks/BE-07-provider-port-abstraction.md
@@ -1,0 +1,129 @@
+# Task BE-07 — Provider Port Abstraction
+
+**Branch:** `feature/be-07-provider-port-abstraction`
+
+*Depends on BE-05 (PriceCode) and BE-06 (canonical subscription model).
+Blocks BE-08 (sandbox adapter implements every port) and every task
+that calls a port (BE-09..BE-13).*
+
+## Detailed description
+
+Define provider-agnostic ports and canonical DTOs so the domain never
+imports Paddle/Stripe/Mono SDK types. Ship the `BillingProviderCapabilities`
+record and a startup validator that fails fast if the selected adapter
+does not advertise the MVP-mandatory capabilities.
+
+Scope:
+
+1. New package `io.backend.lined.billing.port` containing the six
+   interfaces from design §19.2:
+   - `BillingPricingProvider`
+   - `BillingCheckoutProvider`
+   - `BillingSubscriptionProvider`
+   - `BillingRefundProvider`
+   - `BillingPortalProvider`
+   - `BillingReconciliationProvider`
+2. Canonical DTOs under `billing/port/model/` (records only, no
+   provider-specific fields):
+   - `ProviderCustomer(providerCustomerId)`
+   - `ProviderPriceId(String value)` value object
+   - `ProviderSubscriptionId(String value)` value object
+   - `ProviderSubscription(...)` — normalized snapshot with the fields
+     needed by BE-06 (status, current period, cancel_at_period_end,
+     scheduled_price_code/at, past_due_since, grace_ends_at,
+     provider_updated_at)
+   - `ProviderSubscriptionSnapshot` — reconciliation subset
+   - `CheckoutSession(providerCheckoutId, overlayData, expiresAt)`
+   - `CreateCheckoutCommand(billingAccountId, priceCode, providerCustomerId,
+     idempotencyKey, returnUrl?)`
+   - `PricingPreview(planCode, countryCode, prices[])`, `PricingPrice(...)`
+   - `PricingPreviewRequest(planCode, countryCode?, currency?)`
+   - `RefundPreview`, `RefundPreviewRequest`, `RefundCommand`,
+     `ProviderRefundResult`
+   - `CustomerPortalSession`
+   - `ProviderOperationResult(status, snapshot, warnings[])`
+3. `BillingProviderCapabilities` record with the fields in §19.3.
+4. `BillingProviderCapabilityValidator` — a
+   `ApplicationRunner`/`@PostConstruct` that reads the injected
+   adapter's `getCapabilities()` and throws on startup if any
+   MVP-mandatory capability from §19.4 is false. Log a warning for
+   missing "preferred" capabilities.
+5. `billing.provider` Spring property + a `BillingProviderConfig` that
+   picks the adapter bean by qualifier. Ship no adapter here — BE-08
+   provides the sandbox adapter with qualifier `sandbox`. Startup fails
+   with a clear message if the property is unset or names an unknown
+   adapter.
+6. ArchUnit test enforcing:
+   - no class in `billing.domain..` or `billing.application..` imports
+     from `billing.infrastructure.provider..`
+   - no class in `billing.domain..` imports Paddle/Stripe/Mono SDK
+     package prefixes
+   - port interfaces live only in `billing.port..`
+
+## Design references
+
+- §9 Dependency Rules (rule 1, 2)
+- §19 Provider Abstraction (all subsections)
+- §19.4 Required MVP capabilities
+- §54 Architecture Enforcement
+
+## Idea of this task
+
+Provider selection is deferred. Every downstream task calls the ports,
+not a concrete adapter. Codifying the ports + capability contract now
+means the day the real provider is chosen, one new adapter class + one
+property change flips it on — with the capability validator catching
+"we chose a provider that lacks partial refunds" at boot.
+
+## Development steps
+
+1. Create `billing.port` package + the six interfaces (methods per
+   design §19.2 exactly).
+2. Create `billing.port.model` package with the canonical DTOs. Use
+   Java records everywhere; no null-checked SDK types.
+3. Add `BillingProviderCapabilities` record.
+4. Add `BillingProviderCapabilityValidator` with unit test.
+5. Add `BillingProviderConfig` — `@ConfigurationProperties` for
+   `billing.provider` (String) + Spring config that wires the chosen
+   bean into every port interface via qualifier.
+6. Add ArchUnit test class `BillingArchitectureTest` with the three
+   rules above.
+7. Tests.
+8. Run `./gradlew test checkstyleMain spotbugsMain`.
+
+## Final / expected result
+
+- `billing.port` package exists with six interfaces and canonical DTOs.
+- `BillingProviderCapabilityValidator` fails fast at startup when a
+  mandatory capability is absent.
+- Application does not start without a `billing.provider` setting and
+  a matching adapter bean (BE-08 will provide the sandbox bean).
+- ArchUnit test blocks any future PR that leaks provider DTOs into the
+  domain layer.
+- `./gradlew test`, `./gradlew checkstyleMain`, `./gradlew spotbugsMain`
+  pass.
+
+## REST API added / changed
+
+None.
+
+## Tests to add
+
+- **Unit — `BillingProviderCapabilityValidatorTest`**: passes when all
+  mandatory caps true; throws with a message naming the missing cap
+  when any mandatory cap is false; only logs when a preferred cap is
+  false.
+- **Unit — `BillingProviderConfigTest`**: unknown provider name at
+  startup → clear error message.
+- **Architecture — `BillingArchitectureTest`** (ArchUnit): three rules
+  pass on the current codebase; deliberately violating each rule in a
+  scratch class breaks the corresponding test.
+
+## Risk & follow-ups
+
+- Startup will fail after this PR without BE-08's sandbox adapter.
+  Land the two PRs together, or ship BE-07 behind a default provider
+  property of `noop` and add a `NoopProviderAdapter` that throws
+  `UnsupportedOperationException` from every port until BE-08 lands.
+- The canonical DTOs are the public shape of the port surface — once
+  an adapter is shipped, changing them requires updating every adapter.

--- a/backend/lined/docs/billing/tasks/BE-08-sandbox-stub-provider-adapter.md
+++ b/backend/lined/docs/billing/tasks/BE-08-sandbox-stub-provider-adapter.md
@@ -1,0 +1,134 @@
+# Task BE-08 — Sandbox Stub Provider Adapter
+
+**Branch:** `feature/be-08-sandbox-stub-provider-adapter`
+
+*Depends on BE-07 (ports). Enables local + CI development of every
+subsequent task without a real provider account.*
+
+## Detailed description
+
+Ship an in-memory, deterministic sandbox adapter that satisfies every
+port from BE-07. It advertises every MVP-mandatory capability from §19.4
+so the capability validator passes. It stores state in a
+`ConcurrentHashMap` (no persistence) and produces synthetic events that
+the webhook processor (BE-09) can ingest via a helper endpoint used
+only in dev/test profiles.
+
+Scope:
+
+1. Package `io.backend.lined.billing.infrastructure.provider.sandbox`
+   with `SandboxProviderAdapter` implementing all six port interfaces
+   and qualified as `sandbox`.
+2. Deterministic behavior:
+   - `createCustomer` returns `provider_customer_id = "cus_" +
+     billingAccountId.hex`
+   - `createCheckout` returns a canonical `CheckoutSession` with
+     `providerCheckoutId = "co_" + UUID` and a fake `overlayData`
+     payload
+   - `getSubscription`/`snapshot` reads from the internal map
+   - `scheduleCancellation`/`resumeSubscription`/`schedulePriceChange`
+     update the internal map and emit synthetic events
+   - `issueRefund` moves refund to `SUCCEEDED` immediately and emits
+     a refund event
+   - `previewRefund` returns the full remaining refundable amount
+3. Capability advertisement: every MVP-mandatory cap `true`; preferred
+   caps `true` where reasonable (overlay checkout, localized pricing,
+   cancel-at-period-end, resume, full/partial refunds, sandbox mode,
+   customer portal). `automaticTax=false`, `merchantOfRecord=false`.
+4. Dev/test-only helper: `SandboxWebhookSimulator` — a
+   `@Profile("dev|test")` component with methods like
+   `simulatePaymentConfirmed(subscriptionId)` invoked from an
+   integration test to drive BE-09's webhook processor. Not exposed via
+   HTTP.
+5. Localized pricing: `getPricingPreview(countryCode='UA')` returns the
+   Ukrainian preview from design §20.2 verbatim; other country codes
+   return USD values. Values are hard-coded in the adapter — nothing
+   real is happening.
+6. Provider selection matrix (design §19.5) — reproduced as a table in
+   the task file itself + committed as
+   `backend/lined/docs/billing/PROVIDER_SELECTION_MATRIX.md` with the
+   "TBD" cells so the eventual provider decision has a home.
+
+## Design references
+
+- §19 Provider Abstraction
+- §19.4 Required MVP capabilities
+- §19.5 Provider selection matrix
+- §20 Localized Pricing
+- §52 Phase 2 Sandbox provider adapter
+- §56 Open decision #1
+
+## Idea of this task
+
+Every task from BE-09 onward needs a working provider to test against.
+A deterministic in-memory sandbox lets BE-09..BE-15 be built,
+integration-tested, and even manually poked in the dev environment
+without provider credentials, sandbox accounts, or webhook forwarding
+tools. The eventual real adapter re-implements the same ports and
+passes the same contract tests.
+
+## Development steps
+
+1. Create the sandbox package.
+2. Implement `SandboxProviderAdapter` — one class per port interface,
+   or one composite class implementing all six (composite is simpler
+   for shared state).
+3. Wire `billing.provider=sandbox` as the default in
+   `application.properties` and add a comment explaining that production
+   overrides this via env var.
+4. Add `SandboxWebhookSimulator` (profile-gated).
+5. Add the pricing preview table (Ukrainian localized) and the USD
+   fallback.
+6. Write the provider selection matrix file
+   (`PROVIDER_SELECTION_MATRIX.md`) with the design §19.5 columns
+   populated with `TBD` for Paddle / Stripe / Mono and `sandbox` for
+   the current in-tree adapter.
+7. Contract test suite (`SandboxProviderContractTest`) that BE-07's
+   architecture rule requires every future adapter to also pass —
+   organized as a `@Nested` test class per port so a new adapter can
+   `extends BillingProviderContractSuite` and provide its own bean.
+8. Tests.
+9. Run `./gradlew test checkstyleMain spotbugsMain`.
+
+## Final / expected result
+
+- Application starts with `billing.provider=sandbox`; capability
+  validator passes.
+- Every port method returns a canonical DTO with deterministic values.
+- `SandboxWebhookSimulator` lets an integration test in BE-09/BE-11
+  drive an ACTIVE subscription end-to-end without external services.
+- Provider selection matrix committed with the design's cells filled
+  from the sandbox and the rest `TBD`.
+- `./gradlew test`, `./gradlew checkstyleMain`, `./gradlew spotbugsMain`
+  pass.
+
+## REST API added / changed
+
+None. `SandboxWebhookSimulator` is a Java component, not an HTTP
+endpoint.
+
+## Tests to add
+
+- **Contract — `SandboxProviderContractTest`** (extends the shared
+  `BillingProviderContractSuite`): create pricing preview, create
+  checkout, subscription state map (ACTIVE/PAST_DUE/CANCELED),
+  schedule cancellation returns snapshot with `cancelAtPeriodEnd=true`,
+  resume clears it, schedule price change fills the scheduled fields,
+  refund preview + issue return canonical results.
+- **Unit — `SandboxProviderCapabilitiesTest`**: every MVP-mandatory
+  capability from §19.4 is `true`; the capability validator returns
+  no errors.
+- **Unit — `SandboxWebhookSimulatorTest`**: publishing a synthetic
+  payment-confirmed event enqueues the expected canonical event object
+  for BE-09's processor.
+
+## Risk & follow-ups
+
+- State is in-memory only. Restarting the app drops sandbox
+  subscriptions; that is intended for local/CI and would be a bug in
+  production — the config guards against `sandbox` being the selected
+  provider in `prod` profile with a startup assertion.
+- The synthetic webhook path skips signature verification; BE-09's
+  test that "invalid signature is rejected" must not use the sandbox
+  helper — it must fabricate a raw request against the real webhook
+  endpoint.

--- a/backend/lined/docs/billing/tasks/BE-09-webhook-inbox-signature.md
+++ b/backend/lined/docs/billing/tasks/BE-09-webhook-inbox-signature.md
@@ -1,0 +1,138 @@
+# Task BE-09 — Webhook Inbox + Signature Verification
+
+**Branch:** `feature/be-09-webhook-inbox-signature`
+
+*Depends on BE-07 (ports), BE-08 (sandbox for tests). Blocks BE-11
+(subscription activation reads from the inbox), BE-13 (refund events),
+BE-15 (reconciliation retries failed events).*
+
+## Detailed description
+
+Ship the `billing_provider_events` inbox and the webhook endpoint that
+verifies provider signatures, deduplicates, and hands off to an
+asynchronous processor. HTTP response returns as soon as the inbox row
+is durable — business processing happens in a scheduled processor so
+the endpoint stays within provider timeouts.
+
+Scope:
+
+1. New table `billing_provider_events` per design §12.9 with unique
+   constraint `(provider, provider_event_id)` and status enum
+   `RECEIVED|PROCESSING|PROCESSED|FAILED|IGNORED`.
+2. `WebhookController` under `billing/api/webhook/`:
+   - `POST /api/billing/webhooks/{provider}` where `{provider}` matches
+     a configured adapter qualifier
+   - reads the raw request body (preserves bytes for signature
+     verification) via `@RequestBody byte[]` + a `HandlerInterceptor` /
+     `RequestBodyAdvice` if needed
+   - hard 1 MiB size limit — larger requests return 413
+   - no `X-User-Id` — this endpoint has no user identity
+3. `ProviderWebhookRouter` looks up the adapter via
+   `BillingCheckoutProvider`/`BillingSubscriptionProvider` port
+   (extension: add a `verifySignature(byte[] body, HttpHeaders headers)`
+   method to a new `BillingWebhookVerifier` port and update BE-07's port
+   list — see BE-07 follow-up).
+4. Invalid signature → 401, log a `billing_webhook_invalid_signature`
+   security event (metric added in BE-15), do NOT insert into inbox.
+5. Valid signature → insert into `billing_provider_events` with
+   `processing_status=RECEIVED`; return 200. On unique-constraint
+   violation (duplicate `provider_event_id`), still return 200 (idempotent).
+6. `WebhookProcessor` — scheduled job that picks up `RECEIVED` events
+   ordered by `occurred_at ASC`, marks `PROCESSING`, dispatches to a
+   `ProviderEventHandler` per event type, and marks `PROCESSED` /
+   `FAILED` (with retry count + `last_error`).
+7. Out-of-order protection: before applying a state-changing event,
+   compare event's `occurred_at` with the target
+   `SubscriptionEntity.providerUpdatedAt`; if older, mark `IGNORED`
+   (design §22.3).
+8. This task ships **no** event handlers — those live in BE-11
+   (subscription lifecycle) and BE-13 (refund). The dispatcher looks up
+   handlers by event type via a `Map<String, ProviderEventHandler>`
+   populated by Spring, defaulting to `IgnoreUnknownEventHandler` that
+   marks the event `IGNORED` with reason "no handler".
+
+## Design references
+
+- §12.9 `billing_provider_events`
+- §22 Webhook Processing
+- §22.3 Out-of-order events
+- §22.4 Webhook acknowledgement
+- §41.4 Webhook security
+- §42.4 Webhook deduplication
+- §43 Transaction Boundaries
+
+## Idea of this task
+
+Webhooks are the primary real-time synchronization mechanism. Getting
+the receive → verify → dedupe → durable-insert → async-process pipeline
+right — with signature verification, size limit, and out-of-order guard
+— means every business handler (BE-11, BE-13) can assume it is only
+called for valid, deduplicated, in-order events.
+
+## Development steps
+
+1. Add `BillingWebhookVerifier` port to `billing.port` (extending
+   BE-07's set) with `verifySignature(byte[] body, Map<String,String>
+   headers) → boolean` and the sandbox adapter always returns `true` in
+   dev/test but has a lightweight HMAC path for
+   `SandboxProviderContractTest` to exercise.
+2. Append `billing_provider_events` DDL to `schema.sql`.
+3. Add entity + repository under `billing/domain/event/`.
+4. Add `WebhookController` + `ProviderWebhookRouter` under
+   `billing/api/webhook/`.
+5. Add `WebhookProcessor` scheduled component
+   (`@Scheduled(fixedDelayString="${billing.webhook.processor.delayMs:5000}")`),
+   dispatch map, `IgnoreUnknownEventHandler`.
+6. Add `ProviderEventHandler` interface: `handle(ProviderEvent event) →
+   ProviderEventOutcome`.
+7. Configure raw-body preservation for the webhook path only (don't
+   change the app-wide message converters).
+8. Tests.
+9. Run `./gradlew test checkstyleMain spotbugsMain`.
+
+## Final / expected result
+
+- `POST /api/billing/webhooks/sandbox` accepts a signed request and
+  returns 200; the row lands in `billing_provider_events`.
+- Duplicate delivery of the same `provider_event_id` returns 200 and
+  does not insert a second row.
+- Invalid signature returns 401 and no inbox row is created.
+- Async processor picks up the row within one delay interval and
+  dispatches to a handler; unknown event types are `IGNORED`.
+- Out-of-order events (older than the target subscription's
+  `provider_updated_at`) are `IGNORED`.
+- `./gradlew test`, `./gradlew checkstyleMain`, `./gradlew spotbugsMain`
+  pass.
+
+## REST API added / changed
+
+| Purpose | Method + Path |
+|---|---|
+| Provider webhook | `POST /api/billing/webhooks/{provider}` (raw body, provider signature) |
+
+## Tests to add
+
+- **Controller — `WebhookControllerSignatureTest`**: 401 when signature
+  fails; 200 when it succeeds; 200 on duplicate delivery; 413 on
+  oversized body.
+- **Integration — `WebhookProcessorIT`** (Testcontainers +
+  `@Scheduled` invoked directly): row lands, transitions
+  RECEIVED→PROCESSING→PROCESSED via a test-only handler; failure
+  marks FAILED and increments `attempt_count`.
+- **Integration — `WebhookOutOfOrderIT`**: seeded subscription with
+  `providerUpdatedAt=T2`; event with `occurredAt=T1` is marked
+  IGNORED, subscription untouched.
+- **Integration — `WebhookDeduplicationIT`**: 100 concurrent inserts
+  of the same event ID → exactly one row.
+- **Security — `WebhookNoAuthHeaderTest`**: endpoint does not read or
+  require `X-User-Id`; a stray one is ignored.
+
+## Risk & follow-ups
+
+- Raw body preservation can conflict with global `@RequestBody`
+  message converters — restrict the interceptor to
+  `/api/billing/webhooks/**` paths.
+- The scheduled processor runs single-threaded by default. If webhook
+  volume grows, BE-15 can move it to a bounded thread pool.
+- `SandboxProviderContractTest` should include an HMAC-verify path so
+  the sandbox exercises the signature contract too, not only ports.

--- a/backend/lined/docs/billing/tasks/BE-10-checkout-endpoint-pricing-preview.md
+++ b/backend/lined/docs/billing/tasks/BE-10-checkout-endpoint-pricing-preview.md
@@ -1,0 +1,147 @@
+# Task BE-10 — Checkout Endpoint + Pricing Preview
+
+**Branch:** `feature/be-10-checkout-endpoint-pricing-preview`
+
+*Depends on BE-05 (PriceCode), BE-06 (subscription/customer tables),
+BE-07 (ports), BE-08 (sandbox). Blocks BE-11 (activation) and UI-39 +
+UI-40.*
+
+## Detailed description
+
+Ship the two endpoints that let the frontend open a provider-controlled
+checkout: pricing preview and checkout creation. Never accept
+amount/currency/`providerPriceId` from the client; look everything up
+server-side from BE-05's catalog. Lazily create a `ProviderCustomer`
+during the first checkout for a BillingAccount, safe under concurrent
+requests.
+
+Scope:
+
+1. New table `billing_checkout_attempts` per design §12.6:
+   `id`, `billing_account_id`, `price_code`, `provider`,
+   `provider_checkout_id` (nullable), `status`
+   (`CREATED|COMPLETED|EXPIRED|FAILED`), `idempotency_key` (unique
+   with `(billing_account_id, 'CHECKOUT')`), `expires_at`, timestamps.
+2. `POST /api/billing/checkout`:
+   - requires header `Idempotency-Key` (`428 PRECONDITION_REQUIRED` if
+     missing)
+   - body: `{ "priceCode": "PRO_MONTHLY" | "PRO_YEARLY" }` — nothing
+     else accepted
+   - looks up `PriceCode` via `PricingCatalogService`
+     (`404 PRICE_NOT_AVAILABLE` if not active)
+   - resolves BillingAccount from `X-User-Id`
+   - ensures a `ProviderCustomer` exists; if not, creates one via
+     `BillingCheckoutProvider.createCustomer(...)`, then persists the
+     mapping with `INSERT ... ON CONFLICT DO NOTHING` (safe under
+     concurrent first checkouts — see §42.2)
+   - calls `BillingCheckoutProvider.createCheckout(...)` with the
+     canonical `CreateCheckoutCommand` (billingAccountId, priceCode
+     resolved to `providerPriceId`, `providerCustomerId`, idempotency
+     key)
+   - persists a `billing_checkout_attempts` row and returns
+     `{ providerCheckoutId, overlayData, expiresAt, checkoutAttemptId }`
+   - repeated calls with the same `Idempotency-Key` return the same
+     row's data (idempotent)
+3. `GET /api/billing/prices`:
+   - reads active prices for `PRO` from catalog
+   - calls `BillingPricingProvider.getPricingPreview(...)` (country
+     detected from `Accept-Language` / geo IP header if available; else
+     default)
+   - returns the shape from design §20.2
+   - cached in-memory for 5 minutes keyed on
+     `(provider, priceCodes, country)`; cache miss populates
+   - never used as a financial source of truth — a warning banner in
+     the DTO description makes this explicit for downstream
+
+## Design references
+
+- §12.6 `billing_checkout_attempts`
+- §20 Localized Pricing
+- §21 Checkout Flow
+- §37.2 Pricing preview
+- §37.3 Create checkout
+- §41.2 Price integrity
+- §42.1 Checkout idempotency
+- §42.2 Provider customer creation
+
+## Idea of this task
+
+The two endpoints together are the "before payment" contract:
+frontend shows a price, frontend asks backend for a checkout session,
+backend hands back overlay data. Everything about the price and the
+session — amount, currency, provider price id, provider customer — is
+decided server-side. This is the boundary that keeps a hostile
+frontend from paying `$0.01` for Pro.
+
+## Development steps
+
+1. Append `billing_checkout_attempts` DDL to `schema.sql`.
+2. Add entity + repository under `billing/domain/checkout/`.
+3. Add `BillingController` methods for `POST /api/billing/checkout` and
+   `GET /api/billing/prices` (or split into `BillingCheckoutController`
+   / `BillingPriceController` — pick per project convention).
+4. `CheckoutService.startCheckout(userId, priceCode, idempotencyKey)`:
+   - look up BillingAccount
+   - look up + activate `PriceCode` mapping
+   - `ensureProviderCustomer(billingAccountId)` with the ON CONFLICT
+     safeguard
+   - `checkoutProvider.createCheckout(...)`
+   - persist attempt (unique on `idempotency_key` scoped to
+     `billing_account_id`)
+   - return DTO
+5. `PricingPreviewService.getPreview(planCode, requestContext)` +
+   Caffeine cache with 5 min TTL.
+6. Configure raw exception mapping for `PRICE_NOT_AVAILABLE`,
+   `CHECKOUT_ALREADY_IN_PROGRESS`, `PROVIDER_TEMPORARILY_UNAVAILABLE`
+   (map provider port timeouts to the last one).
+7. Tests.
+8. Run `./gradlew test checkstyleMain spotbugsMain`.
+
+## Final / expected result
+
+- `GET /api/billing/prices` returns the sandbox-preview payload; UI-39
+  can render against it.
+- `POST /api/billing/checkout` (with `Idempotency-Key`) returns overlay
+  data on happy path; repeated calls return the same overlay data.
+- Provider customer is created lazily and only once per (account,
+  provider) — enforced by the unique index and the ON CONFLICT retry.
+- Missing/inactive `PriceCode` returns `404 PRICE_NOT_AVAILABLE`.
+- Missing `Idempotency-Key` returns `428`.
+- `./gradlew test`, `./gradlew checkstyleMain`, `./gradlew spotbugsMain`
+  pass.
+
+## REST API added / changed
+
+| Purpose | Method + Path |
+|---|---|
+| Pricing preview | `GET /api/billing/prices` |
+| Create checkout | `POST /api/billing/checkout` (body `{ priceCode }`, header `Idempotency-Key`) |
+
+## Tests to add
+
+- **Controller — `BillingCheckoutControllerTest`**:
+  - 428 when `Idempotency-Key` missing
+  - 400 on unknown `priceCode`
+  - 404 `PRICE_NOT_AVAILABLE` on `active=false` price
+  - 200 happy path against the sandbox; second call with same key
+    returns identical body
+  - client cannot pass `amount`, `currency`, `providerPriceId`,
+    `userId` — extra body fields are ignored/400 (per Jackson config)
+- **Controller — `BillingPricesControllerTest`**: returns the sandbox
+  preview shape; second call in cache window returns from cache (spy
+  on port).
+- **Integration — `CheckoutConcurrentFirstCustomerIT`**: two threads
+  submit first-checkout in parallel → exactly one
+  `billing_provider_customers` row.
+- **Integration — `CheckoutIdempotencyIT`**: two POSTs with same
+  `Idempotency-Key` → one `billing_checkout_attempts` row.
+
+## Risk & follow-ups
+
+- The pricing preview cache is per-instance. In a multi-instance
+  deploy, users on different pods may see a stale preview until TTL
+  expires — acceptable at 5 min; BE-15 can add a manual invalidation
+  endpoint.
+- No `PENDING` subscription row is created here — design §14 leaves it
+  optional. BE-11 creates the row on webhook confirmation instead;
+  frontend polls `GET /api/billing/me` after overlay close.

--- a/backend/lined/docs/billing/tasks/BE-11-subscription-lifecycle.md
+++ b/backend/lined/docs/billing/tasks/BE-11-subscription-lifecycle.md
@@ -1,0 +1,159 @@
+# Task BE-11 — Subscription Lifecycle (Activate / Cancel / Resume / Change / Grace)
+
+**Branch:** `feature/be-11-subscription-lifecycle`
+
+*Depends on BE-06 (subscription table + state machine), BE-07/BE-08
+(ports + sandbox), BE-09 (webhook inbox), BE-10 (checkout). Blocks
+BE-12 (downgrade), BE-13 (refund path).*
+
+## Detailed description
+
+Wire up the full subscription lifecycle from confirmed webhook → ACTIVE
+→ user-initiated cancel/resume/change-price at period end → PAST_DUE
+(grace) → recovery / expiration. Publishes domain events for BE-12 and
+BE-15 to consume.
+
+Scope:
+
+1. Webhook event handlers under `billing/application/event/`
+   registered with BE-09's dispatcher for the sandbox event types (real
+   provider events map through the adapter to the same canonical
+   event enum):
+   - `PAYMENT_CONFIRMED` → upsert subscription row: `status=ACTIVE`,
+     `current_period_start/end`, `current_price_code`,
+     `provider_updated_at`, `version+=1`. If no row exists, insert;
+     enforces the partial unique index on non-terminal subs (see
+     BE-06)
+   - `PAYMENT_FAILED` → `ACTIVE → PAST_DUE`, set `past_due_since`,
+     set `grace_ends_at = failure_effective_time + 3 days`
+   - `PAYMENT_RECOVERED` → `PAST_DUE → ACTIVE`, clear past_due /
+     grace fields
+   - `PROVIDER_EXPIRED` → `PAST_DUE → EXPIRED` or `ACTIVE → EXPIRED`
+   - `PERIOD_ELAPSED` → for `ACTIVE + cancelAtPeriodEnd=true` → move
+     to `CANCELED`; for `ACTIVE + scheduledPriceCode` → apply the
+     price change and start a fresh period
+2. User-initiated endpoints (all derive account from `X-User-Id`):
+   - `POST /api/billing/subscription/cancel` — calls
+     `subscriptionProvider.scheduleCancellation(id, currentPeriodEnd)`,
+     locally sets `cancel_at_period_end=true`, `scheduled_change_at =
+     currentPeriodEnd`. Rejects with `SUBSCRIPTION_NOT_ACTIVE` when
+     not `ACTIVE`; `CANCELLATION_ALREADY_SCHEDULED` when already true.
+   - `POST /api/billing/subscription/resume` — requires `ACTIVE +
+     cancel_at_period_end=true + now < currentPeriodEnd`; calls
+     `subscriptionProvider.resumeSubscription`, clears the local
+     scheduled fields. `RESUME_NOT_ALLOWED` otherwise.
+   - `POST /api/billing/subscription/change-price` (body:
+     `{ priceCode }`) — server-side maps `PriceCode → providerPriceId`;
+     calls `subscriptionProvider.schedulePriceChange(id,
+     nextPriceId, currentPeriodEnd)`; local writes
+     `scheduled_price_code`, `scheduled_change_at`.
+     `PRICE_CHANGE_ALREADY_SCHEDULED` on duplicate; also allowed
+     while `cancel_at_period_end=true` because it implicitly resumes
+     (design §26 is silent on this — reject with
+     `RESUME_NOT_ALLOWED` and require the user to resume first).
+3. `GET /api/billing/me` (from BE-04) now populates the `subscription`
+   field with `{ status, priceCode, currentPeriodEnd,
+   cancelAtPeriodEnd, scheduledPriceCode, graceEndsAt }`.
+4. Every write publishes a domain event via BE-15's outbox (the outbox
+   table is delivered by BE-15; this task publishes to an in-process
+   event bus and TODO-marks the outbox integration). Events:
+   `SUBSCRIPTION_ACTIVATED`, `SUBSCRIPTION_CANCELLATION_SCHEDULED`,
+   `SUBSCRIPTION_CANCELLATION_RESUMED`,
+   `SUBSCRIPTION_PRICE_CHANGE_SCHEDULED`,
+   `SUBSCRIPTION_PAYMENT_FAILED`,
+   `SUBSCRIPTION_PAYMENT_RECOVERED`,
+   `SUBSCRIPTION_EXPIRED`, `EFFECTIVE_PLAN_CHANGED`.
+5. All operations use optimistic locking (BE-06 `version` column).
+   Conflict resolution: reload subscription, if the requested change is
+   already applied return idempotent success; otherwise return `409
+   PROVIDER_STATE_CONFLICT`.
+
+## Design references
+
+- §14 Statuses
+- §15 State Machine
+- §21 Upgrade Activation
+- §24 Upgrade Activation sequence
+- §25 Cancellation and Resume
+- §26 Monthly / Yearly Interval Changes
+- §27 Failed Payment and Grace Period
+- §37.4–.6 REST endpoints
+- §42.3 Subscription transitions
+
+## Idea of this task
+
+This is where the state machine from BE-06 meets real events. Keeping
+every state change flowing through `SubscriptionStateMachine.assertTransition`
+means the reachability of every canonical status is provably correct.
+Every action (webhook or user) becomes: load, assert-transition, mutate,
+publish event, save (with optimistic lock).
+
+## Development steps
+
+1. Add event handlers implementing `ProviderEventHandler` for each
+   sandbox event type; register them with the dispatcher (BE-09).
+2. Add `SubscriptionCommandService`:
+   `cancel(userId)`, `resume(userId)`, `changePrice(userId, priceCode)`.
+   Each: load `BillingAccount → active subscription`, assert-transition,
+   call provider port, update local row, publish event.
+3. Add `SubscriptionEventBus` (Spring `ApplicationEventPublisher` for
+   now; BE-15 replaces with outbox).
+4. Add endpoints in `BillingSubscriptionController`.
+5. Extend `BillingController.getMe(...)` (BE-04) to fill the
+   `subscription` field.
+6. Add scheduled `PeriodElapsedJob` (design §15) that runs hourly and
+   applies `PERIOD_ELAPSED` events to subs with `currentPeriodEnd <
+   now` (belt-and-braces alongside provider webhooks that would fire
+   `RENEWAL_SUCCEEDED` / `EXPIRED`).
+7. Tests.
+8. Run `./gradlew test checkstyleMain spotbugsMain`.
+
+## Final / expected result
+
+- Webhook `PAYMENT_CONFIRMED` moves the account from FREE to PRO on
+  next `GET /api/billing/me`.
+- Cancel / resume / change-price endpoints work per design; illegal
+  transitions return stable error codes.
+- PAST_DUE persists for 3 days; effective plan stays PRO during grace
+  via `EffectivePlanResolver`, drops to FREE after `graceEndsAt`.
+- `PeriodElapsedJob` cleans up subs whose period elapsed without a
+  provider event (safety net).
+- `./gradlew test`, `./gradlew checkstyleMain`, `./gradlew spotbugsMain`
+  pass.
+
+## REST API added / changed
+
+| Purpose | Method + Path |
+|---|---|
+| Cancel at period end | `POST /api/billing/subscription/cancel` |
+| Resume scheduled cancellation | `POST /api/billing/subscription/resume` |
+| Change interval at period end | `POST /api/billing/subscription/change-price` |
+| DTO change | `GET /api/billing/me` `subscription` field now populated when a subscription exists |
+
+## Tests to add
+
+- **Unit — `SubscriptionCommandServiceTest`**: cancel/resume/change
+  happy paths; illegal transitions return stable codes; optimistic
+  lock conflict returns idempotent success when the target state is
+  already applied.
+- **Integration — `WebhookPaymentConfirmedIT`** (sandbox + processor):
+  synthesize `PAYMENT_CONFIRMED` → row appears, `GET /api/billing/me`
+  reports PRO.
+- **Integration — `PastDueGraceIT`**: `PAYMENT_FAILED` → PAST_DUE +
+  grace; `EffectivePlanResolver` returns PRO during grace, FREE after.
+- **Integration — `PeriodElapsedJobIT`**: ACTIVE+`cancelAtPeriodEnd`
+  with elapsed period → CANCELED after job runs.
+- **Controller — `BillingSubscriptionControllerTest`**: 401 without
+  `X-User-Id`; 409 on illegal cancel/resume/change; 200 on happy path.
+- **Controller — `BillingMeSubscriptionShapeTest`**: field shape
+  matches §37.1 example.
+
+## Risk & follow-ups
+
+- `PeriodElapsedJob` and provider webhook can race. State machine +
+  optimistic lock make this safe: whichever writes second sees a
+  version mismatch and re-checks the current state.
+- Real provider event mapping (Stripe `invoice.payment_failed` etc.)
+  happens in the future adapter — canonical event names are stable.
+- BE-15's outbox replaces the in-process event bus; the handler
+  contract stays the same.

--- a/backend/lined/docs/billing/tasks/BE-12-downgrade-archive-workflow.md
+++ b/backend/lined/docs/billing/tasks/BE-12-downgrade-archive-workflow.md
@@ -1,0 +1,140 @@
+# Task BE-12 — Downgrade + Archive Workflow
+
+**Branch:** `feature/be-12-downgrade-archive-workflow`
+
+*Depends on BE-03 (lobby lifecycle + access mode + endpoints), BE-11
+(subscription events). Blocks UI-44, UI-45, UI-46.*
+
+## Detailed description
+
+When the effective plan flips from PRO to FREE, mark excess owned
+lobbies READ_ONLY with a 30-day archive deadline. Wire a daily job to
+archive lobbies whose deadline has passed. Restore READ_WRITE
+automatically when the effective plan flips back to PRO, except for
+already-archived lobbies (owner must restore those manually via BE-03's
+endpoint).
+
+Scope:
+
+1. `entitlement/application/EffectivePlanChangeHandler` subscribes to
+   `EFFECTIVE_PLAN_CHANGED` events published by BE-11:
+   - **PRO → FREE**: for each active lobby owned by the account's
+     owner user beyond the Free limit (1), set
+     `access_mode=READ_ONLY`, `restriction_reason=OWNER_PLAN_LIMIT_EXCEEDED`,
+     `archive_at = now + 30 days`. The retained lobby is chosen by the
+     user via `POST /api/lobbies/{id}/select-as-free` (BE-03); if no
+     selection has been made, keep the oldest lobby READ_WRITE as a
+     placeholder and mark all others READ_ONLY.
+   - **FREE → PRO**: for each `READ_ONLY, lifecycle=ACTIVE` lobby with
+     `restriction_reason=OWNER_PLAN_LIMIT_EXCEEDED`, flip to
+     READ_WRITE, clear `restriction_reason` and `archive_at`.
+     Archived lobbies stay ARCHIVED — owner uses BE-03's `restore`
+     endpoint.
+2. New scheduled job `LobbyArchiveJob`
+   (`@Scheduled(cron="0 30 3 * * *")` daily at 03:30 UTC):
+   - selects `lifecycle_status=ACTIVE`, `access_mode=READ_ONLY`,
+     `archive_at <= now` lobbies
+   - sets `lifecycle_status=ARCHIVED` (keeps access_mode READ_ONLY),
+     publishes `LOBBY_ARCHIVED` event for BE-15 to notify
+   - job is idempotent: repeated runs on the same row are no-ops
+3. Reduction-writes whitelist (design §29.3) — reuse the
+   `LobbyWritePolicy` from BE-03 with the four allowed actions:
+   `REMOVE_MEMBER`, `DELETE_LOBBY`, `LEAVE_LOBBY`,
+   `SELECT_AS_FREE_LOBBY`.
+4. New endpoint annotation via BE-03's `POST /api/lobbies/{id}/restore`
+   — this task just plugs the capacity + entitlement check into it
+   properly.
+5. Explicit refusal of new invites when owner is FREE and lobby is at
+   member cap — already handled by BE-02, but this task adds an
+   integration test proving the interaction.
+6. Notifications: when a lobby flips to READ_ONLY or is archived, this
+   task publishes `LOBBY_READ_ONLY` / `LOBBY_ARCHIVED` events; BE-15
+   attaches the notification handlers.
+
+## Design references
+
+- §28 Downgrade and Over-Limit Resource Policy
+- §29 Read-Only Lobby Operations
+- §30 Archived Lobby Policy
+- §30.1 Re-purchase behavior
+- §36.2 Lobby lifecycle events
+
+## Idea of this task
+
+Downgrade must never destroy data and must give the owner a real path
+back to writeable state without a re-subscription. Wrapping the read-only
+mark + 30-day archive deadline + auto-restore in one event-driven
+workflow means every trigger (cancel, expire, full refund) reaches the
+same consistent outcome.
+
+## Development steps
+
+1. Add `EffectivePlanChangeHandler` under `entitlement/application/`,
+   subscribed to `EFFECTIVE_PLAN_CHANGED`.
+2. Implement the PRO→FREE reduction: query
+   `LobbyRepository.findActiveOwnedBy(userId)`, sort by createdAt asc,
+   keep the oldest READ_WRITE, mark the rest READ_ONLY with the
+   30-day deadline.
+3. Implement the FREE→PRO restoration: query lobbies flagged by this
+   handler, flip back.
+4. Add `LobbyArchiveJob` under `lobby/application/`.
+5. Publish `LOBBY_READ_ONLY_APPLIED`, `LOBBY_RESTORED_TO_WRITE`,
+   `LOBBY_ARCHIVED` domain events.
+6. Extend `LobbyController.restore` (BE-03) to call
+   `EntitlementService`/`LimitEvaluator` for capacity — if BE-03
+   already did this, add an integration test confirming Pro capacity is
+   enforced on restore.
+7. Tests.
+8. Run `./gradlew test checkstyleMain spotbugsMain`.
+
+## Final / expected result
+
+- Cancelling Pro subscription and letting the period elapse (or a
+  full refund) results in all-but-one owned lobbies flipped to
+  READ_ONLY with `archive_at = now + 30d`.
+- Daily job archives lobbies whose `archive_at` has passed; no lobby
+  is deleted.
+- Restoring Pro flips READ_ONLY lobbies back to READ_WRITE
+  automatically; archived lobbies stay archived and must be restored
+  manually via BE-03's endpoint.
+- Attempts to create a new lobby, add a member, or write a task to a
+  READ_ONLY lobby return `LOBBY_READ_ONLY_DUE_TO_PLAN`; reduction
+  writes still succeed.
+- `./gradlew test`, `./gradlew checkstyleMain`, `./gradlew spotbugsMain`
+  pass.
+
+## REST API added / changed
+
+None here (BE-03 shipped the endpoints). This task changes the
+behavior of the effective-plan transition indirectly: `GET /api/lobbies/mine`
+starts including READ_ONLY / ARCHIVED lobbies with the new fields
+already introduced by BE-03.
+
+## Tests to add
+
+- **Unit — `EffectivePlanChangeHandlerTest`**: PRO→FREE with 3 owned
+  lobbies → 1 READ_WRITE + 2 READ_ONLY with deadline; FREE→PRO
+  restores the 2 to READ_WRITE.
+- **Integration — `LobbyArchiveJobIT`**: seeded READ_ONLY lobby with
+  past `archive_at` becomes ARCHIVED after job runs; job is idempotent.
+- **Integration — `DowngradeReductionWritesIT`**: on a READ_ONLY
+  lobby: `PATCH /api/lobbies/{id}` returns 409; `DELETE
+  /api/lobbies/{id}/members/{userId}` succeeds; `DELETE
+  /api/lobbies/{id}` succeeds; `POST /api/lobbies/{id}/select-as-free`
+  flips it back to READ_WRITE.
+- **Integration — `RestoreCapacityGateIT`**: on Pro with 10 lobbies
+  already active, restoring an 11th returns 409 LOBBY_LIMIT_EXCEEDED.
+- **End-to-end — `SubscriptionExpirationDowngradeIT`**: sandbox
+  `PROVIDER_EXPIRED` event → subscription EXPIRED → effective-plan
+  event fires → lobbies flip READ_ONLY.
+
+## Risk & follow-ups
+
+- If the user removes members to bring a READ_ONLY lobby under
+  `LOBBY_MEMBERS_MAX`, `select-as-free` (BE-03) is the mechanism —
+  the reduction job does not auto-select anything.
+- Multiple owners of shared lobbies: the design assumes single
+  ownership; if that changes (Family / Team), this handler needs to
+  consider effective plan across all co-owners.
+- The oldest-kept-READ_WRITE placeholder policy is a defensive
+  default; if product wants a different tie-break, change it here.

--- a/backend/lined/docs/billing/tasks/BE-13-transactions-refunds-admin.md
+++ b/backend/lined/docs/billing/tasks/BE-13-transactions-refunds-admin.md
@@ -1,0 +1,155 @@
+# Task BE-13 — Transactions + Refunds + Admin Refund Flow
+
+**Branch:** `feature/be-13-transactions-refunds-admin`
+
+*Depends on BE-06 (subscription), BE-09 (webhook inbox handles refund
+events), BE-11 (subscription lifecycle publishes activation-related
+events), BE-14 (permission model — land BE-14 first if the
+`@RequiresPermission` interceptor is not yet available; otherwise ship
+the two together).*
+
+## Detailed description
+
+Persist billing transactions from payment/refund webhooks; expose admin
+endpoints to preview and issue refunds, gated by the new
+`BILLING_REFUND` permission. Provider is authoritative — a refund is
+`SUCCEEDED` only after the refund webhook confirms it.
+
+Scope:
+
+1. New tables:
+   - `billing_transactions` per design §12.7:
+     `id`, `billing_account_id`, `subscription_id` (nullable),
+     `provider_transaction_id` (unique), `provider_price_id`,
+     `amount_minor`, `currency`, `tax_minor` (nullable), `status`,
+     `occurred_at`, `created_at`
+   - `billing_refunds` per design §12.8:
+     `id`, `transaction_id` FK, `provider_refund_id` (nullable, unique
+     when set), `type` (`FULL|PARTIAL|PRORATED_UNUSED_TIME`),
+     `amount_minor`, `currency`, `status`
+     (`REQUESTED|PENDING|SUCCEEDED|FAILED|REJECTED`),
+     `reason_code`, `reason_text`, `access_behavior`
+     (`KEEP_ACCESS_UNTIL_PERIOD_END|END_ACCESS_AFTER_REFUND`),
+     `requested_by_user_id`, `provider_updated_at`, timestamps
+2. Webhook handlers under `billing/application/event/`:
+   - `TRANSACTION_SUCCEEDED` → insert transaction row (idempotent on
+     `provider_transaction_id`)
+   - `REFUND_SUCCEEDED` → mark refund `SUCCEEDED`, apply
+     `access_behavior`: `END_ACCESS_AFTER_REFUND` publishes
+     `EFFECTIVE_PLAN_CHANGED PRO→FREE`
+   - `REFUND_FAILED` → mark refund `FAILED` (retryable via BE-14 admin
+     endpoint)
+3. Admin endpoints under `billing/api/admin/`:
+   - `POST /api/admin/billing/transactions/{transactionId}/refund-preview`
+     — requires `BILLING_REFUND`; returns
+     `RefundPreview` from `BillingRefundProvider.previewRefund(...)`:
+     max refundable, currency, whether provider requires review
+   - `POST /api/admin/billing/transactions/{transactionId}/refunds`
+     — requires `BILLING_REFUND`; body:
+     `{ type, amountMinor, currency, reasonCode, reasonText?,
+     accessBehavior, idempotencyKey }`
+   - Validation: `amount > 0`; `amount ≤ providerRefundable`;
+     `currency == transaction.currency`; not already fully refunded;
+     `PRORATED_UNUSED_TIME` defaults `accessBehavior=END_ACCESS_AFTER_REFUND`
+4. User-facing history endpoints:
+   - `GET /api/billing/transactions` (auth-derived, paginated)
+   - `GET /api/billing/refunds` (auth-derived, paginated)
+5. Every admin action writes to `billing_audit_log` (table introduced
+   in BE-14).
+6. Product refund policy (design §31.1) is enforced as a **check
+   surfaced in the preview response**, not a hard block on the issue
+   endpoint — the design allows exceptional Admin overrides (§32).
+   Preview returns `withinDefaultWindow` boolean; UI-50 uses it.
+
+## Design references
+
+- §12.7 `billing_transactions`
+- §12.8 `billing_refunds`
+- §31 Refund Policy
+- §32 Refund Eligibility Decision
+- §33 Full Refund Sequence
+- §34 Partial Refund Sequence
+- §35 Refund Failure and Retry
+- §40.5–40.6 Admin refund endpoints
+- §41.3 Admin authorization
+- §42.5 Refund idempotency
+
+## Idea of this task
+
+Refunds combine three sources of truth: the transaction (what was
+charged), the product policy (window + admin discretion), and the
+provider (final financial state). Splitting into "preview" (which
+consults the provider for the max refundable amount and the policy for
+eligibility) and "issue" (which persists intent, calls the provider
+with idempotency, then waits for the webhook) is the only pattern that
+avoids double refunds when a provider response times out.
+
+## Development steps
+
+1. Append `billing_transactions` and `billing_refunds` DDL to
+   `schema.sql`.
+2. Add entities + repositories under `billing/domain/transaction/` and
+   `billing/domain/refund/`.
+3. Add `TransactionEventHandler` and `RefundEventHandler` implementing
+   BE-09's `ProviderEventHandler`.
+4. Add `AdminBillingRefundController` under `billing/api/admin/`;
+   annotate with `@RequiresPermission("BILLING_REFUND")` (interceptor
+   from BE-14).
+5. Add `RefundService.preview(transactionId)` and
+   `RefundService.issue(transactionId, RefundCommand)`.
+6. Add `BillingHistoryController` under `billing/api/web/` for user
+   `GET /api/billing/transactions|refunds` (derives account from
+   `X-User-Id`).
+7. Tests.
+8. Run `./gradlew test checkstyleMain spotbugsMain`.
+
+## Final / expected result
+
+- Payment webhook creates a `billing_transactions` row visible via
+  `GET /api/billing/transactions` for the paying user.
+- Admin can preview a refund (returns max amount from provider +
+  within-window flag) and issue it; issue persists REQUESTED, calls
+  provider with idempotency, moves to PENDING; webhook then
+  SUCCEEDED / FAILED.
+- FAILED refunds can be retried via BE-14's `retry-failed-event` (does
+  not create a duplicate provider refund because the same
+  `providerRefundId` is passed).
+- Non-admin caller of admin endpoints: 403.
+- Admin without `BILLING_REFUND`: 403.
+- `./gradlew test`, `./gradlew checkstyleMain`, `./gradlew spotbugsMain`
+  pass.
+
+## REST API added / changed
+
+| Purpose | Method + Path |
+|---|---|
+| List my transactions | `GET /api/billing/transactions?page=&size=` |
+| List my refunds | `GET /api/billing/refunds?page=&size=` |
+| Admin refund preview | `POST /api/admin/billing/transactions/{transactionId}/refund-preview` |
+| Admin issue refund | `POST /api/admin/billing/transactions/{transactionId}/refunds` (body per above) |
+
+## Tests to add
+
+- **Unit — `RefundServiceTest`**: preview returns provider max and
+  within-window flag; issue rejects amount 0 / above max / wrong
+  currency; issue persists REQUESTED and returns immediately.
+- **Integration — `RefundIssueThenWebhookIT`**: admin issue → REQUESTED
+  → `REFUND_SUCCEEDED` synthetic webhook → SUCCEEDED and effective
+  plan flips per `accessBehavior`.
+- **Integration — `RefundWebhookIdempotencyIT`**: duplicate
+  `REFUND_SUCCEEDED` webhooks → single terminal state, no double
+  application to lobbies.
+- **Controller — `AdminRefundControllerAuthTest`**: user without
+  ADMIN role → 403; ADMIN without `BILLING_REFUND` permission → 403;
+  full-permission ADMIN → 200.
+- **Controller — `BillingHistoryControllerTest`**: user sees only
+  their own transactions/refunds; pagination bounds respected.
+
+## Risk & follow-ups
+
+- Immediate-status providers (returning `SUCCEEDED` synchronously)
+  still round-trip through the webhook path — the webhook may fire
+  again as confirmation; state stays SUCCEEDED (idempotent).
+- If the transaction currency differs from the request currency,
+  400 `REFUND_AMOUNT_INVALID` with a clear message. Currency conversion
+  is out of scope.

--- a/backend/lined/docs/billing/tasks/BE-14-admin-billing-api-audit.md
+++ b/backend/lined/docs/billing/tasks/BE-14-admin-billing-api-audit.md
@@ -1,0 +1,140 @@
+# Task BE-14 — Admin Billing API + Audit + Permission Model
+
+**Branch:** `feature/be-14-admin-billing-api-audit`
+
+*Depends on BE-06 (subscriptions), BE-09 (webhook inbox for retry),
+BE-13 (refunds — coordinate; BE-13 uses this task's `@RequiresPermission`
+interceptor). Blocks UI-49.*
+
+## Detailed description
+
+Ship the admin billing surface (search, view, resync, retry event),
+introduce a minimal permission model since Spring Security isn't in
+use, and start writing to a `billing_audit_log` table on every
+privileged action.
+
+Scope:
+
+1. Permission model (new — the codebase has `BuiltInRole` but no
+   permissions):
+   - `common/security/Permission` enum: `BILLING_READ`, `BILLING_OPS`,
+     `BILLING_REFUND`, `FEATURE_FLAG_ADMIN`, `AUDIT_READ`
+   - `user_permissions` join table: `user_id`, `permission`, `granted_by`,
+     `granted_at`, `expires_at` (nullable), `reason`
+   - `PermissionService.hasPermission(userId, permission)` reads from
+     the join table
+   - `@RequiresPermission("XXX")` annotation + `HandlerInterceptor`
+     that reads `X-User-Id`, looks up permissions, and 403s if missing
+   - Bootstrap: no permissions granted automatically; admins are
+     granted via a raw SQL update or (after BE-14) via a new admin
+     endpoint on the user module. This task ships a
+     `PermissionAdminController` with `POST /api/admin/users/{userId}/permissions`
+     (self-referential — an ADMIN with `AUDIT_READ` + `BILLING_OPS` can
+     grant others). First admin permission is granted via SQL by an
+     operator during rollout.
+2. `billing_audit_log` table per §12.11 + `AuditService.record(...)`
+   called from every admin action.
+3. Admin endpoints under `billing/api/admin/`:
+   - `GET /api/admin/billing/accounts?query=` — search by email,
+     billing account id, provider customer id, provider subscription
+     id, transaction id. Requires `BILLING_READ`.
+   - `GET /api/admin/billing/accounts/{billingAccountId}` — full detail
+     per §40.2. Requires `BILLING_READ`.
+   - `POST /api/admin/billing/accounts/{billingAccountId}/resync` —
+     calls `BillingReconciliationProvider.getSubscriptionSnapshot`,
+     applies drift, records audit; returns before/after + changes.
+     Requires `BILLING_OPS`.
+   - `POST /api/admin/billing/provider-events/{eventId}/retry` — sets
+     inbox row `processing_status=RECEIVED`, resets `attempt_count`,
+     lets BE-09's processor pick it up. Requires `BILLING_OPS`.
+   - `GET /api/admin/billing/audit-log?billingAccountId=&limit=` —
+     requires `AUDIT_READ`.
+4. Provider dashboard deep-link: the account detail response includes
+   `providerDashboardUrl` if the adapter's capability advertises
+   `customerPortal` or a dashboard link builder. Server validates and
+   builds the URL — never accepts one from the client.
+
+## Design references
+
+- §40 Admin REST API
+- §40.2 Account details
+- §40.3 Manual resync
+- §40.4 Retry failed event
+- §41.3 Admin authorization matrix
+- §12.11 `billing_audit_log`
+- §47 Admin Panel Design
+
+## Idea of this task
+
+Support/ops need to see what a provider sees, unstick failed webhooks,
+and act on refunds — but every action must be attributable and only
+allowed to actors with the right permission. Introducing the smallest
+permission model (enum + join table + annotation) that satisfies the
+design's `BILLING_REFUND` requirement, paired with an audit log, gives
+future admin surfaces (feature flags, user impersonation) a shared
+mechanism.
+
+## Development steps
+
+1. Append `user_permissions` and `billing_audit_log` DDL to
+   `schema.sql`.
+2. Add `Permission` enum + `UserPermissionEntity` +
+   `UserPermissionRepository`.
+3. Add `PermissionService` + `RequiresPermission` annotation +
+   `PermissionInterceptor` registered in `WebMvcConfigurer`.
+4. Add `AuditService` + `BillingAuditLogEntity`.
+5. Implement the four admin endpoints in a new
+   `AdminBillingController`. The resync endpoint depends on BE-15's
+   reconciliation service — inject an interface stub and land the real
+   implementation in BE-15.
+6. Add `PermissionAdminController` for the grant flow.
+7. Tests.
+8. Run `./gradlew test checkstyleMain spotbugsMain`.
+
+## Final / expected result
+
+- `@RequiresPermission("BILLING_REFUND")` protects BE-13's refund
+  endpoints and returns 403 when missing.
+- Admin can search, view, resync, and retry failed webhook events.
+- Every privileged action writes a `billing_audit_log` row with
+  before/after JSON snapshots (redacted — no card data, no full
+  provider payloads).
+- `./gradlew test`, `./gradlew checkstyleMain`, `./gradlew spotbugsMain`
+  pass.
+
+## REST API added / changed
+
+| Purpose | Method + Path |
+|---|---|
+| Search billing accounts | `GET /api/admin/billing/accounts?query=` |
+| View billing account details | `GET /api/admin/billing/accounts/{billingAccountId}` |
+| Manual resync | `POST /api/admin/billing/accounts/{billingAccountId}/resync` |
+| Retry failed webhook | `POST /api/admin/billing/provider-events/{eventId}/retry` |
+| Audit log | `GET /api/admin/billing/audit-log?billingAccountId=&limit=` |
+| Grant permission (bootstrap after first SQL admin) | `POST /api/admin/users/{userId}/permissions` |
+
+## Tests to add
+
+- **Unit — `PermissionInterceptorTest`**: missing `X-User-Id` → 401;
+  user without permission → 403; user with permission → pass-through.
+- **Unit — `AuditServiceTest`**: records action with sanitized
+  before/after JSON.
+- **Integration — `AdminSearchIT`** (Testcontainers): search by email
+  matches; search by `provider_customer_id` matches; empty results
+  return 200 with empty array.
+- **Integration — `RetryFailedEventIT`**: seeded FAILED inbox event →
+  retry endpoint resets it; processor re-runs.
+- **Controller — `AdminBillingControllerAuthTest`**: cross-permission
+  matrix per §41.3.
+- **Controller — `PermissionAdminControllerBootstrapTest`**: first
+  admin (granted via SQL) can grant `BILLING_REFUND` to a second admin.
+
+## Risk & follow-ups
+
+- The permission interceptor introduces a middleware layer. Ensure the
+  webhook endpoint (BE-09) is excluded — it has no `X-User-Id`.
+- Migrating the whole app to Spring Security is out of scope here; if
+  that ever happens, the `Permission` enum + join table map cleanly to
+  `GrantedAuthority`.
+- Audit-log JSON size grows quickly; BE-15 or a follow-up should add a
+  retention policy.

--- a/backend/lined/docs/billing/tasks/BE-15-reconciliation-outbox-notifications-rollout.md
+++ b/backend/lined/docs/billing/tasks/BE-15-reconciliation-outbox-notifications-rollout.md
@@ -1,0 +1,189 @@
+# Task BE-15 — Reconciliation + Outbox + Notifications + Rollout + Observability
+
+**Branch:** `feature/be-15-reconciliation-outbox-notifications-rollout`
+
+*Depends on BE-11 (subscription events), BE-12 (downgrade events),
+BE-13 (refund events), BE-14 (permission model + audit log). Last
+task — closes out §57 Definition of Done.*
+
+## Detailed description
+
+Ship the remaining operational, observability, and rollout mechanics
+so billing can be enabled safely for allowlisted users, then publicly.
+
+Scope:
+
+1. **Reconciliation** — daily job:
+   - candidate selection per §23.3: `ACTIVE` with elapsed
+     `currentPeriodEnd`, `PAST_DUE` subs, subs with `last_synced_at <
+     now - 24h`, subs referenced by FAILED inbox events, subs manually
+     flagged
+   - for each candidate, call `BillingReconciliationProvider.getSubscriptionSnapshot`,
+     compare with local, apply drift, write to `billing_audit_log`
+     (reason: `RECONCILIATION_DRIFT`)
+   - update `last_synced_at` on each processed row
+   - metric `billing_reconciliation_drift_total` +
+     `billing_reconciliation_failed_total`
+2. **Outbox** — replace BE-11's in-process event bus with a durable
+   outbox table:
+   - `billing_domain_events` table: `id`, `aggregate_type`,
+     `aggregate_id`, `event_type`, `payload_json`, `occurred_at`,
+     `processed_at` (nullable), `attempt_count`, `last_error`
+   - `OutboxPublisher` (`@Scheduled`) picks up unpublished rows and
+     delivers via a `DomainEventPublisher` interface to in-process
+     subscribers (entitlement handler, lobby archive events,
+     notification service)
+   - Publishing is at-least-once; consumers must be idempotent
+     (already true for BE-12's handler and BE-15's notification
+     service).
+3. **Notifications** — templates for §36.1 (billing) and §36.2 (lobby
+   lifecycle) events. `BillingNotificationSubscriber` listens on the
+   outbox, renders `NotificationEntity` rows for in-app inbox + email
+   dispatch (uses existing `notification` module patterns):
+   - `payment_successful`, `subscription_activated`,
+     `cancellation_scheduled`, `cancellation_resumed`,
+     `price_change_scheduled`, `renewal_failed`,
+     `grace_period_expires_soon`, `payment_recovered`,
+     `subscription_expired`, `refund_requested`, `refund_completed`,
+     `refund_failed`
+   - `lobby_read_only`, `owner_must_select_free_lobby`,
+     `lobby_will_be_archived`, `lobby_archived`, `lobby_restored`,
+     `pro_restored_restrictions_removed`
+   - Delivery scheduling per §36.4 (grace warnings at 0h and grace-24h;
+     archive warnings at downgrade, deadline-7d, deadline-1d)
+   - Jobs are idempotent (dedup by `(subscription_id, event_type,
+     bucket)`)
+4. **Feature flags & rollout** — Spring properties + `billing_beta_accounts`
+   table + gate:
+   - `billing.ui.enabled` (boolean) — surfaced in
+     `GET /api/billing/me` as a flag; UI hides the whole billing
+     surface when false
+   - `billing.checkout.enabled` (boolean) — `POST /api/billing/checkout`
+     returns 403 `BILLING_DISABLED` when false
+   - `billing.rollout.mode` — enum `DISABLED|ALLOWLIST|PUBLIC`; when
+     `ALLOWLIST`, both `enabled` flags require the caller's
+     BillingAccount to be in `billing_beta_accounts`
+   - Admin endpoints under `billing/api/admin/`:
+     `POST /api/admin/billing/beta-accounts` and `DELETE` with
+     `BILLING_OPS` permission
+   - `billing.provider` **must never be `sandbox` in `prod` profile** —
+     enforce at startup (design §52 Phase 5 kill switch).
+   - Webhook processing (BE-09) is **not** gated by these flags — it
+     always runs (design §18.2).
+5. **Metrics** — Micrometer counters + timers from §50.1. Register in a
+   central `BillingMetrics` bean and increment from each handler.
+6. **Structured logs** — MDC entries per §50.2 (`correlationId`,
+   `provider`, `providerEventId`, `billingAccountId`, `subscriptionId`,
+   `operation`).
+7. **Alerts** — document alert queries in `docs/billing/OBSERVABILITY.md`
+   (webhook failures, invalid signatures, drift, provider API error
+   rate, stale PAST_DUE, ACTIVE with elapsed period, refund failures,
+   outbox backlog, archive job failures).
+8. **Legacy cleanup** — after ~1 release cycle: `DROP TABLE
+   user_subscriptions`. Deferred to a follow-up so this task doesn't
+   block on that timing.
+9. **ArchUnit slice test** — cycle-free slices per §54:
+   `slices().matching("io.backend.lined.(*)..").should().beFreeOfCycles()`.
+
+## Design references
+
+- §18 Feature Flags and Rollout
+- §22.4 Webhook always processes
+- §23 Reconciliation
+- §24 (outbox events list)
+- §36 Notifications
+- §43.1 Outbox events
+- §50 Observability
+- §52 Rollout plan phases
+- §54 Architecture Enforcement
+- §57 Definition of Done
+
+## Idea of this task
+
+Everything above BE-15 assumes there is a way to (a) detect drift when
+webhooks are missed, (b) turn the whole surface off/on for a subset of
+users, (c) tell users what happened. Landing all three in one task
+means the "Definition of Done" isn't held up by scope splinters.
+
+## Development steps
+
+1. Append `billing_domain_events`, `billing_beta_accounts` DDL to
+   `schema.sql`.
+2. Add `OutboxService.publish(event)` + `OutboxPublisher`
+   (`@Scheduled`).
+3. Migrate BE-11's `subscriptionEventBus.publish(...)` calls to
+   `outboxService.publish(...)`.
+4. Add `ReconciliationJob` (`@Scheduled(cron="0 30 4 * * *")`) +
+   `ReconciliationService` + audit writes.
+5. Wire `AdminBillingController.resync` (BE-14) to
+   `ReconciliationService.reconcileOne(billingAccountId)`.
+6. Add `BillingNotificationSubscriber` listening on outbox event
+   types.
+7. Add feature-flag gates: `BillingFeatureFlags` component reads
+   properties + allowlist; used in
+   `BillingCheckoutController` and returned from `GET /api/billing/me`.
+8. Add `billing/infrastructure/config/BillingProviderProfileGuard`
+   (fails startup when prod + sandbox).
+9. Add `BillingMetrics` bean + increment sites in every handler.
+10. Add MDC filter for structured logs.
+11. Write `docs/billing/OBSERVABILITY.md` with alert queries.
+12. Add ArchUnit slice test.
+13. Tests.
+14. Run `./gradlew test checkstyleMain spotbugsMain`.
+
+## Final / expected result
+
+- Daily reconciliation runs and repairs drift; drift shows up as
+  metrics + audit log entries.
+- All subscription/refund events go through the durable outbox — a
+  restart mid-processing never drops an event.
+- Users receive notifications for the events listed in §36.
+- Flipping `billing.rollout.mode=PUBLIC` (in a follow-up rollout PR)
+  reveals the full billing UI to everyone; `ALLOWLIST` restricts to
+  `billing_beta_accounts`.
+- Prod deploy with `billing.provider=sandbox` fails to start.
+- Micrometer scrape shows the counters from §50.1.
+- ArchUnit slice test passes.
+- `./gradlew test`, `./gradlew checkstyleMain`, `./gradlew spotbugsMain`
+  pass.
+
+## REST API added / changed
+
+| Purpose | Method + Path |
+|---|---|
+| DTO change | `GET /api/billing/me` now includes `rollout: { uiEnabled, checkoutEnabled }` for UI-38 to consume |
+| Add beta account | `POST /api/admin/billing/beta-accounts` (body `{ billingAccountId, expiresAt?, reason }`) |
+| Remove beta account | `DELETE /api/admin/billing/beta-accounts/{billingAccountId}` |
+
+## Tests to add
+
+- **Integration — `ReconciliationJobIT`**: seeded ACTIVE local with
+  provider snapshot `CANCELED` → local flips to CANCELED, drift audit
+  log written, `billing_reconciliation_drift_total` incremented.
+- **Integration — `OutboxPublisherIT`**: event inserted in a
+  transaction that rolls back → not published; committed → published
+  exactly once; publisher crash mid-batch → next run publishes
+  remainder.
+- **Integration — `NotificationEmissionIT`**: subscription activation
+  outbox event → single in-app notification created; grace-warning
+  scheduling is idempotent (running twice → still one notification per
+  bucket).
+- **Controller — `RolloutGateTest`**: `billing.checkout.enabled=false`
+  → 403 `BILLING_DISABLED`; `mode=ALLOWLIST` + not on allowlist → 403;
+  same + allowlisted → 200.
+- **Startup — `SandboxInProdRefusalTest`**: `spring.profiles.active=prod`
+  + `billing.provider=sandbox` → application context fails to start.
+- **Architecture — `BillingSliceCycleTest`**: no package cycles.
+
+## Risk & follow-ups
+
+- Reconciliation is O(rows) per day. If subscription volume grows
+  substantially, add pagination + parallelism.
+- Notification retries currently rely on the existing `notification`
+  module's retry — verify it exists; if not, add a small
+  `NotificationRetryJob`.
+- Dropping `user_subscriptions` is intentionally deferred; add a
+  follow-up ticket referencing this task.
+- The webhook processor (BE-09) runs on the same instance as
+  reconciliation and outbox publisher; if that becomes a hot spot,
+  split them into their own thread pools.

--- a/lined-web/docs/UI_TASKS.md
+++ b/lined-web/docs/UI_TASKS.md
@@ -237,7 +237,7 @@ dark-mode toggle shipped in Task 12 has never been audited screen-by-screen.
 | 23 | `feature/ui-23-dark-mode-audit` | Dark-mode token layer + screen-by-screen audit of the theme toggle shipped in Task 12 | [tasks/UI-23-dark-mode-audit.md](tasks/UI-23-dark-mode-audit.md) | DONE |
 | 24 | `feature/ui-24-i18n-localization` | Localization (react-i18next): English + Ukrainian, plurals, locale dates, settings switcher | [tasks/UI-24-i18n-localization.md](tasks/UI-24-i18n-localization.md) | DONE |
 | 25 | `feature/ui-25-loading-states-audit` | Skeleton system: route/section/action loading tiers, zero layout shift, no full-page spinners | [tasks/UI-25-loading-states-audit.md](tasks/UI-25-loading-states-audit.md) | TODO |
-| 26 | `feature/ui-26-payment-checkout` | Payment flow: checkout modal → provider-hosted payment → return states + payment history | [tasks/UI-26-payment-checkout.md](tasks/UI-26-payment-checkout.md) | TODO |
+| 26 | `feature/ui-26-payment-checkout` | Payment flow: checkout modal → provider-hosted payment → return states + payment history | [tasks/UI-26-payment-checkout.md](tasks/UI-26-payment-checkout.md) | SUPERSEDED — see UI-38..UI-50 |
 | 27 | `feature/ui-27-dashboard-summary` | Adopt `GET /api/dashboard/summary`: one request, accurate lobby-card counts, 404 fallback | [tasks/UI-27-dashboard-summary.md](tasks/UI-27-dashboard-summary.md) | TODO |
 | 28 | `feature/ui-28-lobby-chat` | Lobby Chat tab: polling message list, optimistic send, edit/delete, chat notifications | [tasks/UI-28-lobby-chat.md](tasks/UI-28-lobby-chat.md) | TODO |
 | 29 | `feature/ui-29-lobby-stats` | Lobby Stats tab: time-together tiles, month picker, per-member split bars | [tasks/UI-29-lobby-stats.md](tasks/UI-29-lobby-stats.md) | TODO |
@@ -249,6 +249,19 @@ dark-mode toggle shipped in Task 12 has never been audited screen-by-screen.
 | 35 | `feature/ui-35-feature-flags-foundation` | Typed public feature discovery, TanStack Query hooks, disabled-response synchronization, and reusable guards | [tasks/UI-35-feature-flags-foundation.md](tasks/UI-35-feature-flags-foundation.md) | TODO |
 | 36 | `feature/ui-36-feature-gated-capabilities` | Apply seven feature flags across routes, navigation, composite surfaces, overlays, and protected queries | [tasks/UI-36-feature-gated-capabilities.md](tasks/UI-36-feature-gated-capabilities.md) | TODO |
 | 37 | `feature/ui-37-feature-flags-admin` | Admin-only runtime flag table with ETag-safe toggles and failure/conflict handling | [tasks/UI-37-feature-flags-admin.md](tasks/UI-37-feature-flags-admin.md) | TODO |
+| 38 | `feature/ui-38-billing-me-page-scaffold` | Billing feature scaffold + `GET /api/billing/me` page + shared toast primitive (supersedes UI-14 + first half of UI-26) | [tasks/UI-38-billing-me-page-scaffold.md](tasks/UI-38-billing-me-page-scaffold.md) | TODO |
+| 39 | `feature/ui-39-pricing-preview-monthly-yearly` | Localized pricing card with monthly/yearly toggle from `GET /api/billing/prices` | [tasks/UI-39-pricing-preview-monthly-yearly.md](tasks/UI-39-pricing-preview-monthly-yearly.md) | TODO |
+| 40 | `feature/ui-40-checkout-overlay-activation-pending` | Provider overlay checkout + PAYMENT_CONFIRMATION_PENDING polling (never activate from client callback) | [tasks/UI-40-checkout-overlay-activation-pending.md](tasks/UI-40-checkout-overlay-activation-pending.md) | TODO |
+| 41 | `feature/ui-41-cancel-resume-flows` | Schedule cancellation at period end + resume before period end | [tasks/UI-41-cancel-resume-flows.md](tasks/UI-41-cancel-resume-flows.md) | TODO |
+| 42 | `feature/ui-42-change-interval-flow` | Change monthly ↔ yearly at `currentPeriodEnd` + scheduled-change chip | [tasks/UI-42-change-interval-flow.md](tasks/UI-42-change-interval-flow.md) | TODO |
+| 43 | `feature/ui-43-past-due-grace-warnings` | PAST_DUE banner + persistent chip + lobby callout + "Update payment method" | [tasks/UI-43-past-due-grace-warnings.md](tasks/UI-43-past-due-grace-warnings.md) | TODO |
+| 44 | `feature/ui-44-select-free-lobby-flow` | Post-downgrade "choose your Free lobby" modal + deadline banner | [tasks/UI-44-select-free-lobby-flow.md](tasks/UI-44-select-free-lobby-flow.md) | TODO |
+| 45 | `feature/ui-45-read-only-lobby-ux` | READ_ONLY lobby ribbon + disabled write controls + centralized `LOBBY_READ_ONLY_DUE_TO_PLAN` handler | [tasks/UI-45-read-only-lobby-ux.md](tasks/UI-45-read-only-lobby-ux.md) | TODO |
+| 46 | `feature/ui-46-archived-lobbies-section` | Archived lobbies sidebar section + `/lobbies/archived` route + restore | [tasks/UI-46-archived-lobbies-section.md](tasks/UI-46-archived-lobbies-section.md) | TODO |
+| 47 | `feature/ui-47-billing-history-transactions-refunds` | Payment History card (Transactions + Refunds tabs) paginated | [tasks/UI-47-billing-history-transactions-refunds.md](tasks/UI-47-billing-history-transactions-refunds.md) | TODO |
+| 48 | `feature/ui-48-customer-portal-button` | "Manage billing" button opens provider portal in a new tab | [tasks/UI-48-customer-portal-button.md](tasks/UI-48-customer-portal-button.md) | TODO |
+| 49 | `feature/ui-49-admin-billing-view` | Admin `/admin/billing`: search, account detail, resync, retry event, audit log (permission-gated) | [tasks/UI-49-admin-billing-view.md](tasks/UI-49-admin-billing-view.md) | TODO |
+| 50 | `feature/ui-50-admin-refund-flow` | Admin refund preview + issue flow with `BILLING_REFUND` permission gate and `withinDefaultWindow` flag | [tasks/UI-50-admin-refund-flow.md](tasks/UI-50-admin-refund-flow.md) | TODO |
 
 ## Suggested order
 
@@ -288,6 +301,31 @@ remain usable when all product capabilities are disabled. Task 37 depends on
 the backend admin API, with `feature/feature-flags-sync` required for complete
 multi-replica release behavior. Canonical semantics and capability boundaries
 live in `backend/lined/docs/feature-flags.md`.
+
+**Batch 38–50 (billing subsystem, 2026-07):** these tasks implement the
+target subscription/billing architecture defined in
+`Downloads/subscription-billing-system-design.md` (backend companion:
+`backend/lined/docs/billing/BILLING_TASKS.md`). They **supersede UI-14 and
+UI-26** entirely — the old subscription prototype and the placeholder
+payment-checkout task are replaced by this batch. Provider is deliberately
+TBD; the backend ships a sandbox stub adapter, so every UI task in this
+batch is MSW-first and fully verifiable in dev without provider credentials.
+
+Order: **38** first (scaffold + toast primitive; unblocks all others).
+Then **39 → 40** (pricing preview → checkout overlay) as one paired
+slice. **41, 42, 48** are small, independent, and can land any time
+after 38 in parallel PRs. **43** depends on 48 (shares the "Update
+payment method" CTA). The downgrade thread is **44 → 45 → 46**: land in
+order to keep the read-only visual language consistent. **47** is
+independent after 38. **49 → 50** (admin surfaces) come last; they depend
+on the backend permission model (BE-14) which is late in the backend
+sequence.
+
+Backend dependency map (blocking pairs):
+UI-38 ← BE-04; UI-39 ← BE-10; UI-40 ← BE-10 + BE-11; UI-41/42 ← BE-11;
+UI-43 ← BE-11 (+BE-15 for lobby DTO hint); UI-44/45/46 ← BE-03 + BE-12;
+UI-47 ← BE-13; UI-48 ← BE-11/BE-15 portal endpoint;
+UI-49 ← BE-14; UI-50 ← BE-13 + BE-14.
 
 ## Conventions for every task
 

--- a/lined-web/docs/tasks/UI-38-billing-me-page-scaffold.md
+++ b/lined-web/docs/tasks/UI-38-billing-me-page-scaffold.md
@@ -1,0 +1,120 @@
+# Task 38 — Billing Feature Scaffold + `/api/billing/me`
+
+**Branch:** `feature/ui-38-billing-me-page-scaffold`
+
+*Depends on backend BE-04 (`GET /api/billing/me`). Supersedes the
+first half of Task 14 (subscription page prototype) and part of
+Task 26 (payment checkout). Batch 38–50 (billing, 2026-07): land
+first — every other UI-38..UI-50 task builds on this feature folder.*
+
+## Detailed description
+
+Replace `src/features/subscription/` with a new
+`src/features/billing/` feature and re-point the `/subscription` route
+at it. The new page renders the authenticated billing snapshot
+(`GET /api/billing/me`) — effective plan, subscription status, grace
+deadline, plan limits — and provides the shared toast primitive every
+following billing task will use for feedback.
+
+- **Header card** — plan badge ("FREE" / "PRO"), subscription status
+  ("Active", "Cancels on {date}", "Payment past due — grace ends {date}",
+  "Free"), Free/Pro limit summary ("1 lobby · 4 members" or "10 · 20").
+- **Upgrade CTA** — visible only when `effectivePlan=FREE` and
+  `rollout.uiEnabled=true`; opens the pricing card from UI-39
+  (placeholder button in this task).
+- **Manage-your-plan region** — placeholder card for cancel/resume
+  (UI-41), change interval (UI-42), payment portal (UI-48). Buttons
+  disabled with tooltip "Coming with UI-41/42/48".
+- **Toast primitive** — introduce `sonner` (or a small in-house
+  provider — pick sonner unless the shadcn team has a preference)
+  mounted at the app root. `billing/lib/toast.ts` wraps it as
+  `notify.success(msg)` / `notify.error(msg)` so tests can spy
+  centrally.
+- **Rollout gate** — when `rollout.uiEnabled=false`, the page renders
+  a single "Billing is not available yet" message; the settings-menu
+  link is hidden.
+
+## Idea of this task
+
+Every following billing UI task needs the same feature folder, the same
+data shape from `/api/billing/me`, and consistent error/toast feedback.
+Landing scaffold + minimum render + toast primitive in one task means
+UI-39..UI-50 are additive on a coherent base and never accumulate an
+inconsistent "banner or toast or inline?" decision.
+
+## Reference to mockup
+
+- Reuse existing `subscription` screen
+  (`http://localhost:4321/#subscription`) as the layout baseline. The
+  new page is a strict superset: same left column, same card grid
+  frame; the plan cards / history region will be filled by UI-39 /
+  UI-47.
+
+## Development steps
+
+1. **MSW first.** Under `src/features/billing/api/`, add:
+   - `mockData.ts` — a `MOCK_BILLING_ME` seed (default FREE, then
+     variants: PRO_ACTIVE, PRO_CANCEL_SCHEDULED, PAST_DUE_IN_GRACE)
+   - `handlers.ts` — GET `/api/billing/me` returning the FREE variant
+     by default; expose a `setBillingMeVariant(name)` helper for tests
+   - `dev.ts` + `prod.ts` + `index.ts` following the existing feature
+     convention (matching `src/features/subscription/api/`)
+   - `model/index.ts` — TS types matching the backend `BillingMeDto`
+     shape (BE-04 + BE-11 populated `subscription`, BE-15 populated
+     `rollout`)
+2. **Hook.** Add `src/features/billing/hooks/useBillingMe.ts` — a
+   TanStack `useQuery` reading `GET /api/billing/me`; key in
+   `src/features/billing/lib/constants.ts` `QUERY_KEYS.billingMe = ['billing','me'] as const`.
+3. **Toast provider.** Install sonner and mount `<Toaster />` in
+   `src/App.tsx`. Add `src/lib/toast.ts` — thin `notify` façade over
+   `toast.success/error`. Do **not** modify any `src/components/ui/`
+   file.
+4. **Page.** `src/features/billing/pages/BillingPage.tsx` — replaces
+   the current `SubscriptionPage`. Uses `useBillingMe`, renders header
+   card + rollout gate + placeholder region. Keep the file name
+   `BillingPage` but keep the route path `/subscription` (users bookmark
+   it) and re-export from `src/features/billing/pages` in
+   `src/router.tsx`.
+5. **Route rewire.** Update `src/router.tsx` — `/subscription` now
+   loads `BillingPage`. Delete the old route only after the new page's
+   tests are green.
+6. **Feature-folder cleanup.** Under
+   `src/features/subscription/` — leave the folder in place with a
+   single `README.md` "superseded by src/features/billing/" (so tests
+   from earlier tasks that still reference the old exports fail
+   loudly). UI-47 removes the old cards; do not delete them in this
+   task.
+7. **Settings link.** In `src/features/settings/` update the
+   preferences menu — the link continues to point at `/subscription`
+   but the label changes to "Billing".
+8. **Tests.** Under `src/features/billing/pages/__tests__/`:
+   - `BillingPage.test.tsx` — renders FREE header, renders PRO_ACTIVE
+     header, renders PAST_DUE grace deadline copy, renders rollout-off
+     placeholder, upgrade CTA hidden when disabled
+   - `useBillingMe.test.tsx` — 200 populates cache; 500 sets error;
+     `enabled` respects `rollout.uiEnabled`
+   - Toast: assert `notify.error(...)` is called via a spy when the
+     query rejects with 5xx
+
+## Final / expected result
+
+- `/subscription` renders the new billing page against `GET
+  /api/billing/me`; FREE, PRO active, PRO cancel-scheduled, PAST_DUE
+  states all display correctly.
+- Toast primitive is mounted globally; billing errors surface as a
+  toast; the `notify` façade is the only import site.
+- `rollout.uiEnabled=false` hides the billing UI entirely (page shows
+  a neutral notice, sidebar link hidden).
+- No existing test breaks.
+- Lint, typecheck, tests, build pass.
+
+## REST API used
+
+| Purpose | Endpoint |
+|---|---|
+| Current billing state | `GET /api/billing/me` → `{ billingAccountId, effectivePlan, subscription (nullable), limits, rollout }` |
+
+**Backend gap:** none — BE-04 (foundation) + BE-11 (subscription
+population) + BE-15 (rollout field) provide this endpoint. If BE-15
+isn't shipped yet, treat `rollout` as always-enabled and add a TODO
+referencing BE-15.

--- a/lined-web/docs/tasks/UI-39-pricing-preview-monthly-yearly.md
+++ b/lined-web/docs/tasks/UI-39-pricing-preview-monthly-yearly.md
@@ -1,0 +1,96 @@
+# Task 39 — Pricing Preview + Monthly/Yearly Toggle
+
+**Branch:** `feature/ui-39-pricing-preview-monthly-yearly`
+
+*Depends on Task 38 (billing feature scaffold), backend BE-10
+(`GET /api/billing/prices`). Precedes Task 40 (checkout uses the
+selected price).*
+
+## Detailed description
+
+Add the pricing card so a FREE user can see localized monthly and
+yearly Pro prices and pick one. The frontend never computes amounts or
+currencies — it renders exactly what the server returns.
+
+- **Pricing card** — visible when `effectivePlan=FREE`. Two pill
+  segments: **Monthly** and **Yearly**. Selecting one previews the
+  server-formatted amount + interval label. A subdued "Includes tax"
+  or "Tax added at checkout" line comes from `taxIncluded` on the
+  server DTO.
+- **Feature bullets** — bullet list of PRO capabilities (10 lobbies,
+  20 members, calendar integrations). Copy is static in this task; a
+  future task can move it to `entitlements`.
+- **CTA button** — "Upgrade to Pro" — disabled + tooltip "Checkout
+  arrives with UI-40" in this task. UI-40 wires the click.
+- **Loading + error** — skeleton on load (`Skeleton` from shadcn);
+  inline error with retry button on failure.
+- **Country hint** — the response's `countryCode` becomes a small
+  footnote ("Prices shown for {country}"). Never editable client-side.
+
+## Idea of this task
+
+Localized pricing is the single most trust-critical piece of the
+purchase flow — a wrong currency is a lost sale. Keeping the frontend
+strictly display-only (fetch → render formatted string) protects
+against every "amount in the URL" family of vulnerabilities; the
+server-provided cache TTL means the preview stays reasonably fresh
+without hammering the provider.
+
+## Reference to mockup
+
+- Existing `checkout` screen (`http://localhost:4321/#checkout`) —
+  reuse its Monthly/Yearly pill picker and price row treatment; this
+  task ships the *card* variant (in-page, not modal) — the modal comes
+  in UI-40. The "Yearly saves N%" microcopy comes from comparing the
+  yearly / monthly*12 client-side (display only).
+
+## Development steps
+
+1. **MSW first.** Extend `src/features/billing/api/`:
+   - `mockData.ts` — add `MOCK_PRICING_PREVIEW_UA` (design §20.2
+     Ukrainian sample) and `MOCK_PRICING_PREVIEW_US` (USD sample)
+   - `handlers.ts` — GET `/api/billing/prices` returning UA by default;
+     `setPricingVariant('US'|'UA')` helper for tests
+   - `dev.ts` + `prod.ts` add `getPricingPreview()`; extend `index.ts`
+     re-exports
+2. **Types.** Extend `model/index.ts` with `PricingPreviewDto`,
+   `PricingPriceDto` (fields: `priceCode`, `interval`, `amountMinor`,
+   `currency`, `formattedAmount`, `taxIncluded`).
+3. **Hook.** `src/features/billing/hooks/usePricingPreview.ts` —
+   `useQuery` keyed on `QUERY_KEYS.pricing`. `staleTime` 5 minutes;
+   only enabled when `effectivePlan=FREE`.
+4. **UI store.** New Zustand slice `useBillingUiStore` in
+   `src/features/billing/store/billingUi.ts` with
+   `selectedInterval: 'MONTH' | 'YEAR'`; default `'MONTH'`.
+5. **Components.**
+   - `src/features/billing/PricingCard.tsx` — segment toggle + price
+     row + bullets + disabled CTA. Purely presentational.
+   - `src/features/billing/IntervalToggle.tsx` — small `Tabs`-based
+     component; store the selection in the UI store.
+6. **Page wiring.** Render `PricingCard` in `BillingPage` when
+   `effectivePlan=FREE`.
+7. **Tests.**
+   - `PricingCard.test.tsx` — renders UA sample; toggling to yearly
+     shows yearly amount; loading state renders skeleton; error state
+     renders retry
+   - `usePricingPreview.test.tsx` — disabled when PRO; 5-minute
+     `staleTime` respected; 500 handled
+   - Zustand slice test: default is `MONTH`; setter updates state
+
+## Final / expected result
+
+- FREE users see a Monthly/Yearly pricing card with server-formatted
+  amounts; PRO users see no card.
+- Toggling interval updates the displayed price without a new server
+  call within the cache window.
+- Loading → skeleton; error → retry.
+- Lint, typecheck, tests, build pass.
+
+## REST API used
+
+| Purpose | Endpoint |
+|---|---|
+| Pricing preview | `GET /api/billing/prices` → `PricingPreviewDto { planCode, countryCode, prices[] }` |
+
+**Backend gap:** none once BE-10 is shipped. In dev, the sandbox
+adapter (BE-08) returns the UA sample.

--- a/lined-web/docs/tasks/UI-40-checkout-overlay-activation-pending.md
+++ b/lined-web/docs/tasks/UI-40-checkout-overlay-activation-pending.md
@@ -1,0 +1,115 @@
+# Task 40 — Checkout Overlay + Payment Confirmation Pending
+
+**Branch:** `feature/ui-40-checkout-overlay-activation-pending`
+
+*Depends on Task 38 (billing scaffold) and Task 39 (pricing card).
+Backend BE-10 (`POST /api/billing/checkout`) + BE-11 (webhook
+activation writes `subscription.status=ACTIVE`). Supersedes Task 26.*
+
+## Detailed description
+
+Wire the "Upgrade to Pro" button to a provider-controlled overlay
+checkout. Never activate PRO from any client-side signal — always poll
+`GET /api/billing/me` until the backend reports `status=ACTIVE`.
+
+- **Click → provider overlay** — the button calls
+  `POST /api/billing/checkout` with the selected `priceCode` from
+  UI-39's store and a fresh `Idempotency-Key` (`crypto.randomUUID()`
+  stored in `sessionStorage` per (billingAccountId, priceCode) so a
+  reload re-uses the same key). The response's `overlayData` is passed
+  to the provider script (sandbox handler mimics this with a fake
+  redirect + timed webhook simulation).
+- **UI state machine** (design §49.2): `IDLE → LOADING_PRICES →
+  CREATING_CHECKOUT → CHECKOUT_OPEN → PAYMENT_CONFIRMATION_PENDING →
+  ACTIVE | ERROR`. Modeled as a small XState-lite reducer or Zustand
+  slice — do not spread booleans across components.
+- **Pending state** — after overlay closes (or the provider frontend
+  event fires — treat as a *hint*, not a confirmation), poll
+  `GET /api/billing/me` every 1.5s up to 30s. When
+  `subscription?.status==='ACTIVE'` and
+  `effectivePlan==='PRO'`, transition to ACTIVE, close the modal,
+  toast "You're on Pro". Otherwise show a non-error "Payment received
+  — activation pending. This can take a moment." with a manual refresh
+  button.
+- **Errors** — 429 → toast "Too many attempts, try again in a moment";
+  409 `CHECKOUT_ALREADY_IN_PROGRESS` → toast + re-poll `me`;
+  `PROVIDER_TEMPORARILY_UNAVAILABLE` → toast + retry button;
+  network error → inline retry.
+- **Guards** — button hidden when `effectivePlan==='PRO'` or
+  `rollout.checkoutEnabled===false`.
+
+## Idea of this task
+
+Trust in the checkout flow is set by what happens between "click pay"
+and "see Pro". The design forbids activation from any client signal
+because provider frontend callbacks can lie or be replayed. Polling
+the server, on the other hand, is deterministic and matches production
+reconciliation exactly.
+
+## Reference to mockup
+
+- Existing `checkout` screen — the modal-overlay treatment there is
+  the visual reference. The provider iframe is opaque; this task's
+  focus is the *pending* state after overlay close: the same modal
+  card shrinks to a small spinner + "Activating your Pro plan…"
+  message, replacing the summary.
+
+## Development steps
+
+1. **MSW first.** Extend `src/features/billing/api/`:
+   - `handlers.ts` — POST `/api/billing/checkout` returns a canonical
+     `CheckoutSession` mock (`providerCheckoutId='co_test'`,
+     `overlayData={ testMode: true }`). Add a helper
+     `simulatePaymentConfirmed(delayMs=800)` that after the delay
+     mutates the mock `billingMe` variant to `PRO_ACTIVE` so the
+     polling loop transitions.
+   - `dev.ts` + `prod.ts` — add `createCheckoutSession(priceCode,
+     idempotencyKey)`; extend `index.ts`.
+2. **Types.** `CheckoutSessionDto`, `CreateCheckoutRequest`,
+   `CheckoutErrorCode` union.
+3. **State machine.** `src/features/billing/checkout/checkoutMachine.ts`
+   — Zustand slice or reducer implementing the state machine above.
+4. **Hooks.**
+   - `useCreateCheckout()` mutation — inputs `priceCode`; generates +
+     persists `Idempotency-Key`.
+   - `useBillingMePolling(active: boolean)` — wraps `useBillingMe`
+     with `refetchInterval: 1500` while `active`; stops on ACTIVE or
+     after 30s.
+5. **Components.**
+   - `CheckoutModal.tsx` — dialog hosting overlay iframe + pending
+     state.
+   - `PricingCard.tsx` — enable the CTA in this task; on click, open
+     `CheckoutModal`.
+6. **Integration.** `BillingPage` renders `<CheckoutModal />` behind a
+   Zustand flag.
+7. **Tests.**
+   - `checkoutMachine.test.ts` — every transition; illegal transitions
+     ignored.
+   - `CheckoutModal.test.tsx` — happy path (open → provider →
+     simulated webhook → ACTIVE toast); pending timeout renders
+     manual refresh; 409 renders toast + reset; sessionStorage key
+     persists on reload.
+   - `PricingCard.test.tsx` — CTA disabled when rollout off; enabled
+     otherwise.
+
+## Final / expected result
+
+- Clicking "Upgrade to Pro" opens the checkout modal, calls the
+  backend, opens the provider overlay, and after simulated payment
+  confirmation the page reflects PRO. No client-side activation short
+  cut.
+- The `Idempotency-Key` is stable across reloads within a session.
+- Polling stops within 30s regardless of outcome; the user sees
+  either PRO or the pending-with-refresh state.
+- Lint, typecheck, tests, build pass.
+
+## REST API used
+
+| Purpose | Endpoint |
+|---|---|
+| Create checkout | `POST /api/billing/checkout` (body `{ priceCode }`, header `Idempotency-Key`) → `{ providerCheckoutId, overlayData, expiresAt, checkoutAttemptId }` |
+| Poll activation | `GET /api/billing/me` |
+
+**Backend gap:** BE-10 + BE-11 provide these. If BE-11 isn't yet
+shipped when this task starts, the sandbox MSW simulator lets UI work
+proceed against a mocked activation.

--- a/lined-web/docs/tasks/UI-41-cancel-resume-flows.md
+++ b/lined-web/docs/tasks/UI-41-cancel-resume-flows.md
@@ -1,0 +1,101 @@
+# Task 41 — Cancel + Resume Subscription
+
+**Branch:** `feature/ui-41-cancel-resume-flows`
+
+*Depends on Task 38 (billing scaffold). Backend BE-11 (cancel + resume
+endpoints).*
+
+## Detailed description
+
+Give a PRO user the two symmetric actions: schedule cancellation at
+the current period end, and resume a scheduled cancellation before it
+takes effect. Both actions surface the exact provider timestamp so the
+user knows precisely when access changes.
+
+- **Cancel button** — visible when `subscription.status==='ACTIVE'`
+  and `cancelAtPeriodEnd===false`. Opens `ConfirmDialog` (existing
+  shared component) with copy:
+  > "Cancel your Pro subscription? You'll keep Pro until
+  > **{formattedCurrentPeriodEnd}**. After that, you drop to Free and
+  > any lobbies above the Free limit become read-only for 30 days
+  > before being archived."
+  Confirm → `POST /api/billing/subscription/cancel`. Success:
+  invalidate `billingMe`, toast "Cancellation scheduled for {date}".
+- **Resume button** — visible when `cancelAtPeriodEnd===true` and
+  `now < currentPeriodEnd`. Confirm dialog:
+  > "Resume renewal? Your Pro subscription will renew automatically
+  > on **{formattedCurrentPeriodEnd}**."
+  Confirm → `POST /api/billing/subscription/resume`. Success: toast
+  "Renewal resumed".
+- **Cancelled banner** — when `cancelAtPeriodEnd===true`, show a
+  neutral (not error-colored) banner: "Pro ends on {date}. You can
+  resume anytime before then."
+- **Error handling** — 409 `SUBSCRIPTION_NOT_ACTIVE`,
+  `CANCELLATION_ALREADY_SCHEDULED`, `RESUME_NOT_ALLOWED` → toast with
+  the stable code and a friendly message; refresh `billingMe`.
+
+## Idea of this task
+
+Cancelling should not feel like a trap — showing the exact
+end-of-access instant, and offering resume until then, is the
+minimum-viable "user in control" experience. Both actions being one
+call and one toast keeps the surface small.
+
+## Reference to mockup
+
+- Reuse the `subscription` screen's current-plan card treatment. The
+  cancel action mirrors the existing danger-secondary button style
+  used on lobby settings; the resume action uses the primary brand
+  button.
+
+## Development steps
+
+1. **MSW first.** Extend `src/features/billing/api/handlers.ts`:
+   - POST `/api/billing/subscription/cancel` — updates the mock
+     `billingMe` to `PRO_CANCEL_SCHEDULED` variant; returns the new
+     snapshot
+   - POST `/api/billing/subscription/resume` — flips it back to
+     `PRO_ACTIVE`; error variants: 409 `SUBSCRIPTION_NOT_ACTIVE`
+     when starting from FREE; 409 `RESUME_NOT_ALLOWED` when
+     `now >= currentPeriodEnd`
+   - `dev.ts` + `prod.ts`: `cancelSubscription()`, `resumeSubscription()`
+2. **Hooks.** `useCancelSubscription()`, `useResumeSubscription()` —
+   both `useMutation` with `onSuccess: invalidateBillingMe`;
+   surface stable error codes to callers.
+3. **Components.**
+   - `SubscriptionManageCard.tsx` — houses the cancel / resume
+     buttons; consumes `billingMe.subscription`.
+   - `CancelSubscriptionDialog.tsx` — wraps `ConfirmDialog` with the
+     copy above; formats the date via `formatDate` shared util
+     (locale-aware from UI-24).
+   - `ResumeSubscriptionDialog.tsx` — same pattern.
+   - `CancellationScheduledBanner.tsx` — neutral banner shown when
+     `cancelAtPeriodEnd`.
+4. **Page wiring.** Render `SubscriptionManageCard` + banner in
+   `BillingPage`.
+5. **Tests.**
+   - `CancelSubscriptionDialog.test.tsx` — confirm calls the API,
+     success toasts; 409 shows error toast without changing state.
+   - `ResumeSubscriptionDialog.test.tsx` — parallel coverage.
+   - `SubscriptionManageCard.test.tsx` — button visibility across
+     FREE, ACTIVE, ACTIVE+cancel scheduled, PAST_DUE states.
+   - Hook tests: query invalidation after success.
+
+## Final / expected result
+
+- PRO user can schedule cancel; sees banner with exact end date; can
+  resume until then.
+- Post-period elapses (mocked via variant swap) → the account drops
+  to FREE per BE-11 + BE-12; UI updates via `billingMe` refetch.
+- Stable error codes surfaced as friendly toasts.
+- Lint, typecheck, tests, build pass.
+
+## REST API used
+
+| Purpose | Endpoint |
+|---|---|
+| Schedule cancellation | `POST /api/billing/subscription/cancel` |
+| Resume scheduled cancellation | `POST /api/billing/subscription/resume` |
+| Refresh state | `GET /api/billing/me` |
+
+**Backend gap:** none once BE-11 ships.

--- a/lined-web/docs/tasks/UI-42-change-interval-flow.md
+++ b/lined-web/docs/tasks/UI-42-change-interval-flow.md
@@ -1,0 +1,90 @@
+# Task 42 — Change Billing Interval (Monthly ↔ Yearly)
+
+**Branch:** `feature/ui-42-change-interval-flow`
+
+*Depends on Task 38 (scaffold), Task 39 (pricing card), Task 41
+(cancel/resume — this task reuses the manage card). Backend BE-11
+(`POST /api/billing/subscription/change-price`).*
+
+## Detailed description
+
+Let a PRO user switch between monthly and yearly. The change is
+always scheduled for `currentPeriodEnd` — no proration, no immediate
+charge, no mid-period surprise (design §26).
+
+- **Change-interval button** — visible when `subscription.status==='ACTIVE'`
+  and no `scheduledPriceCode` already set. Opens a small dialog:
+  > "Switch to **{yearlyLabel}** on **{formattedCurrentPeriodEnd}**?
+  > Your next charge will be {yearlyPreview.formattedAmount}."
+  Confirm → `POST /api/billing/subscription/change-price` with the
+  target `priceCode`. Success: invalidate `billingMe`; toast
+  "Switching to yearly on {date}".
+- **Scheduled change badge** — when `scheduledPriceCode !== null`, the
+  current-plan card shows a chip: `→ Yearly on {date}` (or `→ Monthly
+  on {date}`) with an "Undo" affordance that calls the same endpoint
+  with the *current* `priceCode` to cancel the change (BE-11 accepts
+  this as `PRICE_CHANGE_ALREADY_SCHEDULED` → returns idempotent
+  cancellation).
+- **Guardrails**:
+  - Hide when `cancelAtPeriodEnd===true` (must resume first);
+    tooltip explains.
+  - Hide when `status !== 'ACTIVE'`.
+  - `PRICE_CHANGE_ALREADY_SCHEDULED` on submit → toast + refetch.
+
+## Idea of this task
+
+Yearly saves money for committed users but must never trap them; the
+design's "at period end" rule sidesteps proration math entirely. This
+task keeps the UI honest by showing the exact effective date and the
+exact next charge from the pricing preview — not a client computation.
+
+## Reference to mockup
+
+- Reuse the `checkout` screen's Monthly/Yearly toggle inside the
+  dialog. The scheduled-change chip on the current-plan card uses the
+  same style as the "Pending Invites · N" chip in the dashboard.
+
+## Development steps
+
+1. **MSW first.** Extend handlers:
+   - POST `/api/billing/subscription/change-price` — updates the mock
+     `billingMe` to a variant with `scheduledPriceCode` and
+     `scheduledChangeAt=currentPeriodEnd`
+   - Same endpoint with current `priceCode` clears the scheduled fields
+   - Add `PRO_CANCEL_SCHEDULED` guard: returns
+     `RESUME_NOT_ALLOWED` if the caller tries to change while
+     cancelling
+   - `dev.ts` + `prod.ts`: `changePrice(priceCode)`
+2. **Hook.** `useChangePrice()` mutation invalidating `billingMe` and
+   `pricing`.
+3. **Components.**
+   - `ChangeIntervalDialog.tsx` — reads pricing preview from UI-39's
+     hook to show the next-charge amount; confirms; error handling
+   - `ScheduledChangeBadge.tsx` — the chip on the current-plan card
+     with an inline Undo button
+4. **Page wiring.** Add the button to `SubscriptionManageCard` from
+   UI-41; render `ScheduledChangeBadge` when applicable.
+5. **Tests.**
+   - `ChangeIntervalDialog.test.tsx` — shows target price + date;
+     confirm triggers API; 409 handled; hidden when cancel scheduled.
+   - `ScheduledChangeBadge.test.tsx` — renders correct label; Undo
+     calls the endpoint with the current `priceCode`.
+   - Hook: invalidates both `billingMe` and `pricing`.
+
+## Final / expected result
+
+- PRO monthly user can schedule a switch to yearly; the current-plan
+  card shows the scheduled change; the "Undo" action reverts.
+- Attempting to switch while cancellation is scheduled is blocked in
+  the UI (button hidden with tooltip).
+- Lint, typecheck, tests, build pass.
+
+## REST API used
+
+| Purpose | Endpoint |
+|---|---|
+| Change price at period end | `POST /api/billing/subscription/change-price` (body `{ priceCode }`) |
+| Pricing preview | `GET /api/billing/prices` (already cached from UI-39) |
+| Refresh state | `GET /api/billing/me` |
+
+**Backend gap:** none once BE-11 ships.

--- a/lined-web/docs/tasks/UI-43-past-due-grace-warnings.md
+++ b/lined-web/docs/tasks/UI-43-past-due-grace-warnings.md
@@ -1,0 +1,104 @@
+# Task 43 — Past-Due + Grace Period Warnings
+
+**Branch:** `feature/ui-43-past-due-grace-warnings`
+
+*Depends on Task 38 (scaffold), Task 48 (customer portal — this task
+reuses the portal button; if UI-48 hasn't shipped, use a placeholder
+button and swap in UI-48). Backend BE-11 (past-due state), BE-15
+(customer portal availability).*
+
+## Detailed description
+
+When a Pro user's payment fails, tell them exactly what happened,
+when the grace period ends, and how to fix it — without hiding the
+fact that Pro is still working for now.
+
+- **Top-of-page banner on `/subscription`** — when
+  `subscription.status==='PAST_DUE'`:
+  > "**Payment issue** — we couldn't charge your card. You have Pro
+  > until **{formattedGraceEndsAt}**. Update your payment method to
+  > keep it."
+  Amber color; primary CTA "Update payment method" (opens the
+  customer portal via UI-48); secondary "Try renewal again" is
+  omitted for MVP because it's the provider's job.
+- **Persistent app-wide chip** — a small "⚠ Payment issue" chip in
+  the top bar (right of the user avatar) linking to `/subscription`.
+  Rendered by a new `BillingStatusChip` component consuming the same
+  `useBillingMe`. Hidden on `/subscription`.
+- **Grace-ended state** — the moment `now > graceEndsAt` (as computed
+  by the server; local clock is only for display) and effective plan
+  drops to FREE, the banner switches to:
+  > "Your Pro subscription expired on **{formattedGraceEndsAt}**. Your
+  > data is safe; some lobbies are now read-only. **Choose your Free
+  > lobby** or **Re-subscribe**."
+  Two CTAs: "Choose Free lobby" links to the flow shipped in UI-44;
+  "Re-subscribe" opens the pricing card.
+- **In-lobby callout** — every lobby detail page shows a subtle
+  banner at the top when the owner is PAST_DUE (grace not ended)
+  giving members context: "Payment issue on this lobby's owner
+  account. Pro continues until {date}." Members only see it if they
+  are in the lobby.
+- **Notifications** — piggyback on the notification inbox (Task 16);
+  no new notification types shipped here (BE-15 owns the templates).
+
+## Idea of this task
+
+A silent past-due state → surprise Free downgrade is the worst
+possible UX. Visible-but-not-alarming banners + one clear "Update
+payment method" action ride out the entire grace window; the same
+component gracefully re-uses itself for the post-grace state.
+
+## Reference to mockup
+
+- No mockup screen exists yet — reuse the existing `notifications`
+  amber-warning tone. Sketch inline in the PR description.
+
+## Development steps
+
+1. **MSW first.** Extend handlers with a new variant
+   `PAST_DUE_IN_GRACE` (existing) and add a variant
+   `PAST_DUE_GRACE_ENDED`; `setBillingMeVariant` can flip between.
+2. **Components.**
+   - `PaymentIssueBanner.tsx` — reads `billingMe.subscription`;
+     renders three states (grace in progress, grace ended, none).
+     Includes the "Update payment method" CTA (UI-48's button).
+   - `BillingStatusChip.tsx` — the top-bar chip; hidden on
+     `/subscription`.
+   - `LobbyPaymentIssueCallout.tsx` — shown atop the lobby detail
+     page when owner status is PAST_DUE. Owner-vs-member copy varies.
+3. **Data.** Extend the existing `useLobby` hook (or add a new
+   `useLobbyOwnerBillingHint`) to expose the owner's plan status via
+   `GET /api/lobbies/{id}` (the response already includes owner id;
+   this task adds a lightweight `GET /api/billing/me/lobby/{lobbyId}`
+   or piggybacks on the lobby DTO — flag as backend gap if needed).
+4. **Integration.** Render `PaymentIssueBanner` at the top of
+   `BillingPage`; mount `BillingStatusChip` inside `TopBar`; render
+   `LobbyPaymentIssueCallout` on the lobby detail page.
+5. **Tests.**
+   - `PaymentIssueBanner.test.tsx` — renders each of the three states;
+     CTA opens portal (mocked); date formatting correct.
+   - `BillingStatusChip.test.tsx` — hidden on `/subscription`;
+     visible elsewhere; hidden when status is not PAST_DUE.
+   - `LobbyPaymentIssueCallout.test.tsx` — owner vs. member copy.
+
+## Final / expected result
+
+- PAST_DUE (in grace): amber banner + persistent chip + lobby
+  callouts + working portal CTA.
+- PAST_DUE (grace ended): banner switches to the expired copy with
+  Choose-Free-lobby and Re-subscribe actions.
+- No banner when status is anything else.
+- Lint, typecheck, tests, build pass.
+
+## REST API used
+
+| Purpose | Endpoint |
+|---|---|
+| Billing state | `GET /api/billing/me` |
+| Open customer portal | `POST /api/billing/portal` (from UI-48) |
+| Lobby detail (owner id) | `GET /api/lobbies/{id}` (existing) |
+
+**Backend gap:** the "member sees owner's payment issue" requires the
+lobby DTO to expose a small `ownerBillingHint` field. If BE doesn't
+add it, gate the lobby callout behind a check that lives only on the
+owner side. Flag in the PR description.

--- a/lined-web/docs/tasks/UI-44-select-free-lobby-flow.md
+++ b/lined-web/docs/tasks/UI-44-select-free-lobby-flow.md
@@ -1,0 +1,103 @@
+# Task 44 — Select-Free-Lobby Flow
+
+**Branch:** `feature/ui-44-select-free-lobby-flow`
+
+*Depends on Task 38 (scaffold). Backend BE-03 (`select-as-free`
+endpoint), BE-12 (downgrade workflow marks lobbies READ_ONLY with
+`archive_at`).*
+
+## Detailed description
+
+After a downgrade to Free, help the owner pick the single lobby they
+want to keep writable. Explain the 30-day archive deadline plainly;
+enforce the 4-member cap before the switch happens.
+
+- **Downgrade modal** — auto-opens the first time the user visits
+  `/subscription` after `effectivePlan` becomes FREE **with** any of
+  their owned lobbies in `access_mode=READ_ONLY`. Shown once per
+  session; a "Not now" button dismisses to a persistent banner.
+- **Lobby list** — table of owned lobbies with:
+  - name + type accent
+  - member count (`N/4` — red if > 4)
+  - current mode (READ_WRITE / READ_ONLY)
+  - archive deadline (`archiveAt`) if applicable
+  - radio to select as the Free lobby
+- **Validation** — the "Confirm" button is disabled while the selected
+  lobby has `> 4` members. Inline hint: "Remove {N-4} members before
+  selecting this lobby." Provides a shortcut link to the lobby's
+  Members tab.
+- **Submit** — `POST /api/lobbies/{id}/select-as-free`. Success:
+  toast "Free lobby set — the others will be archived on
+  **{archiveDeadline}** unless you subscribe again"; invalidate
+  `useMyLobbies` + `billingMe`; close modal.
+- **Deadline banner** — when at least one owned lobby is READ_ONLY
+  with `archiveAt` set, show a persistent banner on the dashboard:
+  "Some lobbies are read-only. Choose your Free lobby by
+  **{earliestArchiveAt}** or subscribe to Pro."
+- **Errors** — 409 `LOBBY_MEMBER_LIMIT_EXCEEDED` (server-side, in
+  case UI validation was bypassed) → inline error; 403 when caller
+  isn't owner; 404 when lobby was deleted concurrently.
+
+## Idea of this task
+
+Downgrade doesn't destroy data — it asks the owner to choose. Turning
+that choice into a single modal + one confirmed action, with the
+member-count blocker clearly explained, keeps the flow calm even
+though the underlying event is stressful.
+
+## Reference to mockup
+
+- No mockup screen exists — reuse the "Add Member" modal treatment
+  from Task 6. Sketch in PR description; align copy with §29.4 (the
+  design's exact wording).
+
+## Development steps
+
+1. **MSW first.** Extend `src/features/lobby/api/handlers.ts` with
+   POST `/api/lobbies/{id}/select-as-free`:
+   - success: mock lobby list flips selected to READ_WRITE, others
+     stay READ_ONLY
+   - 409 `LOBBY_MEMBER_LIMIT_EXCEEDED` when target has > 4 members
+   - `dev.ts` + `prod.ts`: `selectAsFreeLobby(lobbyId)`
+2. **Hooks.**
+   - `useSelectAsFreeLobby()` mutation invalidating `myLobbies` and
+     `billingMe`.
+   - `useOwnedReadOnlyLobbies()` — derives from `useMyLobbies`.
+3. **Components.**
+   - `SelectFreeLobbyModal.tsx` — the modal itself.
+   - `DowngradeDeadlineBanner.tsx` — dashboard banner.
+4. **Session flag.** A Zustand slice remembers "dismissed this
+   session" to avoid re-popping the modal on every route change.
+5. **Integration.** Mount the modal from `BillingPage` (auto-open)
+   and from the deadline banner's action; mount the banner on the
+   dashboard.
+6. **Tests.**
+   - `SelectFreeLobbyModal.test.tsx` — auto-opens when applicable;
+     confirm disabled while target has >4 members; success toasts +
+     invalidates queries; 409 shows inline error.
+   - `DowngradeDeadlineBanner.test.tsx` — visible only when any
+     owned READ_ONLY lobby with `archiveAt` in the future; hidden
+     otherwise.
+   - Zustand slice: dismissal persists within session, resets on
+     reload.
+
+## Final / expected result
+
+- Post-downgrade, the owner sees the modal on `/subscription` and a
+  banner on the dashboard until they select a Free lobby.
+- Selecting a lobby with >4 members is blocked with clear guidance;
+  after member removal the selection unblocks.
+- Success updates both `myLobbies` (mode changes) and `billingMe`.
+- Lint, typecheck, tests, build pass.
+
+## REST API used
+
+| Purpose | Endpoint |
+|---|---|
+| Select Free lobby | `POST /api/lobbies/{lobbyId}/select-as-free` |
+| Owned lobbies (with mode + `archiveAt`) | `GET /api/lobbies/mine` |
+| Refresh billing state | `GET /api/billing/me` |
+
+**Backend gap:** none once BE-03 + BE-12 ship. Note that `GET
+/api/lobbies/mine` must include the new fields (`accessMode`,
+`archiveAt`) — BE-03's DTO change delivers them.

--- a/lined-web/docs/tasks/UI-45-read-only-lobby-ux.md
+++ b/lined-web/docs/tasks/UI-45-read-only-lobby-ux.md
@@ -1,0 +1,104 @@
+# Task 45 — Read-Only Lobby UX
+
+**Branch:** `feature/ui-45-read-only-lobby-ux`
+
+*Depends on Task 38 (scaffold), Task 44 (deadline banner reuses the
+same access-mode field). Backend BE-03 (lobby DTO includes
+`accessMode` + `restrictionReason`), BE-12 (workflow flips lobbies to
+READ_ONLY).*
+
+## Detailed description
+
+Every write control in a READ_ONLY lobby must be visually disabled
+(not silently no-op) and the reduction actions from design §29.1 must
+remain available. When the server rejects a write with the stable
+code `LOBBY_READ_ONLY_DUE_TO_PLAN`, surface a consistent explanation.
+
+- **Header ribbon** — at the top of any READ_ONLY lobby detail page:
+  > "**Read-only** — this lobby is read-only because the owner's Pro
+  > subscription ended. Nothing has been deleted."
+  Includes an "Archive on **{archiveAt}**" sub-line when set. Owner
+  sees an additional CTA "Select as Free lobby" (deep-links to UI-44
+  modal, pre-selecting this lobby); non-owners see the same read-only
+  message without the CTA.
+- **Disabled controls** — Task/Event create buttons, `AddTaskDrawer`
+  save, `CreateEventModal` save, `AddMemberModal`, invites, lobby
+  settings General edit — all disabled with a shared tooltip helper
+  `<ReadOnlyTooltip reason="…" />`. Delete/Leave/Remove-member/Select
+  buttons stay enabled (design's reduction whitelist).
+- **Error handling** — a shared axios/ky interceptor extension in
+  `src/lib/apiClient.ts` detects `code=LOBBY_READ_ONLY_DUE_TO_PLAN`
+  and dispatches a toast + query invalidation, guarding against races
+  where the local state hasn't updated yet.
+- **Sidebar + lobby cards** — a small "🔒 Read-only" badge next to
+  the lobby name in the sidebar and on dashboard lobby cards.
+
+## Idea of this task
+
+A user shouldn't have to press "Save" to discover an action isn't
+allowed. Reading `accessMode` in every write component and disabling
+the control up-front avoids the whole class of "why can't I click
+this?" tickets. Wiring the stable error code centrally ensures the
+same message when a race sneaks past.
+
+## Reference to mockup
+
+- No mockup exists — reuse the existing lobby detail layout with
+  disabled-button treatments from Task 22 (touch-target audit). Copy
+  matches design §29.4 verbatim.
+
+## Development steps
+
+1. **Types + hook.** `LobbyDto` already includes `accessMode` +
+   `restrictionReason` + `archiveAt` from BE-03; verify types match
+   in `src/features/lobby/model/`.
+2. **Shared primitive.** `src/features/lobby/read-only/ReadOnlyTooltip.tsx`
+   — wraps a disabled control with a `Tooltip` explaining the reason;
+   reused by every write action.
+3. **Header ribbon.** `src/features/lobby/read-only/ReadOnlyRibbon.tsx`
+   — inserted at the top of `LobbyPage`, above the tab bar.
+4. **Write-path sweep.** For each of these files, gate the interactive
+   control behind `lobby.accessMode === 'READ_WRITE'`:
+   - `src/features/lobby/header/LobbyHeader.tsx` (edit button)
+   - `src/features/lobby/tasks/AddTaskDrawer.tsx` (save button)
+   - `src/features/calendar/CreateEventModal.tsx` (only when lobby
+     is pre-locked to a READ_ONLY lobby)
+   - `src/features/lobby/members/AddMemberModal.tsx` (invite send)
+   - `src/features/lobby/settings/LobbyGeneralCard.tsx` (save)
+   - `src/features/lobby/settings/LobbyNotificationsCard.tsx` (allow
+     save — notifications aren't a lobby write per se; verify with
+     product)
+   Keep enabled: Members-tab "Remove", "Make owner"; DangerZone
+   "Leave" and "Delete"; `SelectFreeLobbyModal` action.
+5. **API client extension.** In `src/lib/apiClient.ts`, add an
+   `afterResponse` hook that detects `code=LOBBY_READ_ONLY_DUE_TO_PLAN`
+   in 409 bodies and calls a shared `notify.error` + emits a custom
+   event so the affected query invalidates.
+6. **Sidebar + card badges.** Small badge in `Sidebar.tsx` and
+   `LobbyCardGrid.tsx`.
+7. **Tests.**
+   - `ReadOnlyRibbon.test.tsx` — copy, owner vs. member CTA visibility.
+   - Sweep tests: each write component with a READ_ONLY lobby prop —
+     button is disabled; reduction-write buttons stay enabled.
+   - `apiClient.readonly.test.ts` — 409 with the code triggers the
+     shared toast + invalidation.
+
+## Final / expected result
+
+- Every write in a READ_ONLY lobby is visibly disabled with a
+  consistent tooltip; reduction actions still work.
+- A race that gets a write past the UI gets a consistent toast + a
+  fresh lobby query.
+- Sidebar + dashboard show the "read-only" badge.
+- Lint, typecheck, tests, build pass.
+
+## REST API used
+
+| Purpose | Endpoint |
+|---|---|
+| Lobby detail (includes access fields) | `GET /api/lobbies/{id}` |
+| Any write path | existing endpoints; interceptor handles `LOBBY_READ_ONLY_DUE_TO_PLAN` |
+
+**Backend gap:** none once BE-03 + BE-12 ship. If BE-03's DTO change
+lands after this task starts, feature-flag the badges on
+`accessMode !== undefined`.

--- a/lined-web/docs/tasks/UI-46-archived-lobbies-section.md
+++ b/lined-web/docs/tasks/UI-46-archived-lobbies-section.md
@@ -1,0 +1,96 @@
+# Task 46 — Archived Lobbies Section + Restore
+
+**Branch:** `feature/ui-46-archived-lobbies-section`
+
+*Depends on Task 45 (read-only UX shares the badges). Backend BE-03
+(`?lifecycleStatus=ARCHIVED` query + `restore` endpoint), BE-12
+(archive job flips lifecycle after 30 days).*
+
+## Detailed description
+
+Give owners a way to see, use (read-only), and restore lobbies that
+were archived after downgrade. Archived lobbies stay out of the main
+sidebar/dashboard until restored.
+
+- **New "Archived" section in sidebar** — collapsed by default, shows
+  a count "Archived (N)". Expanding lists archived lobbies with a
+  read-only icon + last-active date.
+- **Archived list page** — `/lobbies/archived` route showing an
+  `ArchivedLobbyCard` per row: name, type accent, member count,
+  archived date, and actions:
+  - **View** — deep-links into the lobby detail page (which will
+    display the read-only ribbon from Task 45).
+  - **Restore** — visible only for the owner and only when the
+    owner's effective plan is PRO and adding this lobby wouldn't
+    exceed `LOBBIES_MAX`. Calls
+    `POST /api/lobbies/{id}/restore`. Success: toast "Lobby restored";
+    invalidate `myLobbies` + archived-list.
+  - **Leave** — visible to non-owner members; existing leave endpoint.
+  - **Delete** — visible to owner; existing delete endpoint (survives
+    read-only via reduction whitelist).
+- **Errors** — 409 `LOBBY_LIMIT_EXCEEDED` on restore → inline "You've
+  reached your Pro lobby limit. Delete or archive another lobby
+  first."; 403 when caller is not owner.
+- **Empty state** — reuse `EmptyState` primitive (Task 21) with
+  friendly copy: "No archived lobbies. Lobbies land here 30 days after
+  a downgrade if you don't select them as your Free lobby."
+
+## Idea of this task
+
+Archive is the design's data-preservation guarantee — but only if
+users can actually find and act on archived lobbies. Making them
+discoverable in the sidebar + a dedicated route (not a scrollable
+buried section) turns the promise into something users can rely on.
+
+## Reference to mockup
+
+- No mockup exists — mirror the existing dashboard `LobbyCardGrid`
+  layout. Sketch in PR description.
+
+## Development steps
+
+1. **MSW first.** Extend `src/features/lobby/api/handlers.ts`:
+   - GET `/api/lobbies?lifecycleStatus=ARCHIVED` → filtered mock
+     lobby list
+   - POST `/api/lobbies/{id}/restore` → flips lifecycle back;
+     409 when mock hits capacity
+   - `dev.ts` + `prod.ts`: `getArchivedLobbies()`, `restoreLobby(id)`
+2. **Hooks.**
+   - `useArchivedLobbies()` — `useQuery` keyed
+     `['lobbies','archived']`.
+   - `useRestoreLobby()` — mutation invalidating both keys.
+3. **Components.**
+   - `ArchivedSection.tsx` — the sidebar accordion.
+   - `ArchivedLobbyCard.tsx` — the list card with actions.
+   - `ArchivedLobbiesPage.tsx` — the `/lobbies/archived` page.
+4. **Route.** Add `/lobbies/archived` under `<RequireAuth />` in
+   `src/router.tsx`.
+5. **Nav.** Sidebar shows the "Archived (N)" entry beneath "My
+   Lobbies"; link points to `/lobbies/archived`.
+6. **Tests.**
+   - `ArchivedLobbiesPage.test.tsx` — renders list; owner sees
+     Restore; non-owner sees Leave.
+   - `useRestoreLobby.test.tsx` — success invalidates both keys;
+     409 shows inline error.
+   - `ArchivedSection.test.tsx` — count reflects mock; collapsed by
+     default; expands on click.
+
+## Final / expected result
+
+- Sidebar surfaces an Archived section with count; clicking navigates
+  to `/lobbies/archived`.
+- Archived list shows all archived lobbies; owners can restore (with
+  capacity gate); everyone else sees appropriate actions.
+- Restoring a lobby moves it back into `GET /api/lobbies/mine` and
+  removes it from the archived list.
+- Lint, typecheck, tests, build pass.
+
+## REST API used
+
+| Purpose | Endpoint |
+|---|---|
+| List archived | `GET /api/lobbies?lifecycleStatus=ARCHIVED` |
+| Restore | `POST /api/lobbies/{lobbyId}/restore` |
+| Active lobbies | `GET /api/lobbies/mine` |
+
+**Backend gap:** none once BE-03 ships the query + restore endpoint.

--- a/lined-web/docs/tasks/UI-47-billing-history-transactions-refunds.md
+++ b/lined-web/docs/tasks/UI-47-billing-history-transactions-refunds.md
@@ -1,0 +1,94 @@
+# Task 47 — Transactions & Refunds History
+
+**Branch:** `feature/ui-47-billing-history-transactions-refunds`
+
+*Depends on Task 38 (scaffold). Backend BE-13 (`GET /api/billing/transactions`
++ `GET /api/billing/refunds`).*
+
+## Detailed description
+
+Give users a receipts/refunds view on `/subscription` so they can see
+what they were charged, when, and the status of any refund. This
+replaces the old `SubscriptionHistoryCard` (which listed subscription
+periods, not financial transactions).
+
+- **Two tabs** — Transactions | Refunds — under a "Payment history"
+  card. Empty tab shows an `EmptyState` ("No payments yet" / "No
+  refunds yet").
+- **Transactions row** — date (localized), interval label (Monthly /
+  Yearly), amount (`formattedAmount` from the server — never
+  computed), status badge (Succeeded / Failed / Refunded / Partially
+  refunded), and — where the server exposes it — a "Receipt ↗" link
+  to the provider receipt.
+- **Refunds row** — date, refund type (Full / Partial / Prorated),
+  amount, status badge (Pending / Succeeded / Failed / Rejected),
+  refund reason (short — click to expand for full reason text).
+- **Pagination** — `useInfiniteQuery` with `page`/`size` (backend
+  paginates); "Load more" button.
+- **Cross-links** — a refund row's "View transaction" opens a small
+  drawer/modal showing the parent transaction inline (extracted from
+  the same list via id).
+
+## Idea of this task
+
+Support tickets about "what did you charge me?" are eliminated when
+the user can self-serve the answer. Keeping the display purely
+`formattedAmount` + `status` (both from the server) means the browser
+is never wrong.
+
+## Reference to mockup
+
+- Reuse the existing `SubscriptionHistoryCard` layout (list rows with
+  a status badge). Sketch the tab treatment in PR description; align
+  with the Kanban filter pills used elsewhere for tabs.
+
+## Development steps
+
+1. **MSW first.** Extend `src/features/billing/api/handlers.ts`:
+   - GET `/api/billing/transactions?page=&size=` returning mock rows
+     with pagination shape `{ items, page, size, total }`
+   - GET `/api/billing/refunds?page=&size=` same shape
+   - `dev.ts` + `prod.ts`: `listTransactions(page, size)`,
+     `listRefunds(page, size)`
+2. **Types.** `TransactionDto`, `RefundDto`, `PaginatedList<T>` types
+   in `model/index.ts`.
+3. **Hooks.** `useTransactions()`, `useRefunds()` — `useInfiniteQuery`
+   keyed under `QUERY_KEYS.transactions` / `.refunds`.
+4. **Components.**
+   - `PaymentHistoryCard.tsx` — tab host.
+   - `TransactionsList.tsx`, `RefundsList.tsx`.
+   - `RefundReasonRow.tsx` — expand/collapse of `reasonText`.
+   - `TransactionDetailDrawer.tsx` — the small drawer opened from a
+     refund row.
+5. **Page wiring.** Render `PaymentHistoryCard` in `BillingPage`
+   below the manage card.
+6. **Remove legacy.** Delete `SubscriptionHistoryCard.tsx` from
+   `src/features/subscription/` and its imports. The old MSW handler
+   for `/api/subscriptions/{userId}/history` was already removed in
+   UI-38's cleanup — verify.
+7. **Tests.**
+   - `TransactionsList.test.tsx` — renders rows; loads more;
+     empty state.
+   - `RefundsList.test.tsx` — status badges; expand reason;
+     "View transaction" opens drawer with correct data.
+   - Hook tests: `useInfiniteQuery` pagination.
+
+## Final / expected result
+
+- `/subscription` shows a Payment History card with Transactions and
+  Refunds tabs, each paginated.
+- Rows display server-provided amounts and statuses; no client-side
+  currency math.
+- Empty states render appropriately when there's no history.
+- Lint, typecheck, tests, build pass.
+
+## REST API used
+
+| Purpose | Endpoint |
+|---|---|
+| Transactions | `GET /api/billing/transactions?page=&size=` |
+| Refunds | `GET /api/billing/refunds?page=&size=` |
+
+**Backend gap:** none once BE-13 ships. Verify server returns
+pagination shape `{ items, page, size, total }`; if it differs, adapt
+the hook.

--- a/lined-web/docs/tasks/UI-48-customer-portal-button.md
+++ b/lined-web/docs/tasks/UI-48-customer-portal-button.md
@@ -1,0 +1,77 @@
+# Task 48 — Customer Portal Button
+
+**Branch:** `feature/ui-48-customer-portal-button`
+
+*Depends on Task 38 (scaffold). Backend needs a `POST
+/api/billing/portal` endpoint — the design references it (§37.7); if
+BE-11 doesn't include it, coordinate as a small addendum to BE-11 or
+BE-15.*
+
+## Detailed description
+
+Add a "Manage billing" button that opens the provider's customer
+portal so users can update card, view invoices, etc. — anything Lined
+doesn't own the UI for.
+
+- **Button** — visible whenever a `ProviderCustomer` exists for the
+  account (server flag exposed on `GET /api/billing/me` as
+  `hasProviderCustomer` or inferred from `subscription != null`).
+- **Click** — `POST /api/billing/portal` returns
+  `{ portalUrl, expiresAt }`. Open in a **new tab** (`window.open(url,
+  '_blank', 'noopener,noreferrer')`). Do not iframe — provider CSP
+  usually blocks it, and the short-lived URL should be visible in the
+  address bar for trust.
+- **Loading + error** — button spinner while the mutation is in
+  flight; on failure toast "Couldn't open the payment portal —
+  try again in a moment" and log correlation id.
+- **Reuse** — Task 43's "Update payment method" CTA calls the same
+  hook.
+
+## Idea of this task
+
+Customer portals are the standard place for card updates, invoices,
+and cancellation confirmation — attempting to re-implement each screen
+in Lined would triple this project's scope and remain worse than the
+provider's version. One button, one server call, done.
+
+## Reference to mockup
+
+- No mockup — the button lives on the current-plan card in
+  `/subscription` next to Cancel/Resume, and inside Task 43's
+  payment-issue banner.
+
+## Development steps
+
+1. **MSW first.** Extend `src/features/billing/api/handlers.ts`:
+   - POST `/api/billing/portal` returns
+     `{ portalUrl: 'https://sandbox.example/portal/xyz', expiresAt: ISO }`
+   - `dev.ts` + `prod.ts`: `openCustomerPortal()`
+2. **Hook.** `useOpenCustomerPortal()` — mutation returning the URL;
+   consumers call `window.open` themselves so tests can spy.
+3. **Component.** `ManageBillingButton.tsx` — pill button; loading
+   spinner; consumes the hook.
+4. **Integration.**
+   - Add to `SubscriptionManageCard` (from UI-41).
+   - Task 43's `PaymentIssueBanner` uses this same button internally.
+5. **Tests.**
+   - `useOpenCustomerPortal.test.tsx` — success returns URL; 500 sets
+     error; loading state exposed.
+   - `ManageBillingButton.test.tsx` — click triggers mutation; on
+     success calls `window.open` with the URL and correct flags.
+
+## Final / expected result
+
+- "Manage billing" button appears when there's a provider customer;
+  click opens the portal in a new tab.
+- Same button used from `/subscription` and the payment-issue banner.
+- Lint, typecheck, tests, build pass.
+
+## REST API used
+
+| Purpose | Endpoint |
+|---|---|
+| Open customer portal | `POST /api/billing/portal` → `{ portalUrl, expiresAt }` |
+
+**Backend gap:** if BE-11/BE-15 don't include this endpoint, add a
+one-hour PR to BE-11 that wires
+`BillingPortalProvider.createCustomerPortal(...)` from BE-07's port.

--- a/lined-web/docs/tasks/UI-49-admin-billing-view.md
+++ b/lined-web/docs/tasks/UI-49-admin-billing-view.md
@@ -1,0 +1,109 @@
+# Task 49 — Admin Billing View
+
+**Branch:** `feature/ui-49-admin-billing-view`
+
+*Depends on Task 38 (scaffold). Backend BE-14 (admin API + permission
+model). Precedes Task 50 (admin refund reuses the account detail
+page).*
+
+## Detailed description
+
+A new `/admin/billing` route surfaces the admin operations from
+design §40 to authorized support/ops users: search accounts, view
+account detail, resync, retry failed events, view audit log.
+
+- **Route guard** — new `<RequireAdmin />` component that checks the
+  current user's `permissions` (added to `useCurrentUser`) — the
+  route renders only when `BILLING_READ` is present; otherwise 404 to
+  avoid leaking the existence of admin surfaces.
+- **Search page** (`/admin/billing`) — single search input; hits
+  `GET /api/admin/billing/accounts?query=`. Results table:
+  billing-account-id, owner email, effective plan, subscription
+  status, provider customer id.
+- **Account detail** (`/admin/billing/accounts/{billingAccountId}`) —
+  four sections:
+  1. **Overview** — owner, effective plan, subscription status +
+     dates, provider ids, scheduled changes, `providerDashboardUrl`
+     as an external link.
+  2. **Transactions** — a paginated list identical shape to UI-47
+     but read from the admin endpoint.
+  3. **Provider events** — recent inbox rows with status + retry
+     button (`POST /api/admin/billing/provider-events/{eventId}/retry`)
+     visible only when caller has `BILLING_OPS`.
+  4. **Audit log** — recent audit rows with actor + action; visible
+     only when caller has `AUDIT_READ`.
+- **Resync button** — top-right of overview; `POST
+  /api/admin/billing/accounts/{billingAccountId}/resync`; result modal
+  shows before/after diff + warnings. Requires `BILLING_OPS`.
+
+## Idea of this task
+
+Instead of shell scripts and psql access, ops needs a page where the
+routine "why is this user stuck?" question can be answered in three
+clicks. Keeping the surface strictly read-only + resync + retry (not
+refund — that's UI-50) makes the security review manageable.
+
+## Reference to mockup
+
+- No mockup — utility-first admin layout using shadcn `Table` +
+  `Card`. Sketch in PR description.
+
+## Development steps
+
+1. **MSW first.** New `src/features/admin/api/handlers.ts`:
+   - GET `/api/admin/billing/accounts?query=` — array of matches
+   - GET `/api/admin/billing/accounts/{id}` — full detail mock
+   - POST `.../resync` — returns mock diff
+   - POST `/api/admin/billing/provider-events/{eventId}/retry`
+   - `dev.ts` + `prod.ts` mirror.
+2. **Feature folder.** `src/features/admin/billing/`:
+   - `model/index.ts` — DTO types
+   - `hooks/` — `useAdminSearch`, `useAdminAccount`, `useResync`,
+     `useRetryEvent`
+   - `pages/AdminBillingSearchPage.tsx`,
+     `AdminBillingAccountPage.tsx`
+   - Section components: `AdminAccountOverview`,
+     `AdminTransactionsSection`, `AdminProviderEventsSection`,
+     `AdminAuditLogSection`
+3. **Auth.** Extend `useCurrentUser` (in `src/features/users/`) to
+   include `permissions: Permission[]` from backend (BE-14 adds this
+   field to the user endpoint). Add `<RequireAdmin />` wrapping the
+   admin routes; 404 when permission missing.
+4. **Route.** Register `/admin/billing` + `/admin/billing/accounts/:id`
+   in `src/router.tsx` under `<RequireAuth /> → <RequireAdmin
+   permission="BILLING_READ" />`.
+5. **Sidebar link.** New "Admin" section in the sidebar, visible only
+   when caller has any admin permission.
+6. **Tests.**
+   - `RequireAdmin.test.tsx` — permission present → renders;
+     missing → 404 route.
+   - `AdminBillingSearchPage.test.tsx` — types in search, hits
+     endpoint, renders results.
+   - `AdminBillingAccountPage.test.tsx` — renders all four sections;
+     retry button hidden without `BILLING_OPS`; resync opens diff
+     modal on success.
+   - `useResync.test.tsx` — success + failure paths.
+
+## Final / expected result
+
+- `/admin/billing` surfaces search + account detail + resync + event
+  retry per §40.
+- Route + retry + audit visibility respect the permission matrix from
+  §41.3.
+- Non-admin users get a 404 for the admin routes.
+- Lint, typecheck, tests, build pass.
+
+## REST API used
+
+| Purpose | Endpoint |
+|---|---|
+| Search accounts | `GET /api/admin/billing/accounts?query=` |
+| Account detail | `GET /api/admin/billing/accounts/{billingAccountId}` |
+| Resync | `POST /api/admin/billing/accounts/{billingAccountId}/resync` |
+| Retry event | `POST /api/admin/billing/provider-events/{eventId}/retry` |
+| Audit log | `GET /api/admin/billing/audit-log?billingAccountId=&limit=` |
+| Current user permissions | extend existing user endpoint to include `permissions` |
+
+**Backend gap:** the "current user permissions" field must be included
+in whatever endpoint powers `useCurrentUser`. BE-14 owns adding this;
+coordinate.

--- a/lined-web/docs/tasks/UI-50-admin-refund-flow.md
+++ b/lined-web/docs/tasks/UI-50-admin-refund-flow.md
@@ -1,0 +1,114 @@
+# Task 50 — Admin Refund Preview + Issue Flow
+
+**Branch:** `feature/ui-50-admin-refund-flow`
+
+*Depends on Task 49 (admin account detail page). Backend BE-13
+(refund preview + issue endpoints), BE-14 (`BILLING_REFUND`
+permission).*
+
+## Detailed description
+
+Add a refund action to the admin transactions section. Preview shows
+the exact refundable amount, currency, refund type, and access-behavior
+choice — with the "outside default window" flag surfaced so the admin
+knows they're issuing an exceptional refund.
+
+- **Refund button on each transaction row** — visible only when
+  caller has `BILLING_REFUND`; hidden when transaction is
+  `FAILED` or already fully refunded.
+- **Two-step flow:**
+  1. **Preview modal** — `POST /api/admin/billing/transactions/{id}/refund-preview`.
+     Modal shows: transaction summary, `maxRefundable` amount +
+     currency, `withinDefaultWindow` badge (green when true; amber
+     "Outside window — exceptional refund" when false), refund type
+     picker (`FULL`, `PARTIAL`, `PRORATED_UNUSED_TIME`), amount
+     input (auto-filled from `maxRefundable` for FULL; user-editable
+     for PARTIAL/PRORATED — validated `> 0` and `≤ maxRefundable`),
+     reason code dropdown (fixed list from design §31), reason text
+     (optional textarea), `accessBehavior` toggle:
+     `KEEP_ACCESS_UNTIL_PERIOD_END | END_ACCESS_AFTER_REFUND`
+     (default: `END_ACCESS_AFTER_REFUND` for `PRORATED_UNUSED_TIME`
+     and `FULL`, `KEEP_ACCESS_UNTIL_PERIOD_END` for `PARTIAL`).
+     Also displays the resulting effective plan (`PRO → FREE`) and
+     expected lobby-downgrade effect ("N lobbies will become
+     read-only for 30 days"). Design §47's confirmation UI list.
+  2. **Confirm** — `POST /api/admin/billing/transactions/{id}/refunds`
+     with a fresh `Idempotency-Key`. Success: toast "Refund submitted
+     — waiting for provider confirmation"; the transaction row updates
+     with a `Refund PENDING` badge; the refunds section polls until
+     terminal.
+- **Errors** — 400 `REFUND_AMOUNT_INVALID`, 409
+  `REFUND_ALREADY_PROCESSED`, `REFUND_NOT_ELIGIBLE` → inline error in
+  the modal.
+- **Audit visibility** — the admin sees a note in the modal: "This
+  action is audited to `billing_audit_log`."
+
+## Idea of this task
+
+Refunds are the highest-stakes admin action — the only irreversible
+one that moves money and can flip a user's plan. The two-step
+preview→confirm split, with `withinDefaultWindow` clearly flagged and
+`accessBehavior` explicit, matches the design's §47 checklist and
+gives the admin a chance to catch mistakes before they hit the
+provider.
+
+## Reference to mockup
+
+- No mockup — modal treatment matches the existing `ConfirmDialog`
+  scaled up; sketch in PR description.
+
+## Development steps
+
+1. **MSW first.** Extend `src/features/admin/api/handlers.ts`:
+   - POST `.../transactions/{id}/refund-preview` returns
+     `{ maxRefundableMinor, currency, withinDefaultWindow, type,
+     transactionSnapshot }`
+   - POST `.../transactions/{id}/refunds` returns
+     `{ refundId, status: 'PENDING' }`; on 400/409 return stable
+     error code
+   - `dev.ts` + `prod.ts` mirror
+2. **Hooks.** `usePreviewRefund(transactionId)`,
+   `useIssueRefund(transactionId)`; mutations invalidate the admin
+   account view.
+3. **Components.**
+   - `RefundActionButton.tsx` — the row-level button + gate on
+     `BILLING_REFUND`.
+   - `RefundPreviewModal.tsx` — the multi-field form; controlled by
+     `useForm` (react-hook-form) or a local Zustand slice; validation
+     inline.
+   - `RefundTypeSelector.tsx`, `AccessBehaviorToggle.tsx`,
+     `RefundReasonCombobox.tsx` — small controlled inputs.
+4. **Integration.** Mount `RefundActionButton` in
+   `AdminTransactionsSection` (Task 49); render the modal from a
+   parent Zustand flag.
+5. **Tests.**
+   - `RefundPreviewModal.test.tsx` — renders full/partial/prorated
+     scenarios; amount validation; `accessBehavior` defaults correct;
+     preview call fires on open; confirm fires the issue call.
+   - `RefundActionButton.test.tsx` — hidden without
+     `BILLING_REFUND`; hidden on FAILED or fully-refunded rows.
+   - Hook tests: error codes surfaced correctly; refund PENDING
+     appears in the row after submit.
+
+## Final / expected result
+
+- Admin with `BILLING_REFUND` can preview and issue any of the three
+  refund types; UI blocks obviously invalid amounts; server error
+  codes surface as inline errors.
+- Post-submit the row reflects the PENDING refund and eventually
+  SUCCEEDED / FAILED via polling (or the admin re-opens the page).
+- The out-of-window flag is prominent when applicable.
+- Lint, typecheck, tests, build pass.
+
+## REST API used
+
+| Purpose | Endpoint |
+|---|---|
+| Preview refund | `POST /api/admin/billing/transactions/{transactionId}/refund-preview` |
+| Issue refund | `POST /api/admin/billing/transactions/{transactionId}/refunds` (header `Idempotency-Key`) |
+| Poll refund status | `GET /api/admin/billing/accounts/{billingAccountId}` (refunds section) or a dedicated GET refund endpoint if BE-13 adds one |
+
+**Backend gap:** BE-13 owns the endpoints. Verify BE-13's preview
+response includes `withinDefaultWindow` (design §31 doesn't mandate it,
+but §47 does for the UI). If missing, request its addition in the
+BE-13 PR.


### PR DESCRIPTION
## Summary

- Turns `subscription-billing-system-design.md` (3369 lines, 60 sections) into an actionable roadmap: **15 backend task specs + 13 web task specs** with a matching backend index and updated UI table.
- Backend follows the design's §58 recommended order: BillingAccount + effective-plan resolver → entitlement + Free limits → lobby lifecycle → remove unsafe legacy endpoints → catalog → subscription schema + state machine → provider ports → sandbox adapter → webhook inbox → checkout → subscription lifecycle → downgrade/archive → transactions + refunds → admin + audit → reconciliation + outbox + rollout.
- Web covers the full billing UI: scaffold + toast, pricing preview, checkout overlay, cancel/resume, change interval, past-due/grace, select-Free-lobby, read-only lobby UX, archived lobbies, transactions/refunds history, customer portal, admin view, admin refund. Marks UI-26 (`payment-checkout` placeholder) as SUPERSEDED.
- Provider is deliberately left TBD — the design's sandbox stub adapter (BE-08) lets every downstream task be shipped and tested without provider credentials.

## Files

- `backend/lined/docs/billing/BILLING_TASKS.md` — new index (table, module map, conventions, suggested order, DoD)
- `backend/lined/docs/billing/tasks/BE-01..BE-15-*.md` — 15 backend task specs
- `lined-web/docs/tasks/UI-38..UI-50-*.md` — 13 web task specs
- `lined-web/docs/UI_TASKS.md` — 13 rows appended, UI-26 flipped to SUPERSEDED, batch note + backend dependency map added

## Notes

- Docs-only change; no code touched, no schema changes, no CI impact.
- The `.agents/` and top-level `docs/` untracked directories present before this session are intentionally left out of the commit.

## Test plan

- [ ] `ls backend/lined/docs/billing/tasks/ | wc -l` → 15
- [ ] `ls lined-web/docs/tasks/UI-{38..50}*.md | wc -l` → 13
- [ ] Open any task file and confirm it follows the sibling convention (UI-14 for web, this PR's own BE-01 for backend)
- [ ] Confirm every task references specific §N ranges from the design doc
- [ ] Confirm no task file names a specific provider (Paddle/Stripe/Mono) in its acceptance criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)