### PR TITLE
Add personal billing accounts and implicit Free resolution

### DIFF
--- a/backend/lined/docs/billing/BILLING_TASKS.md
+++ b/backend/lined/docs/billing/BILLING_TASKS.md
@@ -102,7 +102,7 @@ io.backend.lined
 
 | # | Branch name | Task description | Reference | Status |
 |---|---|---|---|---|
-| BE-01 | `feature/be-01-billing-account-effective-plan` | Introduce `BillingAccount` (Personal), backfill for existing users, `EffectivePlanResolver` returning implicit FREE | [tasks/BE-01-billing-account-effective-plan.md](tasks/BE-01-billing-account-effective-plan.md) | TODO |
+| BE-01 | `feature/be-01-billing-account-effective-plan` | Introduce `BillingAccount` (Personal), backfill for existing users, `EffectivePlanResolver` returning implicit FREE | [tasks/BE-01-billing-account-effective-plan.md](tasks/BE-01-billing-account-effective-plan.md) | DONE |
 | BE-02 | `feature/be-02-entitlement-module-free-limits` | `entitlement` module: `PlanEntitlements` (Free 1×4, Pro 10×20), capability checks, enforce Free limits in lobby create + invite accept | [tasks/BE-02-entitlement-module-free-limits.md](tasks/BE-02-entitlement-module-free-limits.md) | TODO |
 | BE-03 | `feature/be-03-lobby-lifecycle-access-mode` | Lobby lifecycle status + access mode + restriction reason + `archiveAt`; select-as-free / restore / archived-list endpoints | [tasks/BE-03-lobby-lifecycle-access-mode.md](tasks/BE-03-lobby-lifecycle-access-mode.md) | TODO |
 | BE-04 | `feature/be-04-remove-legacy-billing-endpoints` | Remove unsafe prototype endpoints; add secured `GET /api/billing/me` derived from the authenticated principal | [tasks/BE-04-remove-legacy-billing-endpoints.md](tasks/BE-04-remove-legacy-billing-endpoints.md) | TODO |

--- a/backend/lined/src/main/java/io/backend/lined/app/AccountApplicationServiceImpl.java
+++ b/backend/lined/src/main/java/io/backend/lined/app/AccountApplicationServiceImpl.java
@@ -1,5 +1,6 @@
 package io.backend.lined.app;
 
+import io.backend.lined.billing.application.BillingAccountService;
 import io.backend.lined.plan.api.PlanDto;
 import io.backend.lined.plan.service.PlanService;
 import io.backend.lined.role.service.RoleService;
@@ -22,6 +23,7 @@ public class AccountApplicationServiceImpl implements AccountApplicationService 
   private final PlanService planService;
   private final SubscriptionService subscriptionService;
   private final AccountProvisioningPolicy provisioningPolicy;
+  private final BillingAccountService billingAccountService;
 
   @Override
   @Transactional
@@ -29,10 +31,7 @@ public class AccountApplicationServiceImpl implements AccountApplicationService 
     AccountProvisioningSpec provisioning = provisioningPolicy.defaultRegistration();
     UserDto user = userService.create(createDto);
     roleService.setUserRoles(user.id(), provisioning.roleNames());
-
-    PlanDto defaultPlan = planService.getByName(provisioning.planName());
-    subscriptionService.start(
-        user.id(), defaultPlan.id(), null, null, provisioning.activeSubscription());
+    billingAccountService.ensurePersonalAccount(user.id());
 
     return userService.getById(user.id());
   }

--- a/backend/lined/src/main/java/io/backend/lined/billing/application/BillingAccountService.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/application/BillingAccountService.java
@@ -1,0 +1,38 @@
+package io.backend.lined.billing.application;
+
+import io.backend.lined.billing.domain.account.BillingAccountEntity;
+import io.backend.lined.billing.domain.account.BillingAccountRepository;
+import io.backend.lined.billing.domain.account.BillingAccountStatus;
+import io.backend.lined.billing.domain.account.BillingAccountType;
+import io.backend.lined.common.EntityFinder;
+import io.backend.lined.common.exception.NotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BillingAccountService {
+
+  private final BillingAccountRepository billingAccountRepository;
+
+  public BillingAccountEntity ensurePersonalAccount(Long userId) {
+    return billingAccountRepository.findByOwnerUserIdAndType(userId, BillingAccountType.PERSONAL)
+        .orElseGet(() -> billingAccountRepository.save(newPersonalAccount(userId)));
+  }
+
+  public BillingAccountEntity getByOwnerUserId(Long userId) {
+    return EntityFinder.findOrThrow(
+        billingAccountRepository.findByOwnerUserIdAndType(userId, BillingAccountType.PERSONAL),
+        () -> new NotFoundException("Personal billing account not found for user %d".formatted(userId)));
+  }
+
+  private BillingAccountEntity newPersonalAccount(Long userId) {
+    return BillingAccountEntity.builder()
+        .ownerUserId(userId)
+        .type(BillingAccountType.PERSONAL)
+        .status(BillingAccountStatus.ACTIVE)
+        .build();
+  }
+}

--- a/backend/lined/src/main/java/io/backend/lined/billing/application/BillingAccountService.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/application/BillingAccountService.java
@@ -13,21 +13,59 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 @Transactional
+/**
+ * Manages the billing account that owns a user's commercial state.
+ *
+ * <p>The initial product model creates one active {@link BillingAccountType#PERSONAL PERSONAL}
+ * account for each user. Later billing features resolve subscriptions, invoices, and entitlements
+ * through this aggregate rather than attaching them directly to a user.</p>
+ *
+ * <p>Example: registering user {@code 42} calls {@code ensurePersonalAccount(42L)}. The first
+ * call persists an active personal account; a later call returns that same account.</p>
+ */
 public class BillingAccountService {
 
   private final BillingAccountRepository billingAccountRepository;
 
+  /**
+   * Returns the user's personal account, creating it when it does not exist yet.
+   *
+   * <p>This is intentionally idempotent for ordinary retries. For example,
+   * {@code ensurePersonalAccount(42L)} can safely be invoked by registration and a repair flow:
+   * once the personal account exists, no second account is saved.</p>
+   *
+   * @param userId identifier of the user who owns the personal account
+   * @return the existing or newly persisted active personal account
+   */
   public BillingAccountEntity ensurePersonalAccount(Long userId) {
     return billingAccountRepository.findByOwnerUserIdAndType(userId, BillingAccountType.PERSONAL)
         .orElseGet(() -> billingAccountRepository.save(newPersonalAccount(userId)));
   }
 
+  /**
+   * Retrieves the active user's personal billing account for downstream billing operations.
+   *
+   * <p>For example, a later {@code GET /api/billing/me} endpoint can resolve the authenticated
+   * user ID with {@code getByOwnerUserId(currentUserId)} before calculating an effective plan.</p>
+   *
+   * @param userId identifier of the account owner
+   * @return the owner's personal billing account
+   * @throws NotFoundException when no personal billing account exists for {@code userId}
+   */
   public BillingAccountEntity getByOwnerUserId(Long userId) {
     return EntityFinder.findOrThrow(
         billingAccountRepository.findByOwnerUserIdAndType(userId, BillingAccountType.PERSONAL),
         () -> new NotFoundException("Personal billing account not found for user %d".formatted(userId)));
   }
 
+  /**
+   * Builds the initial state for an account that is about to be persisted.
+   *
+   * <p>Example result: {@code {ownerUserId=42, type=PERSONAL, status=ACTIVE}}.</p>
+   *
+   * @param userId identifier of the user who will own the account
+   * @return a new, unsaved personal billing account
+   */
   private BillingAccountEntity newPersonalAccount(Long userId) {
     return BillingAccountEntity.builder()
         .ownerUserId(userId)

--- a/backend/lined/src/main/java/io/backend/lined/billing/application/EffectivePlanResolver.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/application/EffectivePlanResolver.java
@@ -1,0 +1,21 @@
+package io.backend.lined.billing.application;
+
+import io.backend.lined.billing.domain.plan.PlanCode;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EffectivePlanResolver {
+
+  private final PaidSubscriptionLookupPort paidSubscriptionLookup;
+
+  public PlanCode resolve(Long billingAccountId, Instant now) {
+    return paidSubscriptionLookup.findCurrentByBillingAccountId(billingAccountId)
+        .filter(subscription -> subscription.planCode() == PlanCode.PRO)
+        .filter(subscription -> subscription.currentPeriodEnd().isAfter(now))
+        .map(PaidSubscription::planCode)
+        .orElse(PlanCode.FREE);
+  }
+}

--- a/backend/lined/src/main/java/io/backend/lined/billing/application/EffectivePlanResolver.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/application/EffectivePlanResolver.java
@@ -7,10 +7,32 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+/**
+ * Resolves the plan currently effective for a billing account.
+ *
+ * <p>Free is implicit: an absent, expired, or non-Pro paid subscription resolves to
+ * {@link PlanCode#FREE}. This avoids persisting a Free subscription merely to represent the
+ * default product state.</p>
+ *
+ * <p>Example: if account {@code 17} has a Pro subscription ending after the supplied instant,
+ * {@code resolve(17L, now)} returns {@code PRO}; if the lookup is empty, it returns
+ * {@code FREE}.</p>
+ */
 public class EffectivePlanResolver {
 
   private final PaidSubscriptionLookupPort paidSubscriptionLookup;
 
+  /**
+   * Determines the plan that applies at one precise instant.
+   *
+   * <p>The caller supplies time so that renewal-boundary behavior is deterministic in tests and
+   * independent of the server clock. A subscription ending exactly at {@code now} is expired;
+   * only an end time strictly after {@code now} grants Pro.</p>
+   *
+   * @param billingAccountId identifier used to look up paid subscription state
+   * @param now instant at which entitlement is evaluated
+   * @return {@code PRO} for a current Pro subscription; otherwise {@code FREE}
+   */
   public PlanCode resolve(Long billingAccountId, Instant now) {
     return paidSubscriptionLookup.findCurrentByBillingAccountId(billingAccountId)
         .filter(subscription -> subscription.planCode() == PlanCode.PRO)

--- a/backend/lined/src/main/java/io/backend/lined/billing/application/NoOpPaidSubscriptionLookup.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/application/NoOpPaidSubscriptionLookup.java
@@ -1,0 +1,13 @@
+package io.backend.lined.billing.application;
+
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NoOpPaidSubscriptionLookup implements PaidSubscriptionLookupPort {
+
+  @Override
+  public Optional<PaidSubscription> findCurrentByBillingAccountId(Long billingAccountId) {
+    return Optional.empty();
+  }
+}

--- a/backend/lined/src/main/java/io/backend/lined/billing/application/NoOpPaidSubscriptionLookup.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/application/NoOpPaidSubscriptionLookup.java
@@ -4,8 +4,21 @@ import java.util.Optional;
 import org.springframework.stereotype.Component;
 
 @Component
+/**
+ * Temporary subscription lookup used before the paid-subscription persistence model exists.
+ *
+ * <p>It deliberately exposes no paid subscriptions, so every account resolves to implicit Free.
+ * For example, {@code findCurrentByBillingAccountId(17L)} returns {@link Optional#empty()}.
+ * BE-06 replaces this adapter with a repository-backed implementation.</p>
+ */
 public class NoOpPaidSubscriptionLookup implements PaidSubscriptionLookupPort {
 
+  /**
+   * Returns no subscription because BE-01 has no persisted paid subscription domain yet.
+   *
+   * @param billingAccountId identifier that would identify the subscription owner
+   * @return an empty result, causing the effective-plan resolver to select Free
+   */
   @Override
   public Optional<PaidSubscription> findCurrentByBillingAccountId(Long billingAccountId) {
     return Optional.empty();

--- a/backend/lined/src/main/java/io/backend/lined/billing/application/PaidSubscription.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/application/PaidSubscription.java
@@ -1,0 +1,7 @@
+package io.backend.lined.billing.application;
+
+import io.backend.lined.billing.domain.plan.PlanCode;
+import java.time.Instant;
+
+public record PaidSubscription(PlanCode planCode, Instant currentPeriodEnd) {
+}

--- a/backend/lined/src/main/java/io/backend/lined/billing/application/PaidSubscription.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/application/PaidSubscription.java
@@ -3,5 +3,14 @@ package io.backend.lined.billing.application;
 import io.backend.lined.billing.domain.plan.PlanCode;
 import java.time.Instant;
 
+/**
+ * Minimal provider-neutral view of a paid subscription needed to resolve an effective plan.
+ *
+ * <p>Example: {@code new PaidSubscription(PlanCode.PRO, Instant.parse("2026-08-01T00:00:00Z"))}
+ * represents a Pro entitlement that remains valid until that provider-canonical period end.</p>
+ *
+ * @param planCode paid plan granted by the subscription; BE-01 recognizes {@code PRO}
+ * @param currentPeriodEnd exclusive instant after which the paid entitlement no longer applies
+ */
 public record PaidSubscription(PlanCode planCode, Instant currentPeriodEnd) {
 }

--- a/backend/lined/src/main/java/io/backend/lined/billing/application/PaidSubscriptionLookupPort.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/application/PaidSubscriptionLookupPort.java
@@ -1,0 +1,8 @@
+package io.backend.lined.billing.application;
+
+import java.util.Optional;
+
+public interface PaidSubscriptionLookupPort {
+
+  Optional<PaidSubscription> findCurrentByBillingAccountId(Long billingAccountId);
+}

--- a/backend/lined/src/main/java/io/backend/lined/billing/application/PaidSubscriptionLookupPort.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/application/PaidSubscriptionLookupPort.java
@@ -2,7 +2,24 @@ package io.backend.lined.billing.application;
 
 import java.util.Optional;
 
+/**
+ * Boundary through which effective-plan resolution obtains paid subscription state.
+ *
+ * <p>The port lets the resolver remain independent of the later subscription schema and any
+ * payment provider. For example, a future repository adapter can return a current Pro period for
+ * account {@code 17}, while the BE-01 no-op adapter returns no value.</p>
+ */
 public interface PaidSubscriptionLookupPort {
 
+  /**
+   * Looks up the current paid subscription for one billing account.
+   *
+   * <p>Example: an account with an active Pro period returns
+   * {@code Optional.of(new PaidSubscription(PlanCode.PRO, periodEnd))}; an account with no paid
+   * state returns {@code Optional.empty()}.</p>
+   *
+   * @param billingAccountId identifier of the account whose subscription is requested
+   * @return the current paid subscription when one is available
+   */
   Optional<PaidSubscription> findCurrentByBillingAccountId(Long billingAccountId);
 }

--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountEntity.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountEntity.java
@@ -1,0 +1,75 @@
+package io.backend.lined.billing.domain.account;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "billing_accounts", uniqueConstraints = @UniqueConstraint(
+    name = "uq_billing_accounts_owner_type", columnNames = {"owner_user_id", "type"}))
+public class BillingAccountEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @EqualsAndHashCode.Include
+  private Long id;
+
+  @Column(name = "owner_user_id", nullable = false)
+  private Long ownerUserId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 16)
+  private BillingAccountType type;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 16)
+  private BillingAccountStatus status;
+
+  @Version
+  @Column(nullable = false)
+  private long version;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  @PrePersist
+  void prePersist() {
+    OffsetDateTime now = OffsetDateTime.now();
+    if (createdAt == null) {
+      createdAt = now;
+    }
+    if (updatedAt == null) {
+      updatedAt = now;
+    }
+  }
+
+  @PreUpdate
+  void preUpdate() {
+    updatedAt = OffsetDateTime.now();
+  }
+}

--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountEntity.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountEntity.java
@@ -29,6 +29,17 @@ import lombok.Setter;
 @Entity
 @Table(name = "billing_accounts", uniqueConstraints = @UniqueConstraint(
     name = "uq_billing_accounts_owner_type", columnNames = {"owner_user_id", "type"}))
+/**
+ * Persistent aggregate that owns a user's billing state.
+ *
+ * <p>The unique {@code (owner_user_id, type)} invariant permits exactly one personal account per
+ * user. For example, a new row for user {@code 42} is stored as
+ * {@code {owner_user_id=42, type=PERSONAL, status=ACTIVE}} and later subscriptions attach to its
+ * generated ID.</p>
+ *
+ * <p>The version column supports optimistic locking, while lifecycle callbacks assign UTC
+ * creation and update timestamps when callers do not provide them.</p>
+ */
 public class BillingAccountEntity {
 
   @Id
@@ -57,6 +68,12 @@ public class BillingAccountEntity {
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
 
+  /**
+   * Initializes creation and update timestamps immediately before the first insert.
+   *
+   * <p>Example: a builder-created account with no timestamps receives the same current UTC value
+   * for both fields; explicitly supplied timestamps are retained.</p>
+   */
   @PrePersist
   void prePersist() {
     OffsetDateTime now = OffsetDateTime.now();
@@ -68,6 +85,12 @@ public class BillingAccountEntity {
     }
   }
 
+  /**
+   * Refreshes the mutable update timestamp before an existing account is written.
+   *
+   * <p>Example: changing an account's status updates {@code updatedAt} while retaining its
+   * original {@code createdAt} value.</p>
+   */
   @PreUpdate
   void preUpdate() {
     updatedAt = OffsetDateTime.now();

--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountRepository.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountRepository.java
@@ -5,8 +5,21 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
+/**
+ * Persistence boundary for billing-account aggregates.
+ *
+ * <p>Example: {@code findByOwnerUserIdAndType(42L, PERSONAL)} locates the sole personal account
+ * belonging to user {@code 42}, if it has already been provisioned.</p>
+ */
 public interface BillingAccountRepository extends JpaRepository<BillingAccountEntity, Long> {
 
+  /**
+   * Finds one account by its owner and account type.
+   *
+   * @param ownerUserId identifier of the user who owns the account
+   * @param type account category, currently {@code PERSONAL}
+   * @return the matching account, or an empty result when provisioning has not occurred
+   */
   Optional<BillingAccountEntity> findByOwnerUserIdAndType(
       Long ownerUserId, BillingAccountType type);
 }

--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountRepository.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountRepository.java
@@ -1,0 +1,12 @@
+package io.backend.lined.billing.domain.account;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BillingAccountRepository extends JpaRepository<BillingAccountEntity, Long> {
+
+  Optional<BillingAccountEntity> findByOwnerUserIdAndType(
+      Long ownerUserId, BillingAccountType type);
+}

--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountStatus.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountStatus.java
@@ -1,0 +1,5 @@
+package io.backend.lined.billing.domain.account;
+
+public enum BillingAccountStatus {
+  ACTIVE
+}

--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountStatus.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountStatus.java
@@ -1,5 +1,12 @@
 package io.backend.lined.billing.domain.account;
 
+/**
+ * Lifecycle state of a billing account.
+ *
+ * <p>BE-01 supports only {@link #ACTIVE}; for example, every account created during registration
+ * begins in this state. Later tasks may add suspended or closed states without changing account
+ * ownership.</p>
+ */
 public enum BillingAccountStatus {
   ACTIVE
 }

--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountType.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountType.java
@@ -1,5 +1,12 @@
 package io.backend.lined.billing.domain.account;
 
+/**
+ * Categorizes the commercial owner represented by a billing account.
+ *
+ * <p>BE-01 supports only {@link #PERSONAL}; for example, a registration for user {@code 42}
+ * provisions one Personal account. The enum keeps the uniqueness boundary ready for future
+ * account categories.</p>
+ */
 public enum BillingAccountType {
   PERSONAL
 }

--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountType.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountType.java
@@ -1,0 +1,5 @@
+package io.backend.lined.billing.domain.account;
+
+public enum BillingAccountType {
+  PERSONAL
+}

--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/plan/PlanCode.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/plan/PlanCode.java
@@ -1,0 +1,6 @@
+package io.backend.lined.billing.domain.plan;
+
+public enum PlanCode {
+  FREE,
+  PRO
+}

--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/plan/PlanCode.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/plan/PlanCode.java
@@ -1,5 +1,12 @@
 package io.backend.lined.billing.domain.plan;
 
+/**
+ * Product plan codes used by billing and entitlement decisions.
+ *
+ * <p>{@link #FREE} is the implicit fallback when no valid paid subscription exists. For example,
+ * a current paid period resolves to {@link #PRO}; an expired or absent paid period resolves to
+ * {@code FREE}.</p>
+ */
 public enum PlanCode {
   FREE,
   PRO

--- a/backend/lined/src/main/resources/database/schema.sql
+++ b/backend/lined/src/main/resources/database/schema.sql
@@ -226,3 +226,25 @@ CREATE TABLE IF NOT EXISTS password_reset_tokens
 
 CREATE UNIQUE INDEX IF NOT EXISTS uq_password_reset_tokens_hash ON password_reset_tokens (token_hash);
 CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user ON password_reset_tokens (user_id);
+
+CREATE TABLE IF NOT EXISTS billing_accounts
+(
+    id            BIGSERIAL PRIMARY KEY,
+    owner_user_id BIGINT      NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    type          VARCHAR(16) NOT NULL,
+    status        VARCHAR(16) NOT NULL,
+    version       BIGINT      NOT NULL DEFAULT 0,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_billing_accounts_owner_type UNIQUE (owner_user_id, type)
+);
+
+INSERT INTO billing_accounts (owner_user_id, type, status, created_at, updated_at)
+SELECT users.id, 'PERSONAL', 'ACTIVE', NOW(), NOW()
+FROM users
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM billing_accounts accounts
+    WHERE accounts.owner_user_id = users.id
+      AND accounts.type = 'PERSONAL'
+);

--- a/backend/lined/src/test/java/io/backend/lined/app/AccountApplicationServiceImplTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/app/AccountApplicationServiceImplTest.java
@@ -2,12 +2,14 @@ package io.backend.lined.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.backend.lined.billing.application.BillingAccountService;
 import io.backend.lined.plan.api.PlanDto;
 import io.backend.lined.plan.domain.BuiltInPlan;
 import io.backend.lined.plan.service.PlanService;
@@ -61,6 +63,8 @@ class AccountApplicationServiceImplTest {
   private SubscriptionService subscriptionService;
   @Mock
   private AccountProvisioningPolicy provisioningPolicy;
+  @Mock
+  private BillingAccountService billingAccountService;
 
   @InjectMocks
   private AccountApplicationServiceImpl accountService;
@@ -97,32 +101,27 @@ class AccountApplicationServiceImplTest {
     when(userService.getById(USER_ID)).thenReturn(userDto);
     when(provisioningPolicy.defaultRegistration())
         .thenReturn(new AccountProvisioningSpec(Set.of(USER_ROLE), FREE_PLAN_NAME, true));
-    when(planService.getByName(FREE_PLAN_NAME)).thenReturn(freePlan);
 
     UserDto result = accountService.registerUser(createDto);
 
     assertThat(result).isEqualTo(userDto);
     verify(roleService).setUserRoles(USER_ID, Set.of(USER_ROLE));
-    verify(subscriptionService).start(eq(USER_ID), eq(FREE_PLAN_ID), isNull(), isNull(), eq(true));
+    verify(billingAccountService).ensurePersonalAccount(USER_ID);
+    verify(subscriptionService, never()).start(any(), any(), any(), any(), anyBoolean());
   }
 
   @Test
   void registerUser_usesPolicyPlanNameForDefaultSubscription() {
-    PlanDto starterPlan =
-        new PlanDto(STARTER_PLAN_ID, STARTER_PLAN_NAME, BigDecimal.ZERO, PLAN_DURATION_DAYS, now);
-
     when(userService.create(createDto)).thenReturn(userDto);
     when(userService.getById(USER_ID)).thenReturn(userDto);
     when(provisioningPolicy.defaultRegistration())
         .thenReturn(new AccountProvisioningSpec(Set.of(USER_ROLE), STARTER_PLAN_NAME, true));
-    when(planService.getByName(STARTER_PLAN_NAME)).thenReturn(starterPlan);
 
     accountService.registerUser(createDto);
 
     verify(roleService).setUserRoles(USER_ID, Set.of(USER_ROLE));
-    verify(planService).getByName(STARTER_PLAN_NAME);
-    verify(subscriptionService)
-        .start(eq(USER_ID), eq(STARTER_PLAN_ID), isNull(), isNull(), eq(true));
+    verify(billingAccountService).ensurePersonalAccount(USER_ID);
+    verify(subscriptionService, never()).start(any(), any(), any(), any(), anyBoolean());
   }
 
   @Test
@@ -131,12 +130,12 @@ class AccountApplicationServiceImplTest {
     when(userService.getById(USER_ID)).thenReturn(userDto);
     when(provisioningPolicy.defaultRegistration())
         .thenReturn(new AccountProvisioningSpec(Set.of(USER_ROLE), FREE_PLAN_NAME, false));
-    when(planService.getByName(FREE_PLAN_NAME)).thenReturn(freePlan);
 
     accountService.registerUser(createDto);
 
     verify(roleService).setUserRoles(USER_ID, Set.of(USER_ROLE));
-    verify(subscriptionService).start(eq(USER_ID), eq(FREE_PLAN_ID), isNull(), isNull(), eq(false));
+    verify(billingAccountService).ensurePersonalAccount(USER_ID);
+    verify(subscriptionService, never()).start(any(), any(), any(), any(), anyBoolean());
   }
 
   @Test
@@ -151,12 +150,12 @@ class AccountApplicationServiceImplTest {
     when(userService.getById(ADMIN_USER_ID)).thenReturn(adminUserDto);
     when(provisioningPolicy.defaultRegistration())
         .thenReturn(new AccountProvisioningSpec(policyRoles, FREE_PLAN_NAME, true));
-    when(planService.getByName(FREE_PLAN_NAME)).thenReturn(freePlan);
 
     accountService.registerUser(adminDto);
 
     verify(roleService).setUserRoles(ADMIN_USER_ID, policyRoles);
     verify(roleService, never()).addUserRoles(any(), any());
+    verify(billingAccountService).ensurePersonalAccount(ADMIN_USER_ID);
   }
 
   @Test
@@ -169,12 +168,12 @@ class AccountApplicationServiceImplTest {
     when(userService.create(createDto)).thenReturn(userDto);
     when(provisioningPolicy.defaultRegistration())
         .thenReturn(new AccountProvisioningSpec(Set.of(USER_ROLE), FREE_PLAN_NAME, true));
-    when(planService.getByName(FREE_PLAN_NAME)).thenReturn(freePlan);
     when(userService.getById(USER_ID)).thenReturn(refreshedUser);
 
     UserDto result = accountService.registerUser(createDto);
 
     assertThat(result).isEqualTo(refreshedUser);
+    verify(billingAccountService).ensurePersonalAccount(USER_ID);
   }
 
   /* =======================

--- a/backend/lined/src/test/java/io/backend/lined/billing/application/BillingAccountServiceTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/billing/application/BillingAccountServiceTest.java
@@ -1,0 +1,62 @@
+package io.backend.lined.billing.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.backend.lined.billing.domain.account.BillingAccountEntity;
+import io.backend.lined.billing.domain.account.BillingAccountRepository;
+import io.backend.lined.billing.domain.account.BillingAccountStatus;
+import io.backend.lined.billing.domain.account.BillingAccountType;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BillingAccountServiceTest {
+
+  private static final long USER_ID = 1L;
+
+  @Mock
+  private BillingAccountRepository billingAccountRepository;
+
+  @InjectMocks
+  private BillingAccountService service;
+
+  @Test
+  void ensurePersonalAccount_returnsExistingAccount_whenCalledAgain() {
+    BillingAccountEntity existing = BillingAccountEntity.builder()
+        .id(10L)
+        .ownerUserId(USER_ID)
+        .type(BillingAccountType.PERSONAL)
+        .status(BillingAccountStatus.ACTIVE)
+        .build();
+    when(billingAccountRepository.findByOwnerUserIdAndType(USER_ID, BillingAccountType.PERSONAL))
+        .thenReturn(Optional.of(existing));
+
+    BillingAccountEntity result = service.ensurePersonalAccount(USER_ID);
+
+    assertThat(result).isSameAs(existing);
+    verify(billingAccountRepository).findByOwnerUserIdAndType(USER_ID, BillingAccountType.PERSONAL);
+    verifyNoMoreInteractions(billingAccountRepository);
+  }
+
+  @Test
+  void ensurePersonalAccount_createsActivePersonalAccount_whenMissing() {
+    when(billingAccountRepository.findByOwnerUserIdAndType(USER_ID, BillingAccountType.PERSONAL))
+        .thenReturn(Optional.empty());
+
+    service.ensurePersonalAccount(USER_ID);
+
+    ArgumentCaptor<BillingAccountEntity> account = ArgumentCaptor.forClass(BillingAccountEntity.class);
+    verify(billingAccountRepository).save(account.capture());
+    assertThat(account.getValue().getOwnerUserId()).isEqualTo(USER_ID);
+    assertThat(account.getValue().getType()).isEqualTo(BillingAccountType.PERSONAL);
+    assertThat(account.getValue().getStatus()).isEqualTo(BillingAccountStatus.ACTIVE);
+  }
+}

--- a/backend/lined/src/test/java/io/backend/lined/billing/application/EffectivePlanResolverTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/billing/application/EffectivePlanResolverTest.java
@@ -1,0 +1,52 @@
+package io.backend.lined.billing.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.backend.lined.billing.domain.plan.PlanCode;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EffectivePlanResolverTest {
+
+  private static final long BILLING_ACCOUNT_ID = 1L;
+  private static final Instant NOW = Instant.parse("2026-07-23T12:00:00Z");
+
+  @Mock
+  private PaidSubscriptionLookupPort paidSubscriptionLookup;
+
+  @InjectMocks
+  private EffectivePlanResolver resolver;
+
+  @Test
+  void resolve_returnsFree_whenNoPaidSubscriptionExists() {
+    when(paidSubscriptionLookup.findCurrentByBillingAccountId(BILLING_ACCOUNT_ID))
+        .thenReturn(Optional.empty());
+
+    assertThat(resolver.resolve(BILLING_ACCOUNT_ID, NOW)).isEqualTo(PlanCode.FREE);
+  }
+
+  @Test
+  void resolve_returnsFree_whenPaidSubscriptionIsExpired() {
+    PaidSubscription expired = new PaidSubscription(PlanCode.PRO, NOW.minusSeconds(1));
+    when(paidSubscriptionLookup.findCurrentByBillingAccountId(BILLING_ACCOUNT_ID))
+        .thenReturn(Optional.of(expired));
+
+    assertThat(resolver.resolve(BILLING_ACCOUNT_ID, NOW)).isEqualTo(PlanCode.FREE);
+  }
+
+  @Test
+  void resolve_returnsPro_whenPaidSubscriptionIsCurrent() {
+    PaidSubscription active = new PaidSubscription(PlanCode.PRO, NOW.plusSeconds(1));
+    when(paidSubscriptionLookup.findCurrentByBillingAccountId(BILLING_ACCOUNT_ID))
+        .thenReturn(Optional.of(active));
+
+    assertThat(resolver.resolve(BILLING_ACCOUNT_ID, NOW)).isEqualTo(PlanCode.PRO);
+  }
+}

--- a/backend/lined/src/test/java/io/backend/lined/billing/domain/account/BillingAccountRepositoryIT.java
+++ b/backend/lined/src/test/java/io/backend/lined/billing/domain/account/BillingAccountRepositoryIT.java
@@ -1,0 +1,145 @@
+package io.backend.lined.billing.domain.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.backend.lined.app.AccountApplicationService;
+import io.backend.lined.user.api.UserCreateDto;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers(disabledWithoutDocker = true)
+class BillingAccountRepositoryIT {
+
+  @Container
+  private static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:16-alpine");
+
+  @DynamicPropertySource
+  static void postgresProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+    registry.add("spring.datasource.username", POSTGRES::getUsername);
+    registry.add("spring.datasource.password", POSTGRES::getPassword);
+  }
+
+  @Autowired
+  private AccountApplicationService accountApplicationService;
+
+  @Autowired
+  private BillingAccountRepository billingAccountRepository;
+
+  @Autowired
+  private JdbcTemplate jdbcTemplate;
+
+  @BeforeEach
+  void setUp() {
+    jdbcTemplate.execute("truncate table billing_accounts, users cascade");
+  }
+
+  @AfterEach
+  void tearDown() {
+    jdbcTemplate.execute("drop trigger if exists fail_billing_account_insert on billing_accounts");
+    jdbcTemplate.execute("drop function if exists fail_billing_account_insert()");
+    jdbcTemplate.execute("truncate table billing_accounts, users cascade");
+  }
+
+  @Test
+  void save_rejectsDuplicatePersonalAccountForOneUser() {
+    long userId = insertUser("duplicate-owner");
+    billingAccountRepository.saveAndFlush(personalAccount(userId));
+
+    assertThatThrownBy(() -> billingAccountRepository.saveAndFlush(personalAccount(userId)))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void backfill_createsExactlyOnePersonalAccountPerExistingUser() {
+    long firstUserId = insertUser("first-backfill");
+    long secondUserId = insertUser("second-backfill");
+
+    runBackfill();
+    runBackfill();
+
+    assertThat(countAccounts(firstUserId)).isEqualTo(1);
+    assertThat(countAccounts(secondUserId)).isEqualTo(1);
+  }
+
+  @Test
+  void registerUser_createsPersonalAccountWithoutLegacyFreeSubscription() {
+    accountApplicationService.registerUser(new UserCreateDto(
+        "billing-registration", "billing-registration@example.com", "password", Set.of()));
+
+    assertThat(jdbcTemplate.queryForObject("select count(*) from billing_accounts", Integer.class))
+        .isEqualTo(1);
+    assertThat(jdbcTemplate.queryForObject("select count(*) from user_subscriptions", Integer.class))
+        .isZero();
+  }
+
+  @Test
+  void registerUser_rollsBackUserWhenBillingAccountInsertFails() {
+    jdbcTemplate.execute("""
+        create function fail_billing_account_insert() returns trigger as $$
+        begin
+          raise exception 'billing account insert failed';
+        end;
+        $$ language plpgsql
+        """);
+    jdbcTemplate.execute("""
+        create trigger fail_billing_account_insert
+        before insert on billing_accounts
+        for each row execute function fail_billing_account_insert()
+        """);
+
+    assertThatThrownBy(() -> accountApplicationService.registerUser(new UserCreateDto(
+        "billing-rollback", "billing-rollback@example.com", "password", Set.of())))
+        .isInstanceOf(RuntimeException.class);
+
+    assertThat(jdbcTemplate.queryForObject(
+        "select count(*) from users where username = 'billing-rollback'", Integer.class)).isZero();
+  }
+
+  private long insertUser(String username) {
+    return jdbcTemplate.queryForObject("""
+        insert into users (username, email, password)
+        values (?, ?, 'password')
+        returning id
+        """, Long.class, username, username + "@example.com");
+  }
+
+  private BillingAccountEntity personalAccount(long userId) {
+    return BillingAccountEntity.builder()
+        .ownerUserId(userId)
+        .type(BillingAccountType.PERSONAL)
+        .status(BillingAccountStatus.ACTIVE)
+        .build();
+  }
+
+  private void runBackfill() {
+    jdbcTemplate.execute("""
+        insert into billing_accounts (owner_user_id, type, status, created_at, updated_at)
+        select users.id, 'PERSONAL', 'ACTIVE', now(), now()
+        from users
+        where not exists (
+          select 1 from billing_accounts accounts
+          where accounts.owner_user_id = users.id and accounts.type = 'PERSONAL'
+        )
+        """);
+  }
+
+  private int countAccounts(long userId) {
+    return jdbcTemplate.queryForObject(
+        "select count(*) from billing_accounts where owner_user_id = ?", Integer.class, userId);
+  }
+}


### PR DESCRIPTION
## Purpose

Deliver billing task BE-01, establishing the account-owned foundation required before paid plans, checkout, and entitlement enforcement can be introduced. The change makes Free implicit for new registrations and leaves the existing legacy subscription data untouched.

## Type

- [ ] 🧪 Experiment (fitness function research)
- [x] ✨ Feature (new business logic)
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor / neutral change
- [ ] 📝 Documentation only

## Changes

- Added the `BillingAccount` aggregate with a single active `PERSONAL` account per user, optimistic locking, and UTC lifecycle timestamps.
- Added an idempotent schema backfill that provisions a Personal billing account for each existing user missing one.
- Updated registration to provision the billing account inside its existing transaction and to stop creating new legacy Free subscription rows.
- Added the provider-neutral paid-subscription lookup seam and effective-plan resolver. It returns `PRO` only for an unexpired Pro subscription and otherwise returns implicit `FREE`.
- Added focused unit tests, PostgreSQL Testcontainers coverage for uniqueness/backfill/rollback, and detailed Javadocs with examples for the billing contracts.
- Marked BE-01 as `DONE` in the billing task table.

## Files changed

| File | Change |
|------|--------|
| `src/main/java/io/backend/lined/billing/**` | New billing account domain, application services, resolver port, and documented contracts. |
| `src/main/resources/database/schema.sql` | Adds `billing_accounts` and an idempotent existing-user backfill. |
| `src/main/java/io/backend/lined/app/AccountApplicationServiceImpl.java` | Provisions a Personal billing account during registration instead of a Free subscription row. |
| `src/test/java/io/backend/lined/billing/**` | Unit and PostgreSQL Testcontainers tests for resolver, account service, constraint, backfill, and rollback behavior. |
| `docs/billing/BILLING_TASKS.md` | Marks BE-01 complete. |

## Expected result

Every user has exactly one Personal BillingAccount after startup or registration. New users receive Free implicitly when no valid paid subscription is available; this PR adds no public REST endpoint.

| Metric | Baseline (main) | Branch | Direction |
|--------|----------------|--------|-----------|
| checkstyle_violations | not measured | 0 (checkstyleMain and checkstyleTest passed) | neutral |
| spotbugs_total | unknown | 1 pre-existing unrelated finding in NotificationServiceImpl | neutral |
| line_coverage | not measured | not measured | unknown |
| critical_violations | not measured | not measured | unknown |
| code_smells | not measured | not measured | unknown |
| duplicated_lines_density | not measured | not measured | unknown |
| **F score** | not measured | not measured | unknown |
| **SonarQube QG** | unknown | not measured | unknown |

## How to use and test

Inspect the migration and billing contracts:

```bash
git show --stat HEAD
./gradlew test --tests 'io.backend.lined.billing.domain.account.BillingAccountRepositoryIT'
```

The Testcontainers suite verifies the unique Personal-account constraint, idempotent backfill behavior, registration provisioning, and rollback when the account insert fails.

The following checks were run:

```bash
./gradlew test
./gradlew checkstyleMain
./gradlew checkstyleTest
./gradlew spotbugsMain
```

`./gradlew check` and `./gradlew jacocoTestReport` were not run. SpotBugs retains one pre-existing unrelated finding in `NotificationServiceImpl`; no billing finding was reported.

## Checklist

- [ ] ./gradlew check passes locally
- [ ] ./gradlew jacocoTestReport passes locally
- [ ] No unintended changes to main business logic
- [x] Branch name matches experiment/feature naming convention
