### PR TITLE
Consolidate billing audit timestamps

### DIFF
--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountEntity.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/account/BillingAccountEntity.java
@@ -1,5 +1,6 @@
 package io.backend.lined.billing.domain.account;
 
+import io.backend.lined.billing.domain.common.BillingAuditableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -7,12 +8,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Version;
-import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -22,7 +20,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
@@ -40,7 +38,7 @@ import lombok.Setter;
  * <p>The version column supports optimistic locking, while lifecycle callbacks assign UTC
  * creation and update timestamps when callers do not provide them.</p>
  */
-public class BillingAccountEntity {
+public class BillingAccountEntity extends BillingAuditableEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -62,37 +60,4 @@ public class BillingAccountEntity {
   @Column(nullable = false)
   private long version;
 
-  @Column(name = "created_at", nullable = false, updatable = false)
-  private OffsetDateTime createdAt;
-
-  @Column(name = "updated_at", nullable = false)
-  private OffsetDateTime updatedAt;
-
-  /**
-   * Initializes creation and update timestamps immediately before the first insert.
-   *
-   * <p>Example: a builder-created account with no timestamps receives the same current UTC value
-   * for both fields; explicitly supplied timestamps are retained.</p>
-   */
-  @PrePersist
-  void prePersist() {
-    OffsetDateTime now = OffsetDateTime.now();
-    if (createdAt == null) {
-      createdAt = now;
-    }
-    if (updatedAt == null) {
-      updatedAt = now;
-    }
-  }
-
-  /**
-   * Refreshes the mutable update timestamp before an existing account is written.
-   *
-   * <p>Example: changing an account's status updates {@code updatedAt} while retaining its
-   * original {@code createdAt} value.</p>
-   */
-  @PreUpdate
-  void preUpdate() {
-    updatedAt = OffsetDateTime.now();
-  }
 }

--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/account/ProviderCustomerEntity.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/account/ProviderCustomerEntity.java
@@ -1,5 +1,6 @@
 package io.backend.lined.billing.domain.account;
 
+import io.backend.lined.billing.domain.common.BillingAuditableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -8,11 +9,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -29,7 +27,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
@@ -39,7 +37,7 @@ import lombok.Setter;
         columnNames = {"billing_account_id", "provider"}),
     @UniqueConstraint(name = "uq_billing_provider_customers_provider_customer",
         columnNames = "provider_customer_id")})
-public class ProviderCustomerEntity {
+public class ProviderCustomerEntity extends BillingAuditableEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -56,37 +54,4 @@ public class ProviderCustomerEntity {
   @Column(name = "provider_customer_id", nullable = false, length = 128)
   private String providerCustomerId;
 
-  @Column(name = "created_at", nullable = false, updatable = false)
-  private OffsetDateTime createdAt;
-
-  @Column(name = "updated_at", nullable = false)
-  private OffsetDateTime updatedAt;
-
-  /**
-   * Initializes timestamps for a newly created provider-customer mapping.
-   *
-   * <p>For example, persisting a new sandbox mapping without timestamps assigns one UTC instant
-   * to both {@code createdAt} and {@code updatedAt}; supplied values are preserved.</p>
-   */
-  @PrePersist
-  void prePersist() {
-    OffsetDateTime now = OffsetDateTime.now();
-    if (createdAt == null) {
-      createdAt = now;
-    }
-    if (updatedAt == null) {
-      updatedAt = now;
-    }
-  }
-
-  /**
-   * Refreshes the audit timestamp whenever an existing mapping is written.
-   *
-   * <p>For example, a provider migration that replaces the provider customer identifier updates
-   * {@code updatedAt} while retaining the original creation time.</p>
-   */
-  @PreUpdate
-  void preUpdate() {
-    updatedAt = OffsetDateTime.now();
-  }
 }

--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/common/BillingAuditableEntity.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/common/BillingAuditableEntity.java
@@ -1,0 +1,57 @@
+package io.backend.lined.billing.domain.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.OffsetDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Shared persistence state for billing aggregates that retain creation and modification times.
+ *
+ * <p>For example, a newly persisted billing plan, provider customer, or subscription receives one
+ * UTC instant for both timestamps when neither is supplied. On a later update, only
+ * {@code updatedAt} changes. This mapped superclass keeps that invariant in one billing-domain
+ * module while subclasses retain their own tables and business fields.</p>
+ */
+@Getter
+@Setter
+@MappedSuperclass
+public abstract class BillingAuditableEntity {
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  /**
+   * Initializes missing local audit timestamps immediately before the first insert.
+   *
+   * <p>For example, an entity built without timestamps receives the same current UTC instant in
+   * both fields, while explicitly supplied timestamps remain unchanged for deterministic imports.</p>
+   */
+  @PrePersist
+  protected void initializeAuditTimestamps() {
+    OffsetDateTime now = OffsetDateTime.now();
+    if (createdAt == null) {
+      createdAt = now;
+    }
+    if (updatedAt == null) {
+      updatedAt = now;
+    }
+  }
+
+  /**
+   * Refreshes the mutable audit timestamp before an existing entity is written.
+   *
+   * <p>For example, scheduling a subscription change preserves {@code createdAt} and replaces
+   * {@code updatedAt} with the current UTC instant.</p>
+   */
+  @PreUpdate
+  protected void refreshUpdatedAt() {
+    updatedAt = OffsetDateTime.now();
+  }
+}

--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/plan/PlanCatalogEntity.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/plan/PlanCatalogEntity.java
@@ -1,14 +1,12 @@
 package io.backend.lined.billing.domain.plan;
 
+import io.backend.lined.billing.domain.common.BillingAuditableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
-import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -25,13 +23,13 @@ import lombok.Setter;
  */
 @Getter
 @Setter
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Entity
 @Table(name = "billing_plans")
-public class PlanCatalogEntity {
+public class PlanCatalogEntity extends BillingAuditableEntity {
 
   @Id
   @Enumerated(EnumType.STRING)
@@ -45,37 +43,4 @@ public class PlanCatalogEntity {
   @Column(nullable = false)
   private boolean active;
 
-  @Column(name = "created_at", nullable = false, updatable = false)
-  private OffsetDateTime createdAt;
-
-  @Column(name = "updated_at", nullable = false)
-  private OffsetDateTime updatedAt;
-
-  /**
-   * Initializes timestamps when a catalog plan is first persisted.
-   *
-   * <p>For example, a seed-like entity with no timestamps receives one current UTC value for
-   * both {@code createdAt} and {@code updatedAt}; explicitly supplied values are retained.</p>
-   */
-  @PrePersist
-  void prePersist() {
-    OffsetDateTime now = OffsetDateTime.now();
-    if (createdAt == null) {
-      createdAt = now;
-    }
-    if (updatedAt == null) {
-      updatedAt = now;
-    }
-  }
-
-  /**
-   * Refreshes the catalog plan update timestamp before a persistence update.
-   *
-   * <p>For example, disabling {@code PRO} changes {@code updatedAt} but preserves the original
-   * {@code createdAt} value.</p>
-   */
-  @PreUpdate
-  void preUpdate() {
-    updatedAt = OffsetDateTime.now();
-  }
 }

--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/plan/PriceCatalogEntity.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/plan/PriceCatalogEntity.java
@@ -1,5 +1,6 @@
 package io.backend.lined.billing.domain.plan;
 
+import io.backend.lined.billing.domain.common.BillingAuditableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -8,10 +9,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
-import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -28,13 +26,13 @@ import lombok.Setter;
  */
 @Getter
 @Setter
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Entity
 @Table(name = "billing_prices")
-public class PriceCatalogEntity {
+public class PriceCatalogEntity extends BillingAuditableEntity {
 
   @Id
   @Enumerated(EnumType.STRING)
@@ -59,37 +57,4 @@ public class PriceCatalogEntity {
   @Column(nullable = false)
   private boolean active;
 
-  @Column(name = "created_at", nullable = false, updatable = false)
-  private OffsetDateTime createdAt;
-
-  @Column(name = "updated_at", nullable = false)
-  private OffsetDateTime updatedAt;
-
-  /**
-   * Initializes timestamps when a price mapping is first persisted.
-   *
-   * <p>For example, persisting {@code PRO_YEARLY} without timestamps assigns matching current
-   * UTC values to {@code createdAt} and {@code updatedAt}.</p>
-   */
-  @PrePersist
-  void prePersist() {
-    OffsetDateTime now = OffsetDateTime.now();
-    if (createdAt == null) {
-      createdAt = now;
-    }
-    if (updatedAt == null) {
-      updatedAt = now;
-    }
-  }
-
-  /**
-   * Refreshes the price mapping update timestamp before a persistence update.
-   *
-   * <p>For example, replacing a sandbox identifier during a future provider migration updates
-   * {@code updatedAt} without modifying {@code createdAt}.</p>
-   */
-  @PreUpdate
-  void preUpdate() {
-    updatedAt = OffsetDateTime.now();
-  }
 }

--- a/backend/lined/src/main/java/io/backend/lined/billing/domain/subscription/SubscriptionEntity.java
+++ b/backend/lined/src/main/java/io/backend/lined/billing/domain/subscription/SubscriptionEntity.java
@@ -1,6 +1,7 @@
 package io.backend.lined.billing.domain.subscription;
 
 import io.backend.lined.billing.domain.account.BillingAccountEntity;
+import io.backend.lined.billing.domain.common.BillingAuditableEntity;
 import io.backend.lined.billing.domain.plan.PlanCode;
 import io.backend.lined.billing.domain.plan.PriceCode;
 import jakarta.persistence.Column;
@@ -13,12 +14,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import java.time.Instant;
-import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -36,13 +34,13 @@ import lombok.Setter;
  */
 @Getter
 @Setter
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Entity
 @Table(name = "billing_subscriptions")
-public class SubscriptionEntity {
+public class SubscriptionEntity extends BillingAuditableEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -103,38 +101,4 @@ public class SubscriptionEntity {
   @Column(nullable = false)
   private long version;
 
-  @Column(name = "created_at", nullable = false, updatable = false)
-  private OffsetDateTime createdAt;
-
-  @Column(name = "updated_at", nullable = false)
-  private OffsetDateTime updatedAt;
-
-  /**
-   * Initializes local audit timestamps before inserting a subscription projection.
-   *
-   * <p>For example, a webhook-created subscription keeps its provider timestamp in
-   * {@code providerUpdatedAt} while this callback assigns matching UTC timestamps to the local
-   * {@code createdAt} and {@code updatedAt} fields when they were not supplied.</p>
-   */
-  @PrePersist
-  void prePersist() {
-    OffsetDateTime now = OffsetDateTime.now();
-    if (createdAt == null) {
-      createdAt = now;
-    }
-    if (updatedAt == null) {
-      updatedAt = now;
-    }
-  }
-
-  /**
-   * Refreshes the local audit timestamp after a projection update.
-   *
-   * <p>For example, applying a verified payment-recovered event changes status and updates
-   * {@code updatedAt}, but does not manufacture a replacement provider timestamp.</p>
-   */
-  @PreUpdate
-  void preUpdate() {
-    updatedAt = OffsetDateTime.now();
-  }
 }

--- a/backend/lined/src/test/java/io/backend/lined/billing/domain/account/ProviderCustomerRepositoryIT.java
+++ b/backend/lined/src/test/java/io/backend/lined/billing/domain/account/ProviderCustomerRepositoryIT.java
@@ -1,8 +1,9 @@
 package io.backend.lined.billing.domain.account;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.OffsetDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,6 +62,21 @@ class ProviderCustomerRepositoryIT {
     assertThatThrownBy(() -> providerCustomerRepository.saveAndFlush(
         customer(secondAccountId, "stripe", "cus_shared")))
         .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void save_preservesExplicitCreationTimeAndRefreshesUpdateTime() {
+    ProviderCustomerEntity customer = customer(accountId("audited-customer"), "sandbox", "cus_audited");
+    OffsetDateTime importedAt = OffsetDateTime.parse("2000-01-01T00:00:00Z");
+    customer.setCreatedAt(importedAt);
+    customer.setUpdatedAt(importedAt);
+
+    ProviderCustomerEntity saved = providerCustomerRepository.saveAndFlush(customer);
+    saved.setProviderCustomerId("cus_audited_updated");
+    ProviderCustomerEntity updated = providerCustomerRepository.saveAndFlush(saved);
+
+    assertThat(updated.getCreatedAt()).isEqualTo(importedAt);
+    assertThat(updated.getUpdatedAt()).isAfter(importedAt);
   }
 
   private long accountId(String username) {


### PR DESCRIPTION
## Purpose

Address SonarCloud duplication introduced by the billing subscription foundation without changing billing tables, API contracts, or lifecycle semantics.

## Type

- [ ] 🧪 Experiment (fitness function research)
- [ ] ✨ Feature (new business logic)
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor / neutral change
- [ ] 📝 Documentation only

## Changes

- Introduce `BillingAuditableEntity`, a billing-domain `@MappedSuperclass` that owns the unchanged `created_at` / `updated_at` mappings and JPA insert/update callbacks.
- Migrate billing account, provider customer, plan catalog, price catalog, and subscription entities to the shared lifecycle seam.
- Preserve ID-only equality explicitly with Lombok `callSuper = false`.
- Add persistence coverage that verifies explicit import timestamps survive insertion and only `updatedAt` refreshes on update.

## Files changed

| File | Change |
|---|---|
| `billing/domain/common/BillingAuditableEntity.java` | Centralizes audit timestamp mapping and lifecycle callbacks. |
| Billing account, catalog, provider-customer, and subscription entities | Inherit the shared audited persistence state; remove duplicate fields and callbacks. |
| `ProviderCustomerRepositoryIT.java` | Covers preserved creation time and refreshed update time. |

## Expected result

The billing persistence model and public APIs are unchanged. SonarCloud should no longer report the repeated billing lifecycle callback blocks as new duplication.

| Metric | Baseline (main) | Branch | Direction |
|---|---|---|---|
| checkstyle_violations | not measured | 0 (local gate passed) | neutral |
| spotbugs_total | not measured | 1 pre-existing unrelated finding | neutral |
| line_coverage | not measured | not measured | neutral |
| critical_violations | not measured | not measured | neutral |
| code_smells | not measured | not measured | neutral |
| duplicated_lines_density | 1.8% | not measured pending SonarCloud analysis | decrease expected |
| **F score** | not measured | not measured | unknown |
| **SonarQube QG** | not measured | not measured | unknown |

## How to use and test

```bash
./gradlew test --rerun-tasks
./gradlew checkstyleMain
./gradlew spotbugsMain
```

The full suite produced 57 XML test reports with zero skipped, failed, or errored tests. The billing PostgreSQL Testcontainers suites executed 13 tests with zero skips, failures, or errors.

## Checklist

- [x] `./gradlew test` passes locally
- [ ] `./gradlew jacocoTestReport` passes locally
- [x] No production schema or public API changes
- [x] Branch uses the Codex naming convention
