### PR TITLE
feat: schedule event and task reminders

### DIFF
--- a/backend/lined/docs/api-proposals/event-reminder-scheduler.md
+++ b/backend/lined/docs/api-proposals/event-reminder-scheduler.md
@@ -1,7 +1,7 @@
 # API Proposal — Event Reminder Scheduler
 
 **Branch:** `feature/event-reminder-scheduler`
-**Status:** Proposed
+**Status:** Implemented
 **Motivation:** README MVP list includes "Notifications (basic) — reminders
 for events and tasks", and the notification preferences already expose an
 `eventRemindersEnabled` toggle ("Reminders 30 minutes before an event") —
@@ -24,11 +24,11 @@ client-facing surface:
      `reminder_emission` row) so restarts/multiple instances never
      double-send.
 2. **Task due reminders (same mechanism):** tasks with a `dueDate` arriving
-   today and status ≠ DONE get a `TASK_DUE` notification at a fixed morning
-   hour (e.g. 08:00 in the event's stored timezone; document the choice).
+   today and status ≠ DONE get a `TASK_DUE` notification at or after 08:00
+   UTC. The assignee receives it, or the creator when unassigned.
 3. **Optional per-event override (client-facing):** extend
    `EventCreateDto`/`EventUpdateDto` with `reminderMinutesBefore`
-   (nullable → default 30, `0`/null semantics documented) and return it in
+   (nullable → default 30, `0` disables, maximum seven days) and return it in
    `EventDto`.
 
 ## Why it matters

--- a/backend/lined/docs/api.md
+++ b/backend/lined/docs/api.md
@@ -377,6 +377,7 @@ Create an event.
   "startAt": "2025-11-20T17:00:00Z",
   "endAt": "2025-11-20T19:00:00Z",
   "timezone": "Europe/Kyiv",
+  "reminderMinutesBefore": 30,
   "lobbyId": 101,
   "notifyMembers": true
 }
@@ -387,6 +388,13 @@ Response: `200 OK` with `EventDto`.
 ### `PATCH /api/calendar/events/{id}`
 
 Partially update an event. Blank `location` clears the stored location.
+
+`reminderMinutesBefore` is optional on create: `null` or omission uses the
+30-minute default, `0` disables that event's reminder, and values through
+10,080 (seven days) are accepted. On PATCH, omission or `null` leaves the
+stored setting unchanged. Moving an already-reminded event or changing its
+non-null reminder lead time makes its new occurrence eligible for one new
+reminder.
 
 Send the current event version as `If-Match: "{version}"`; deletion requires the same header.
 
@@ -575,6 +583,20 @@ Inbox entries use this shape:
   "deliveries": []
 }
 ```
+
+### Scheduled reminders
+
+The server runs a reminder job every minute. A shared event emits an
+`EVENT_REMINDER` to the current lobby owner and members; a private event emits
+one only to its owner. Event reminders require both global
+`eventRemindersEnabled` and per-lobby `newEventsEnabled`.
+
+At or after `08:00 UTC`, every unfinished task due on the current UTC date is
+considered for one `TASK_DUE` notification. The assignee receives it when
+present; otherwise the creator does. Task due reminders require both global
+`eventRemindersEnabled` and per-lobby `taskUpdatesEnabled`. Event and task
+markers are claimed atomically, so repeated ticks and concurrent replicas do
+not duplicate an occurrence.
 
 ## Planned / Proposal-Only Endpoints
 

--- a/backend/lined/src/main/java/io/backend/lined/LinedBackendApplication.java
+++ b/backend/lined/src/main/java/io/backend/lined/LinedBackendApplication.java
@@ -1,18 +1,36 @@
 package io.backend.lined;
 
+import java.time.Clock;
 import java.time.ZoneId;
 import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class LinedBackendApplication {
 
   public static void main(String[] args) {
     TimeZone.setDefault(TimeZone.getTimeZone(ZoneId.of("UTC")));
     SpringApplication.run(LinedBackendApplication.class, args);
+  }
+
+  /**
+   * Provides the application clock used by time-sensitive services.
+   *
+   * <p>The clock is deliberately UTC so reminder processing is deterministic across Kubernetes
+   * replicas. For example, a task due reminder becomes eligible at {@code 08:00 UTC} regardless
+   * of the host machine's local timezone. Tests replace this bean with a fixed clock.</p>
+   *
+   * @return the production UTC clock
+   */
+  @Bean
+  public Clock clock() {
+    return Clock.systemUTC();
   }
 
 }

--- a/backend/lined/src/main/java/io/backend/lined/event/api/EventController.java
+++ b/backend/lined/src/main/java/io/backend/lined/event/api/EventController.java
@@ -50,6 +50,7 @@ public class EventController {
                       "startAt":"2025-11-20T17:00:00Z",
                       "endAt":"2025-11-20T19:00:00Z",
                       "timezone":"Europe/Kyiv",
+                      "reminderMinutesBefore":30,
                       "lobbyId":101,
                       "notifyMembers":true
                     }
@@ -61,7 +62,8 @@ public class EventController {
 
   @Operation(summary = "Update event",
       description = "Partial update: title/location/shared/startAt/endAt/timezone. "
-          + "Blank location clears it; omitted location is unchanged.")
+          + "Blank location clears it; omitted location is unchanged. "
+          + "reminderMinutesBefore accepts 0 through 10080; 0 disables reminders.")
   @PatchMapping("/events/{id}")
   public ResponseEntity<EventDto> update(
       @Parameter(example = "9001") @PathVariable Long id,

--- a/backend/lined/src/main/java/io/backend/lined/event/api/EventCreateDto.java
+++ b/backend/lined/src/main/java/io/backend/lined/event/api/EventCreateDto.java
@@ -2,10 +2,18 @@ package io.backend.lined.event.api;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.OffsetDateTime;
 
+/**
+ * Client payload for creating an event with an optional reminder lead time.
+ *
+ * <p>For example, {@code reminderMinutesBefore: 45} requests an alert 45 minutes before an
+ * event, omission uses 30 minutes, and {@code 0} records an explicit opt-out.</p>
+ */
 @Schema(name = "EventCreateDto")
 public record EventCreateDto(
     @Schema(example = "Dinner together") @NotBlank String title,
@@ -14,12 +22,15 @@ public record EventCreateDto(
     @Schema(example = "2025-11-20T17:00:00Z") @NotNull OffsetDateTime startAt,
     @Schema(example = "2025-11-20T19:00:00Z") @NotNull OffsetDateTime endAt,
     @Schema(example = "Europe/Kyiv") @NotBlank String timezone,
+    @Schema(example = "30", description = "Null uses the 30-minute default; 0 disables reminders")
+    @Min(0) @Max(10080) Integer reminderMinutesBefore,
     @Schema(example = "101") @NotNull Long lobbyId,
     @Schema(example = "true") boolean notifyMembers
 ) {
 
   public EventCreateDto(String title, String location, boolean shared, OffsetDateTime startAt,
                         OffsetDateTime endAt, String timezone, Long lobbyId) {
-    this(title, location, shared, startAt, endAt, timezone, lobbyId, false);
+    this(title, location, shared, startAt, endAt, timezone, null, lobbyId, false);
   }
+
 }

--- a/backend/lined/src/main/java/io/backend/lined/event/api/EventDto.java
+++ b/backend/lined/src/main/java/io/backend/lined/event/api/EventDto.java
@@ -3,6 +3,12 @@ package io.backend.lined.event.api;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.OffsetDateTime;
 
+/**
+ * Event response payload exposing the stored reminder override.
+ *
+ * <p>For example, a {@code null reminderMinutesBefore} tells a client that the server uses the
+ * 30-minute default, while {@code 0} means no reminder will be scheduled for that event.</p>
+ */
 @Schema(name = "EventDto")
 public record EventDto(
     @Schema(example = "9001") Long id,
@@ -13,8 +19,11 @@ public record EventDto(
     @Schema(example = "2025-11-20T17:00:00Z") OffsetDateTime startAt,
     @Schema(example = "2025-11-20T19:00:00Z") OffsetDateTime endAt,
     @Schema(example = "Europe/Kyiv") String timezone,
+    @Schema(example = "30", description = "Null means the 30-minute default")
+    Integer reminderMinutesBefore,
     @Schema(example = "101") Long lobbyId,
     @Schema(example = "42") Long ownerId,
     @Schema(example = "2025-11-13T10:00:00Z") OffsetDateTime createdAt
 ) {
+
 }

--- a/backend/lined/src/main/java/io/backend/lined/event/api/EventUpdateDto.java
+++ b/backend/lined/src/main/java/io/backend/lined/event/api/EventUpdateDto.java
@@ -1,9 +1,17 @@
 package io.backend.lined.event.api;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 import java.time.OffsetDateTime;
 
+/**
+ * Partial event update payload, including an optional replacement reminder lead time.
+ *
+ * <p>For example, sending {@code reminderMinutesBefore: 60} updates a prior 30-minute policy;
+ * null keeps the existing setting because this is a PATCH payload.</p>
+ */
 @Schema(name = "EventUpdateDto")
 public record EventUpdateDto(
     @Schema(example = "Lunch together") String title,
@@ -11,6 +19,19 @@ public record EventUpdateDto(
     @Schema(example = "false") Boolean shared,
     @Schema(example = "2025-11-20T18:00:00Z") OffsetDateTime startAt,
     @Schema(example = "2025-11-20T20:00:00Z") OffsetDateTime endAt,
-    @Schema(example = "Europe/Kyiv") String timezone
+    @Schema(example = "Europe/Kyiv") String timezone,
+    @Schema(example = "45", description = "0 disables; omitted or null leaves the current value")
+    @Min(0) @Max(10080) Integer reminderMinutesBefore
 ) {
+
+  /**
+   * Retains the previous partial-update call shape.
+   *
+   * <p>For example, {@code new EventUpdateDto(null, "Park", null, null, null, null)} updates
+   * only a location and leaves the reminder configuration unchanged.</p>
+   */
+  public EventUpdateDto(String title, String location, Boolean shared, OffsetDateTime startAt,
+                        OffsetDateTime endAt, String timezone) {
+    this(title, location, shared, startAt, endAt, timezone, null);
+  }
 }

--- a/backend/lined/src/main/java/io/backend/lined/event/domain/EventEntity.java
+++ b/backend/lined/src/main/java/io/backend/lined/event/domain/EventEntity.java
@@ -23,6 +23,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * Persisted calendar event and its scheduler-owned reminder state.
+ *
+ * <p>For example, a dinner can retain {@code reminderMinutesBefore = 45} and a non-null
+ * {@code reminderSentAt} after its notification is emitted; rescheduling it clears the marker so
+ * the revised occurrence becomes eligible again.</p>
+ */
 @Getter
 @Setter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
@@ -61,6 +68,12 @@ public class EventEntity {
 
   @Column(nullable = false, length = 64)
   private String timezone;
+
+  @Column
+  private Integer reminderMinutesBefore;
+
+  @Column
+  private OffsetDateTime reminderSentAt;
 
   @Column(name = "ics_uid", length = 255)
   private String icsUid;

--- a/backend/lined/src/main/java/io/backend/lined/event/domain/EventRepository.java
+++ b/backend/lined/src/main/java/io/backend/lined/event/domain/EventRepository.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -96,5 +98,50 @@ public interface EventRepository extends JpaRepository<EventEntity, Long>,
    */
   Optional<EventEntity> findByOwner_IdAndLobby_IdAndIcsUid(Long ownerId, Long lobbyId,
                                                             String icsUid);
+
+  /**
+   * Finds unsent events in the bounded horizon used by the minute scheduler.
+   *
+   * <p>For example, a dinner in three days with a four-day override is returned, while an event
+   * with {@code reminderMinutesBefore = 0} is filtered by the service without creating an inbox
+   * entry.</p>
+   *
+   * @param now current UTC time
+   * @param horizon latest candidate start time, at most seven days away
+   * @return candidates with recipient associations initialized
+   */
+  @EntityGraph(attributePaths = {"lobby", "lobby.owner", "lobby.members", "owner"})
+  @Query("""
+      SELECT e FROM EventEntity e
+      WHERE e.reminderSentAt IS NULL
+        AND e.startAt >= :now
+        AND e.startAt <= :horizon
+      ORDER BY e.startAt ASC
+      """)
+  List<EventEntity> findReminderCandidates(@Param("now") OffsetDateTime now,
+                                            @Param("horizon") OffsetDateTime horizon);
+
+  /**
+   * Atomically claims a reminder occurrence for a single scheduler replica.
+   *
+   * <p>For example, two pods may read the same event, but only the row matching its original
+   * version and an empty marker receives a {@code reminderSentAt}; the loser returns zero and
+   * emits nothing.</p>
+   *
+   * @param eventId event identifier
+   * @param expectedVersion version observed while selecting the candidate
+   * @param sentAt marker timestamp
+   * @return {@code 1} for the winning replica, otherwise {@code 0}
+   */
+  @Modifying(flushAutomatically = true, clearAutomatically = true)
+  @Query("""
+      UPDATE EventEntity e
+      SET e.reminderSentAt = :sentAt, e.version = e.version + 1
+      WHERE e.id = :eventId
+        AND e.version = :expectedVersion
+        AND e.reminderSentAt IS NULL
+      """)
+  int claimReminder(@Param("eventId") Long eventId, @Param("expectedVersion") long expectedVersion,
+                    @Param("sentAt") OffsetDateTime sentAt);
 
 }

--- a/backend/lined/src/main/java/io/backend/lined/event/service/EventServiceImpl.java
+++ b/backend/lined/src/main/java/io/backend/lined/event/service/EventServiceImpl.java
@@ -45,6 +45,12 @@ public class EventServiceImpl implements EventService {
   private final FreeSlotCalculator freeSlotCalculator;
   private final NotificationService notificationService;
 
+  /**
+   * Creates an event with its optional reminder policy.
+   *
+   * <p>For example, an omitted {@code reminderMinutesBefore} stores the default policy, while a
+   * value of {@code 0} stores an explicit opt-out and therefore produces no scheduled reminder.</p>
+   */
   @Override
   public EventDto create(EventCreateDto dto, Long currentUserId) {
     var owner = mustUser(currentUserId);
@@ -60,6 +66,7 @@ public class EventServiceImpl implements EventService {
         .startAt(window.start())
         .endAt(window.end())
         .timezone(dto.timezone())
+        .reminderMinutesBefore(dto.reminderMinutesBefore())
         .lobby(lobby)
         .owner(owner)
         .build();
@@ -74,6 +81,12 @@ public class EventServiceImpl implements EventService {
     return mapper.toDto(saved);
   }
 
+  /**
+   * Partially updates an event and re-enables a reminder when its occurrence changes.
+   *
+   * <p>For example, moving a dinner from 18:00 to 20:00 after its first reminder clears the
+   * marker, so the newly scheduled occurrence can emit exactly one fresh reminder.</p>
+   */
   @Override
   public EventDto update(Long id, EventUpdateDto dto, Long currentUserId, long expectedVersion) {
     var e = mustEvent(id);
@@ -84,6 +97,11 @@ public class EventServiceImpl implements EventService {
         dto.startAt() == null ? e.getStartAt() : dto.startAt(),
         dto.endAt() == null ? e.getEndAt() : dto.endAt());
 
+    boolean reminderOccurrenceChanged = (dto.startAt() != null
+        && !dto.startAt().equals(e.getStartAt()))
+        || (dto.reminderMinutesBefore() != null
+        && effectiveReminderMinutes(dto.reminderMinutesBefore())
+        != effectiveReminderMinutes(e.getReminderMinutesBefore()));
     if (dto.title() != null && !dto.title().isBlank()) {
       e.setTitle(dto.title());
     }
@@ -97,6 +115,12 @@ public class EventServiceImpl implements EventService {
     e.setEndAt(window.end());
     if (dto.timezone() != null && !dto.timezone().isBlank()) {
       e.setTimezone(dto.timezone());
+    }
+    if (dto.reminderMinutesBefore() != null) {
+      e.setReminderMinutesBefore(dto.reminderMinutesBefore());
+    }
+    if (reminderOccurrenceChanged) {
+      e.setReminderSentAt(null);
     }
 
     if (expectedVersion >= 0) {
@@ -192,6 +216,10 @@ public class EventServiceImpl implements EventService {
       return null;
     }
     return location.trim();
+  }
+
+  private int effectiveReminderMinutes(Integer reminderMinutesBefore) {
+    return reminderMinutesBefore == null ? 30 : reminderMinutesBefore;
   }
 
   private CalendarTimeWindow queryWindow(OffsetDateTime start, OffsetDateTime end) {

--- a/backend/lined/src/main/java/io/backend/lined/lobby/domain/LobbyRepository.java
+++ b/backend/lined/src/main/java/io/backend/lined/lobby/domain/LobbyRepository.java
@@ -1,6 +1,8 @@
 package io.backend.lined.lobby.domain;
 
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -8,6 +10,18 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LobbyRepository extends JpaRepository<LobbyEntity, Long> {
+
+  /**
+   * Reloads a lobby with the membership snapshot used by a notification recipient decision.
+   *
+   * <p>For example, a reminder worker calls this after claiming an event so a member removed
+   * between candidate selection and notification fan-out is not included in that fan-out.</p>
+   *
+   * @param lobbyId lobby identifier
+   * @return the current lobby and its owner/member relationships when it still exists
+   */
+  @EntityGraph(attributePaths = {"owner", "members"})
+  Optional<LobbyEntity> findWithMembersById(Long lobbyId);
 
   List<LobbyEntity> findAllByOwner_Id(Long ownerId);
 

--- a/backend/lined/src/main/java/io/backend/lined/notification/domain/NotificationType.java
+++ b/backend/lined/src/main/java/io/backend/lined/notification/domain/NotificationType.java
@@ -2,5 +2,7 @@ package io.backend.lined.notification.domain;
 
 public enum NotificationType {
   TASK_ASSIGNED,
-  SHARED_EVENT_CREATED
+  SHARED_EVENT_CREATED,
+  EVENT_REMINDER,
+  TASK_DUE
 }

--- a/backend/lined/src/main/java/io/backend/lined/notification/service/NotificationService.java
+++ b/backend/lined/src/main/java/io/backend/lined/notification/service/NotificationService.java
@@ -1,6 +1,7 @@
 package io.backend.lined.notification.service;
 
 import io.backend.lined.lobby.domain.LobbyEntity;
+import io.backend.lined.event.domain.EventEntity;
 import io.backend.lined.notification.api.LobbyNotificationPreferencesDto;
 import io.backend.lined.notification.api.LobbyNotificationPreferencesUpdateDto;
 import io.backend.lined.notification.api.NotificationDto;
@@ -43,4 +44,27 @@ public interface NotificationService {
 
   void notifySharedEventCreated(UserEntity recipient, UserEntity actor, Long eventId,
                                 LobbyEntity lobby, String eventTitle);
+
+  /**
+   * Emits one preference-gated reminder for an event recipient.
+   *
+   * <p>For example, a current member receives an {@code EVENT_REMINDER} inbox entry for a shared
+   * dinner, while a member with either reminders or new-event notifications disabled receives no
+   * entry.</p>
+   *
+   * @param recipient current owner or member receiving the reminder
+   * @param event event beginning within its effective reminder window
+   */
+  void notifyEventReminder(UserEntity recipient, EventEntity event);
+
+  /**
+   * Emits one preference-gated reminder for a task due today.
+   *
+   * <p>For example, an assigned grocery task creates a {@code TASK_DUE} inbox entry at 08:00 UTC
+   * when task updates and global reminders are enabled.</p>
+   *
+   * @param recipient task assignee, or creator when the task has no assignee
+   * @param task non-completed task whose due date is today
+   */
+  void notifyTaskDue(UserEntity recipient, TaskEntity task);
 }

--- a/backend/lined/src/main/java/io/backend/lined/notification/service/NotificationServiceImpl.java
+++ b/backend/lined/src/main/java/io/backend/lined/notification/service/NotificationServiceImpl.java
@@ -4,6 +4,7 @@ import io.backend.lined.common.EntityFinder;
 import io.backend.lined.common.VersionPrecondition;
 import io.backend.lined.common.exception.ConflictException;
 import io.backend.lined.common.exception.NotFoundException;
+import io.backend.lined.event.domain.EventEntity;
 import io.backend.lined.lobby.domain.LobbyEntity;
 import io.backend.lined.lobby.domain.LobbyRepository;
 import io.backend.lined.lobby.service.LobbyAccessPolicy;
@@ -137,6 +138,26 @@ public class NotificationServiceImpl implements NotificationService {
         null, eventId);
   }
 
+  @Override
+  public void notifyEventReminder(UserEntity recipient, EventEntity event) {
+    if (!isLobbyMember(event.getLobby(), recipient.getId())
+        || !allowsEventReminder(recipient, event.getLobby())) {
+      return;
+    }
+    saveNotification(recipient, event.getLobby(), NotificationType.EVENT_REMINDER,
+        "Event reminder", "%s starts soon".formatted(event.getTitle()), null, event.getId());
+  }
+
+  @Override
+  public void notifyTaskDue(UserEntity recipient, TaskEntity task) {
+    if (!isLobbyMember(task.getLobby(), recipient.getId())
+        || !allowsTaskDue(recipient, task.getLobby())) {
+      return;
+    }
+    saveNotification(recipient, task.getLobby(), NotificationType.TASK_DUE,
+        "Task due today", "%s is due today".formatted(task.getTitle()), task.getId(), null);
+  }
+
   private void saveNotification(UserEntity recipient, LobbyEntity lobby, NotificationType type,
                                 String title, String message, Long taskId, Long eventId) {
     var notification = NotificationEntity.builder()
@@ -180,6 +201,18 @@ public class NotificationServiceImpl implements NotificationService {
     var global = globalPreferences(user.getId());
     var local = lobbyPreferences(user.getId(), lobby);
     return global.isSharedEventsEnabled() && local.isNewEventsEnabled();
+  }
+
+  private boolean allowsEventReminder(UserEntity user, LobbyEntity lobby) {
+    var global = globalPreferences(user.getId());
+    var local = lobbyPreferences(user.getId(), lobby);
+    return global.isEventRemindersEnabled() && local.isNewEventsEnabled();
+  }
+
+  private boolean allowsTaskDue(UserEntity user, LobbyEntity lobby) {
+    var global = globalPreferences(user.getId());
+    var local = lobbyPreferences(user.getId(), lobby);
+    return global.isEventRemindersEnabled() && local.isTaskUpdatesEnabled();
   }
 
   private UserNotificationPreferenceEntity globalPreferences(Long userId) {

--- a/backend/lined/src/main/java/io/backend/lined/notification/service/ReminderScheduler.java
+++ b/backend/lined/src/main/java/io/backend/lined/notification/service/ReminderScheduler.java
@@ -1,0 +1,30 @@
+package io.backend.lined.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Triggers reminder processing once per minute.
+ *
+ * <p>For example, a 17:30 scheduler invocation makes a 17:55 event with the default lead time
+ * eligible, while the service's atomic claim prevents another pod's same-minute invocation from
+ * duplicating the inbox reminder.</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class ReminderScheduler {
+
+  private final ReminderService reminderService;
+
+  /**
+   * Delegates one scheduler tick to transactional reminder processing.
+   *
+   * <p>The cron expression has second precision and therefore runs at {@code :00} of every minute.
+   * It contains no notification logic so tests can invoke the service directly with a fixed clock.</p>
+   */
+  @Scheduled(cron = "0 * * * * *")
+  public void emitDueReminders() {
+    reminderService.processDueReminders();
+  }
+}

--- a/backend/lined/src/main/java/io/backend/lined/notification/service/ReminderService.java
+++ b/backend/lined/src/main/java/io/backend/lined/notification/service/ReminderService.java
@@ -1,0 +1,20 @@
+package io.backend.lined.notification.service;
+
+/**
+ * Processes due event and task reminder occurrences.
+ *
+ * <p>The scheduler calls this boundary once per minute. For example, at {@code 08:00 UTC} it
+ * claims today's unfinished grocery task before sending one {@code TASK_DUE} inbox entry, and it
+ * claims an event beginning within its configured lead time before sending {@code EVENT_REMINDER}
+ * entries.</p>
+ */
+public interface ReminderService {
+
+  /**
+   * Finds, atomically claims, and emits all reminder occurrences eligible at the current clock.
+   *
+   * <p>Repeated calls are safe: a claimed event or due-date task is skipped on later runs, even
+   * when another application replica runs at the same minute.</p>
+   */
+  void processDueReminders();
+}

--- a/backend/lined/src/main/java/io/backend/lined/notification/service/ReminderServiceImpl.java
+++ b/backend/lined/src/main/java/io/backend/lined/notification/service/ReminderServiceImpl.java
@@ -1,0 +1,110 @@
+package io.backend.lined.notification.service;
+
+import io.backend.lined.event.domain.EventEntity;
+import io.backend.lined.event.domain.EventRepository;
+import io.backend.lined.lobby.domain.LobbyRepository;
+import io.backend.lined.task.domain.TaskEntity;
+import io.backend.lined.task.domain.TaskRepository;
+import io.backend.lined.task.domain.TaskStatus;
+import io.backend.lined.user.domain.UserEntity;
+import jakarta.transaction.Transactional;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Transactional, replica-safe implementation of reminder generation.
+ *
+ * <p>Each candidate is claimed through a version-aware conditional update before notifications
+ * are saved in the same transaction. For example, when two Kubernetes pods see the same dinner,
+ * exactly one claim succeeds and only that pod fans out the reminder to current lobby members.</p>
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReminderServiceImpl implements ReminderService {
+
+  static final int DEFAULT_EVENT_REMINDER_MINUTES = 30;
+  static final int MAX_EVENT_REMINDER_MINUTES = 10_080;
+  private static final int TASK_REMINDER_HOUR_UTC = 8;
+
+  private final Clock clock;
+  private final EventRepository eventRepo;
+  private final TaskRepository taskRepo;
+  private final LobbyRepository lobbyRepo;
+  private final NotificationService notificationService;
+
+  /**
+   * Processes all reminder candidates using the injected UTC clock.
+   *
+   * <p>For example, at {@code 08:05 UTC} after a short outage, due tasks for that date are still
+   * processed. Before 08:00 UTC only event reminders run; this prevents a task-due alert from
+   * arriving during the night.</p>
+   */
+  @Override
+  public void processDueReminders() {
+    OffsetDateTime now = OffsetDateTime.now(clock).withOffsetSameInstant(ZoneOffset.UTC);
+    processEventReminders(now);
+    if (now.getHour() >= TASK_REMINDER_HOUR_UTC) {
+      processTaskDueReminders(now.toLocalDate());
+    }
+  }
+
+  private void processEventReminders(OffsetDateTime now) {
+    eventRepo.findReminderCandidates(now, now.plusMinutes(MAX_EVENT_REMINDER_MINUTES)).stream()
+        .filter(event -> isWithinReminderWindow(event, now))
+        .forEach(event -> claimAndNotifyEvent(event, now));
+  }
+
+  private boolean isWithinReminderWindow(EventEntity event, OffsetDateTime now) {
+    int minutes = effectiveReminderMinutes(event);
+    return minutes > 0 && !event.getStartAt().isAfter(now.plusMinutes(minutes));
+  }
+
+  private int effectiveReminderMinutes(EventEntity event) {
+    return event.getReminderMinutesBefore() == null ? DEFAULT_EVENT_REMINDER_MINUTES
+        : event.getReminderMinutesBefore();
+  }
+
+  private void claimAndNotifyEvent(EventEntity event, OffsetDateTime now) {
+    if (eventRepo.claimReminder(event.getId(), event.getVersion(), now) == 1) {
+      lobbyRepo.findWithMembersById(event.getLobby().getId()).ifPresent(lobby -> {
+        event.setLobby(lobby);
+        reminderRecipients(event).forEach(recipient -> notificationService.notifyEventReminder(
+            recipient, event));
+      });
+    }
+  }
+
+  private Set<UserEntity> reminderRecipients(EventEntity event) {
+    Set<UserEntity> recipients = new LinkedHashSet<>();
+    if (event.isShared()) {
+      recipients.add(event.getLobby().getOwner());
+      recipients.addAll(event.getLobby().getMembers());
+    } else {
+      recipients.add(event.getOwner());
+    }
+    return recipients;
+  }
+
+  private void processTaskDueReminders(LocalDate today) {
+    taskRepo.findDueReminderCandidates(today).stream()
+        .filter(task -> task.getDueDate().equals(today) && task.getStatus() != TaskStatus.DONE)
+        .forEach(task -> claimAndNotifyTask(task, today));
+  }
+
+  private void claimAndNotifyTask(TaskEntity task, LocalDate today) {
+    if (taskRepo.claimDueReminder(task.getId(), task.getVersion(), today) == 1) {
+      lobbyRepo.findWithMembersById(task.getLobby().getId()).ifPresent(lobby -> {
+        task.setLobby(lobby);
+        var recipient = task.getAssignee() == null ? task.getCreator() : task.getAssignee();
+        notificationService.notifyTaskDue(recipient, task);
+      });
+    }
+  }
+}

--- a/backend/lined/src/main/java/io/backend/lined/task/domain/TaskEntity.java
+++ b/backend/lined/src/main/java/io/backend/lined/task/domain/TaskEntity.java
@@ -24,6 +24,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * Persisted lobby task, including the date for which its due reminder was processed.
+ *
+ * <p>For example, after a task due on 2026-07-25 receives its morning reminder,
+ * {@code dueReminderSentForDate} is 2026-07-25; moving it to the next day naturally permits a
+ * new occurrence without clearing historical state.</p>
+ */
 @Getter
 @Setter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
@@ -70,6 +77,8 @@ public class TaskEntity {
   private UserEntity assignee;
 
   private LocalDate dueDate;
+
+  private LocalDate dueReminderSentForDate;
 
   @Column(nullable = false)
   private OffsetDateTime createdAt;

--- a/backend/lined/src/main/java/io/backend/lined/task/domain/TaskRepository.java
+++ b/backend/lined/src/main/java/io/backend/lined/task/domain/TaskRepository.java
@@ -1,6 +1,8 @@
 package io.backend.lined.task.domain;
 
 import java.util.List;
+import java.time.LocalDate;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -15,4 +17,46 @@ public interface TaskRepository extends JpaRepository<TaskEntity, Long>,
   @EntityGraph(attributePaths = {"lobby", "creator", "assignee"})
   @Query("SELECT t FROM TaskEntity t JOIN t.lobby l JOIN l.members m WHERE m.id = :userId")
   List<TaskEntity> findAllByLobbyMemberId(@Param("userId") Long userId);
+
+  /**
+   * Finds unfinished tasks due on the supplied UTC calendar date that have not yet been reminded.
+   *
+   * <p>For example, a {@code TODO} task due today is included even if it was rescheduled from a
+   * previously reminded date; a {@code DONE} task is never included.</p>
+   *
+   * @param today current UTC date after the 08:00 reminder cutoff
+   * @return due-task candidates with their recipient and lobby associations initialized
+   */
+  @EntityGraph(attributePaths = {"lobby", "lobby.owner", "lobby.members", "creator", "assignee"})
+  @Query("""
+      SELECT t FROM TaskEntity t
+      WHERE t.dueDate = :today
+        AND t.status <> io.backend.lined.task.domain.TaskStatus.DONE
+        AND (t.dueReminderSentForDate IS NULL OR t.dueReminderSentForDate <> :today)
+      """)
+  List<TaskEntity> findDueReminderCandidates(@Param("today") LocalDate today);
+
+  /**
+   * Atomically claims a task's due-date reminder for one scheduler replica.
+   *
+   * <p>For example, after one pod marks task {@code 55} for {@code 2026-07-25}, another pod's
+   * same-date claim returns zero and therefore cannot create a duplicate inbox entry.</p>
+   *
+   * @param taskId task identifier
+   * @param expectedVersion version observed while selecting the candidate
+   * @param today due date being marked as processed
+   * @return {@code 1} for the winning replica, otherwise {@code 0}
+   */
+  @Modifying(flushAutomatically = true, clearAutomatically = true)
+  @Query("""
+      UPDATE TaskEntity t
+      SET t.dueReminderSentForDate = :today, t.version = t.version + 1
+      WHERE t.id = :taskId
+        AND t.version = :expectedVersion
+        AND t.dueDate = :today
+        AND t.status <> io.backend.lined.task.domain.TaskStatus.DONE
+        AND (t.dueReminderSentForDate IS NULL OR t.dueReminderSentForDate <> :today)
+      """)
+  int claimDueReminder(@Param("taskId") Long taskId, @Param("expectedVersion") long expectedVersion,
+                       @Param("today") LocalDate today);
 }

--- a/backend/lined/src/main/resources/database/schema.sql
+++ b/backend/lined/src/main/resources/database/schema.sql
@@ -111,6 +111,10 @@ CREATE TABLE IF NOT EXISTS events
 );
 
 ALTER TABLE events ADD COLUMN IF NOT EXISTS ics_uid VARCHAR(255);
+ALTER TABLE events ADD COLUMN IF NOT EXISTS reminder_minutes_before INTEGER;
+ALTER TABLE events ADD COLUMN IF NOT EXISTS reminder_sent_at TIMESTAMPTZ;
+
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS due_reminder_sent_for_date DATE;
 
 CREATE INDEX IF NOT EXISTS idx_events_lobby ON events (lobby_id);
 CREATE INDEX IF NOT EXISTS idx_events_time ON events (lobby_id, start_at, end_at);

--- a/backend/lined/src/test/java/io/backend/lined/event/api/EventControllerTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/event/api/EventControllerTest.java
@@ -56,7 +56,7 @@ class EventControllerTest {
     end = start.plusHours(1);
     sampleEvent = new EventDto(9001L, 0L, "Dinner together", "Whole Foods Market", true, start,
         end,
-        "Europe/Kyiv", 101L, 42L, OffsetDateTime.now());
+        "Europe/Kyiv", null, 101L, 42L, OffsetDateTime.now());
     createDto = new EventCreateDto("Dinner together", "Whole Foods Market", true, start, end,
         "Europe/Kyiv", 101L);
     updateDto = new EventUpdateDto("Late dinner", null, null, null, null, null);

--- a/backend/lined/src/test/java/io/backend/lined/event/service/EventConflictAnalyzerTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/event/service/EventConflictAnalyzerTest.java
@@ -137,6 +137,6 @@ class EventConflictAnalyzerTest {
 
   private EventDto dto(Long id) {
     return new EventDto(id, 0L, "Event " + id, null, true, base, base.plusHours(1),
-        "Europe/Kyiv", 101L, 1L, base);
+        "Europe/Kyiv", null, 101L, 1L, base);
   }
 }

--- a/backend/lined/src/test/java/io/backend/lined/event/service/EventServiceImplConflictTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/event/service/EventServiceImplConflictTest.java
@@ -95,11 +95,11 @@ class EventServiceImplConflictTest {
 
   private void setupDtos() {
     dtoA = new EventDto(1L, 0L, "Event A", null, true,
-        eventA.getStartAt(), eventA.getEndAt(), "Europe/Kyiv", 101L, 1L, now);
+        eventA.getStartAt(), eventA.getEndAt(), "Europe/Kyiv", null, 101L, 1L, now);
     dtoB = new EventDto(2L, 0L, "Event B", null, true,
-        eventB.getStartAt(), eventB.getEndAt(), "Europe/Kyiv", 101L, 2L, now);
+        eventB.getStartAt(), eventB.getEndAt(), "Europe/Kyiv", null, 101L, 2L, now);
     dtoC = new EventDto(3L, 0L, "Event C", null, true,
-        eventC.getStartAt(), eventC.getEndAt(), "Europe/Kyiv", 101L, 1L, now);
+        eventC.getStartAt(), eventC.getEndAt(), "Europe/Kyiv", null, 101L, 1L, now);
   }
 
   private void setupEvents() {

--- a/backend/lined/src/test/java/io/backend/lined/event/service/EventServiceImplTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/event/service/EventServiceImplTest.java
@@ -109,7 +109,7 @@ class EventServiceImplTest {
 
     eventDto = new EventDto(
         9001L, 0L, "Dinner together", "Whole Foods Market", true,
-        startAt, endAt, "Europe/Kyiv",
+        startAt, endAt, "Europe/Kyiv", null,
         101L, 1L, now
     );
   }
@@ -140,7 +140,7 @@ class EventServiceImplTest {
   @Test
   void create_notifiesOtherMembers_whenRequestedForSharedEvent() {
     EventCreateDto dto = new EventCreateDto(
-        "Dinner together", null, true, startAt, endAt, "Europe/Kyiv", 101L, true);
+        "Dinner together", null, true, startAt, endAt, "Europe/Kyiv", null, 101L, true);
 
     when(userRepo.findById(1L)).thenReturn(Optional.of(owner));
     when(lobbyRepo.findById(101L)).thenReturn(Optional.of(lobby));
@@ -516,5 +516,34 @@ class EventServiceImplTest {
     assertThatThrownBy(() -> eventService.list(101L, startAt, endAt, 99L))
         .isInstanceOf(ForbiddenException.class)
         .hasMessageContaining("not a member");
+  }
+
+  @Test
+  void update_resetsReminderMarkerWhenStartOrReminderLeadChanges() {
+    eventEntity.setReminderSentAt(now);
+    eventEntity.setReminderMinutesBefore(30);
+    EventUpdateDto dto = new EventUpdateDto(null, null, null, startAt.plusHours(1),
+        endAt.plusHours(1), null, 45);
+    when(repo.findById(9001L)).thenReturn(Optional.of(eventEntity));
+    when(mapper.toDto(eventEntity)).thenReturn(eventDto);
+
+    eventService.update(9001L, dto, 1L, -1L);
+
+    assertThat(eventEntity.getReminderSentAt()).isNull();
+    assertThat(eventEntity.getReminderMinutesBefore()).isEqualTo(45);
+  }
+
+  @Test
+  void update_doesNotResetReminderMarkerForExplicitDefaultLeadTime() {
+    eventEntity.setReminderSentAt(now);
+    eventEntity.setReminderMinutesBefore(null);
+    EventUpdateDto dto = new EventUpdateDto(null, null, null, null, null, null, 30);
+    when(repo.findById(9001L)).thenReturn(Optional.of(eventEntity));
+    when(mapper.toDto(eventEntity)).thenReturn(eventDto);
+
+    eventService.update(9001L, dto, 1L, -1L);
+
+    assertThat(eventEntity.getReminderSentAt()).isEqualTo(now);
+    assertThat(eventEntity.getReminderMinutesBefore()).isEqualTo(30);
   }
 }

--- a/backend/lined/src/test/java/io/backend/lined/notification/service/NotificationServiceImplTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/notification/service/NotificationServiceImplTest.java
@@ -11,6 +11,7 @@ import io.backend.lined.lobby.domain.LobbyRepository;
 import io.backend.lined.lobby.domain.LobbyTypes;
 import io.backend.lined.lobby.service.LobbyAccessPolicy;
 import io.backend.lined.lobby.service.LobbyWritePolicy;
+import io.backend.lined.event.domain.EventEntity;
 import io.backend.lined.notification.api.LobbyNotificationPreferencesDto;
 import io.backend.lined.notification.api.LobbyNotificationPreferencesUpdateDto;
 import io.backend.lined.notification.api.NotificationDto;
@@ -155,6 +156,56 @@ class NotificationServiceImplTest {
     assertThat(captor.getValue().getType()).isEqualTo(
         io.backend.lined.notification.domain.NotificationType.SHARED_EVENT_CREATED);
     assertThat(captor.getValue().getEventId()).isEqualTo(77L);
+  }
+
+  @Test
+  void notifyEventReminder_queuesNotificationWhenGlobalAndLobbyPreferencesAllow() {
+    allowSharedEventNotifications();
+    var event = EventEntity.builder().id(77L).title("Dinner").lobby(lobby).owner(actor).build();
+    ArgumentCaptor<NotificationEntity> captor = ArgumentCaptor.forClass(NotificationEntity.class);
+
+    notificationService.notifyEventReminder(recipient, event);
+
+    verify(notificationRepo).save(captor.capture());
+    assertThat(captor.getValue().getType()).isEqualTo(
+        io.backend.lined.notification.domain.NotificationType.EVENT_REMINDER);
+    assertThat(captor.getValue().getEventId()).isEqualTo(77L);
+  }
+
+  @Test
+  void notifyEventReminder_skipsWhenGlobalReminderPreferenceIsDisabled() {
+    var global = UserNotificationPreferenceEntity.builder().eventRemindersEnabled(false).build();
+    var event = EventEntity.builder().id(77L).title("Dinner").lobby(lobby).owner(actor).build();
+    when(userPreferenceRepo.findByUserId(recipient.getId())).thenReturn(Optional.of(global));
+
+    notificationService.notifyEventReminder(recipient, event);
+
+    verify(notificationRepo, never()).save(any());
+  }
+
+  @Test
+  void notifyTaskDue_usesTaskUpdateGate() {
+    var local = LobbyNotificationPreferenceEntity.builder().taskUpdatesEnabled(false).build();
+    when(userPreferenceRepo.findByUserId(recipient.getId())).thenReturn(Optional.empty());
+    when(lobbyPreferenceRepo.findByUserIdAndLobbyId(recipient.getId(), lobby.getId()))
+        .thenReturn(Optional.of(local));
+
+    notificationService.notifyTaskDue(recipient, task);
+
+    verify(notificationRepo, never()).save(any());
+  }
+
+  @Test
+  void notifyTaskDue_queuesDueNotificationWhenPreferencesAllow() {
+    allowTaskNotifications();
+    ArgumentCaptor<NotificationEntity> captor = ArgumentCaptor.forClass(NotificationEntity.class);
+
+    notificationService.notifyTaskDue(recipient, task);
+
+    verify(notificationRepo).save(captor.capture());
+    assertThat(captor.getValue().getType()).isEqualTo(
+        io.backend.lined.notification.domain.NotificationType.TASK_DUE);
+    assertThat(captor.getValue().getTaskId()).isEqualTo(55L);
   }
 
   @Test

--- a/backend/lined/src/test/java/io/backend/lined/notification/service/ReminderServiceImplTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/notification/service/ReminderServiceImplTest.java
@@ -1,0 +1,178 @@
+package io.backend.lined.notification.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.backend.lined.event.domain.EventEntity;
+import io.backend.lined.event.domain.EventRepository;
+import io.backend.lined.lobby.domain.LobbyEntity;
+import io.backend.lined.lobby.domain.LobbyRepository;
+import io.backend.lined.lobby.domain.LobbyTypes;
+import io.backend.lined.task.domain.TaskEntity;
+import io.backend.lined.task.domain.TaskRepository;
+import io.backend.lined.task.domain.TaskStatus;
+import io.backend.lined.user.domain.UserEntity;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Set;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReminderServiceImplTest {
+
+  private static final Instant NOW = Instant.parse("2026-07-25T08:00:00Z");
+
+  @Mock
+  private EventRepository eventRepo;
+  @Mock
+  private TaskRepository taskRepo;
+  @Mock
+  private LobbyRepository lobbyRepo;
+  @Mock
+  private NotificationService notificationService;
+
+  private ReminderService reminderService;
+  private UserEntity owner;
+  private UserEntity member;
+  private LobbyEntity lobby;
+
+  @BeforeEach
+  void setUp() {
+    reminderService = new ReminderServiceImpl(Clock.fixed(NOW, ZoneOffset.UTC), eventRepo,
+        taskRepo, lobbyRepo, notificationService);
+    owner = user(1L, "owner");
+    member = user(2L, "member");
+    lobby = LobbyEntity.builder().id(101L).name("Family").lobbyType(LobbyTypes.FAMILY)
+        .owner(owner).members(Set.of(owner, member)).build();
+    lenient().when(lobbyRepo.findWithMembersById(101L)).thenReturn(Optional.of(lobby));
+  }
+
+  @Test
+  void processDueReminders_notifiesEveryCurrentMemberForSharedEventAtWindowEdge() {
+    var event = event(true, OffsetDateTime.ofInstant(NOW.plusSeconds(1800), ZoneOffset.UTC), null);
+    when(eventRepo.findReminderCandidates(any(), any())).thenReturn(java.util.List.of(event));
+    when(eventRepo.claimReminder(eq(9001L), eq(0L), any())).thenReturn(1);
+    when(taskRepo.findDueReminderCandidates(LocalDate.of(2026, 7, 25))).thenReturn(java.util.List.of());
+
+    reminderService.processDueReminders();
+
+    verify(notificationService).notifyEventReminder(owner, event);
+    verify(notificationService).notifyEventReminder(member, event);
+    verify(eventRepo).claimReminder(eq(9001L), eq(0L), any());
+  }
+
+  @Test
+  void processDueReminders_usesMembershipReloadedAfterTheEventClaim() {
+    var event = event(true, OffsetDateTime.ofInstant(NOW.plusSeconds(60), ZoneOffset.UTC), null);
+    var currentLobby = LobbyEntity.builder().id(101L).name("Family").lobbyType(LobbyTypes.FAMILY)
+        .owner(owner).members(Set.of(owner)).build();
+    when(eventRepo.findReminderCandidates(any(), any())).thenReturn(java.util.List.of(event));
+    when(eventRepo.claimReminder(eq(9001L), eq(0L), any())).thenReturn(1);
+    when(lobbyRepo.findWithMembersById(101L)).thenReturn(Optional.of(currentLobby));
+    when(taskRepo.findDueReminderCandidates(any())).thenReturn(java.util.List.of());
+
+    reminderService.processDueReminders();
+
+    verify(notificationService).notifyEventReminder(owner, event);
+    verify(notificationService, never()).notifyEventReminder(member, event);
+  }
+
+  @Test
+  void processDueReminders_usesCustomLeadTimeAndSkipsDisabledEventReminder() {
+    var custom = event(false, OffsetDateTime.ofInstant(NOW.plusSeconds(2700), ZoneOffset.UTC), 60);
+    var disabled = event(false, OffsetDateTime.ofInstant(NOW.plusSeconds(60), ZoneOffset.UTC), 0);
+    disabled.setId(9002L);
+    when(eventRepo.findReminderCandidates(any(), any())).thenReturn(java.util.List.of(custom, disabled));
+    when(eventRepo.claimReminder(eq(9001L), eq(0L), any())).thenReturn(1);
+    when(taskRepo.findDueReminderCandidates(any())).thenReturn(java.util.List.of());
+
+    reminderService.processDueReminders();
+
+    verify(notificationService).notifyEventReminder(owner, custom);
+    verify(eventRepo, never()).claimReminder(eq(9002L), any(Long.class), any());
+  }
+
+  @Test
+  void processDueReminders_doesNotDuplicateWhenAnotherReplicaAlreadyClaimedEvent() {
+    var event = event(false, OffsetDateTime.ofInstant(NOW.plusSeconds(60), ZoneOffset.UTC), null);
+    when(eventRepo.findReminderCandidates(any(), any())).thenReturn(java.util.List.of(event));
+    when(eventRepo.claimReminder(eq(9001L), eq(0L), any())).thenReturn(1, 0);
+    when(taskRepo.findDueReminderCandidates(any())).thenReturn(java.util.List.of());
+
+    reminderService.processDueReminders();
+    reminderService.processDueReminders();
+
+    verify(notificationService, times(1)).notifyEventReminder(owner, event);
+  }
+
+  @Test
+  void processDueReminders_notifiesAssigneeForUnfinishedTaskAfterMorningCutoff() {
+    var task = task(member, TaskStatus.TODO);
+    when(eventRepo.findReminderCandidates(any(), any())).thenReturn(java.util.List.of());
+    when(taskRepo.findDueReminderCandidates(LocalDate.of(2026, 7, 25))).thenReturn(java.util.List.of(task));
+    when(taskRepo.claimDueReminder(55L, 0L, LocalDate.of(2026, 7, 25))).thenReturn(1);
+
+    reminderService.processDueReminders();
+
+    verify(notificationService).notifyTaskDue(member, task);
+  }
+
+  @Test
+  void processDueReminders_waitsForMorningCutoffBeforeScanningTasks() {
+    ReminderService beforeMorning = new ReminderServiceImpl(
+        Clock.fixed(Instant.parse("2026-07-25T07:59:00Z"), ZoneOffset.UTC), eventRepo, taskRepo,
+        lobbyRepo, notificationService);
+    when(eventRepo.findReminderCandidates(any(), any())).thenReturn(java.util.List.of());
+
+    beforeMorning.processDueReminders();
+
+    verifyNoInteractions(taskRepo);
+  }
+
+  @Test
+  void processDueReminders_usesCreatorForUnassignedTaskAndSkipsDoneTask() {
+    var unassigned = task(null, TaskStatus.TODO);
+    var done = task(member, TaskStatus.DONE);
+    done.setId(56L);
+    when(eventRepo.findReminderCandidates(any(), any())).thenReturn(java.util.List.of());
+    when(taskRepo.findDueReminderCandidates(any())).thenReturn(java.util.List.of(unassigned, done));
+    when(taskRepo.claimDueReminder(55L, 0L, LocalDate.of(2026, 7, 25))).thenReturn(1);
+
+    reminderService.processDueReminders();
+
+    verify(notificationService).notifyTaskDue(owner, unassigned);
+    verify(taskRepo, never()).claimDueReminder(eq(56L), any(Long.class), any());
+  }
+
+  private EventEntity event(boolean shared, OffsetDateTime startAt, Integer reminderMinutes) {
+    return EventEntity.builder().id(9001L).version(0L).title("Dinner").shared(shared)
+        .startAt(startAt).endAt(startAt.plusHours(1)).timezone("UTC")
+        .reminderMinutesBefore(reminderMinutes).owner(owner).lobby(lobby).build();
+  }
+
+  private TaskEntity task(UserEntity assignee, TaskStatus status) {
+    return TaskEntity.builder().id(55L).version(0L).title("Groceries").lobby(lobby)
+        .creator(owner).assignee(assignee).status(status).dueDate(LocalDate.of(2026, 7, 25)).build();
+  }
+
+  private UserEntity user(Long id, String username) {
+    UserEntity user = new UserEntity();
+    user.setId(id);
+    user.setUsername(username);
+    return user;
+  }
+}


### PR DESCRIPTION
## Summary

Implements `feature/event-reminder-scheduler`, completing the MVP inbox reminder flow for events and due tasks.

- Enables a UTC, once-per-minute Spring scheduler backed by an injectable `Clock`.
- Adds atomic, version-aware event and task reminder claims so concurrent replicas emit an occurrence once.
- Emits `EVENT_REMINDER` for shared-event owner/current members or a private-event owner, and `TASK_DUE` for the assignee or task creator.
- Applies the approved preference gates: global `eventRemindersEnabled`, plus `newEventsEnabled` for events and `taskUpdatesEnabled` for tasks.
- Adds the nullable `reminderMinutesBefore` event contract: default 30 minutes, `0` disables, maximum 10,080 minutes; rescheduling or a real lead-time change re-arms the next occurrence.
- Documents the API and marks the detailed proposal implemented.

## Data and API notes

- `events` gains `reminder_minutes_before` and `reminder_sent_at`.
- `tasks` gains `due_reminder_sent_for_date`, allowing a task rescheduled to another due date to receive one new due reminder.
- Event response/create/update DTOs now expose `reminderMinutesBefore`. On PATCH, omitted or null leaves the stored value unchanged.
- Task due reminders become eligible at or after `08:00 UTC` on the task's due date; completed tasks are excluded.

## How to use and test

1. Create a shared event 20 minutes ahead with `reminderMinutesBefore` omitted or set to `30`.
2. With `eventRemindersEnabled` and lobby `newEventsEnabled` enabled, wait for the minute scheduler tick and call `GET /api/notifications/mine` as each current member; each receives one `EVENT_REMINDER`.
3. Set `eventRemindersEnabled` or the relevant lobby gate to `false` before processing to confirm no inbox record is created.
4. Create a non-`DONE` task due today and run at or after `08:00 UTC`; the assignee, or creator if unassigned, receives one `TASK_DUE` notification when its gates are enabled.
5. Confirm repeat scheduler ticks and concurrent claim losers do not add duplicate entries; moving an already-reminded event or changing its effective lead time produces one reminder for the new occurrence.

Verification run locally:

```text
./gradlew test --rerun-tasks --no-daemon
./gradlew checkstyleMain
./gradlew spotbugsMain --no-daemon
./gradlew check jacocoTestReport --no-daemon
```

The full test suite produced 60 XML reports with zero failures, errors, and skips. Checkstyle and SpotBugs completed successfully. A focused reviewer pass found and verified fixes for default-lead idempotency and stale-membership fan-out.
