### PR TITLE
Add PostgreSQL HTTP API integration tests

### DIFF
--- a/backend/lined/.github/workflows/ci.yml
+++ b/backend/lined/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run static checks (Checkstyle + SpotBugs + Tests)
         run: ./gradlew check
 
+      - name: Run PostgreSQL API integration tests
+        run: ./gradlew integrationTest
+
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/backend/lined/build.gradle
+++ b/backend/lined/build.gradle
@@ -28,6 +28,18 @@ repositories {
     mavenCentral()
 }
 
+sourceSets {
+    integrationTest {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += output + compileClasspath
+    }
+}
+
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-tracing-bridge-otel'
@@ -60,10 +72,37 @@ dependencies {
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    integrationTestImplementation 'org.springframework.boot:spring-boot-starter-test'
+    integrationTestImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    integrationTestImplementation 'org.testcontainers:postgresql'
+    integrationTestRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+tasks.register('integrationTest', Test) {
+    description = 'Runs full backend HTTP API integration tests'
+    group = 'verification'
+
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    useJUnitPlatform()
+    shouldRunAfter tasks.named('test')
+    maxParallelForks = 1
+
+    testLogging {
+        events 'passed', 'skipped', 'failed'
+        exceptionFormat 'full'
+        showStandardStreams = false
+    }
+
+    reports {
+        junitXml.required = true
+        html.required = true
+    }
 }
 
 spotbugs {

--- a/backend/lined/docs/api.md
+++ b/backend/lined/docs/api.md
@@ -180,7 +180,8 @@ Response: `200 OK` with `List<LobbyDto>`.
 
 ### `GET /api/lobbies/{id}`
 
-Return one lobby by id.
+Return one lobby by id. The caller must be an owner or member and supplies the
+temporary MVP `X-User-Id` header.
 
 Response: `200 OK` with `LobbyDto`.
 

--- a/backend/lined/docs/testing.md
+++ b/backend/lined/docs/testing.md
@@ -74,7 +74,27 @@ is already readable.
 - Prefer real DTO records over mocks for request/response values.
 - Mock mappers unless the mapper itself is the subject of the test.
 
-## Integration Tests
+## HTTP API Integration Tests
+
+Full HTTP API integration tests live in `src/integrationTest/`. They start Spring Boot on a
+random port and connect it to a disposable PostgreSQL Testcontainer; ordinary unit-test runs do
+not start Docker.
+
+```bash
+docker info
+./gradlew integrationTest
+./gradlew test integrationTest
+```
+
+The integration profile uses `ddl-auto=create-drop` only for its disposable container database.
+Its reports are written to `build/test-results/integrationTest/` and
+`build/reports/tests/integrationTest/`. Before treating a run as PostgreSQL proof, inspect the
+XML reports and confirm zero failures, errors, and skips.
+
+Caller-scoped scenarios use the current MVP `X-User-Id` header. Login is verified as an API
+contract, but the application does not yet install a Bearer-token filter.
+
+## Other Integration Tests
 
 Use integration tests when validating:
 

--- a/backend/lined/src/integrationTest/java/io/backend/lined/integration/AbstractApiIntegrationTest.java
+++ b/backend/lined/src/integrationTest/java/io/backend/lined/integration/AbstractApiIntegrationTest.java
@@ -1,0 +1,101 @@
+package io.backend.lined.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.backend.lined.integration.support.DatabaseCleaner;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@ApiIntegrationTest
+public abstract class AbstractApiIntegrationTest {
+
+  @Autowired
+  protected TestRestTemplate restTemplate;
+  @Autowired
+  protected JdbcTemplate jdbcTemplate;
+  @Autowired
+  protected ObjectMapper objectMapper;
+  @Autowired
+  private DatabaseCleaner databaseCleaner;
+
+  @BeforeEach
+  void cleanDatabaseBeforeTest() {
+    databaseCleaner.clean();
+  }
+
+  protected JsonNode registerUser(String label) {
+    return request(HttpMethod.POST, "/api/users", Map.of(
+        "username", label,
+        "email", label + "@lined.test",
+        "password", "P@ssw0rd!"), null).getBody();
+  }
+
+  protected String uniqueLabel(String prefix) {
+    return prefix + "-" + UUID.randomUUID().toString().substring(0, 8);
+  }
+
+  protected JsonNode createLobby(long ownerId, String name) {
+    return request(HttpMethod.POST, "/api/lobbies", Map.of(
+        "name", name,
+        "lobbyType", "FAMILY"), ownerId).getBody();
+  }
+
+  protected JsonNode invite(long ownerId, long lobbyId, long inviteeId) {
+    return request(HttpMethod.POST,
+        "/api/lobbies/" + lobbyId + "/invites?userId=" + inviteeId, null, ownerId).getBody();
+  }
+
+  protected JsonNode createSharedEvent(long ownerId, long lobbyId, OffsetDateTime start,
+                                       OffsetDateTime end) {
+    return request(HttpMethod.POST, "/api/calendar/events", Map.of(
+        "title", "Dinner together",
+        "location", "Kitchen",
+        "shared", true,
+        "startAt", start.toString(),
+        "endAt", end.toString(),
+        "timezone", "Europe/Kyiv",
+        "lobbyId", lobbyId,
+        "notifyMembers", false), ownerId).getBody();
+  }
+
+  protected ResponseEntity<JsonNode> request(HttpMethod method, String path, Object body,
+                                              Long userId) {
+    return request(method, path, body, userId, null);
+  }
+
+  protected ResponseEntity<JsonNode> request(HttpMethod method, String path, Object body,
+                                              Long userId, String ifMatch) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    if (userId != null) {
+      headers.set("X-User-Id", String.valueOf(userId));
+    }
+    if (ifMatch != null) {
+      headers.setIfMatch(ifMatch);
+    }
+    return restTemplate.exchange(path, method, new HttpEntity<>(body, headers), JsonNode.class);
+  }
+
+  protected ResponseEntity<JsonNode> listEvents(long userId, long lobbyId, OffsetDateTime from,
+                                                  OffsetDateTime to) {
+    String path = UriComponentsBuilder.fromPath("/api/calendar/events")
+        .queryParam("lobbyId", lobbyId)
+        .queryParam("from", from)
+        .queryParam("to", to)
+        .build()
+        .encode()
+        .toUriString();
+    return request(HttpMethod.GET, path, null, userId);
+  }
+}

--- a/backend/lined/src/integrationTest/java/io/backend/lined/integration/ApiIntegrationTest.java
+++ b/backend/lined/src/integrationTest/java/io/backend/lined/integration/ApiIntegrationTest.java
@@ -1,0 +1,20 @@
+package io.backend.lined.integration;
+
+import io.backend.lined.integration.config.IntegrationTestContainersConfiguration;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@ActiveProfiles("integration-test")
+@Import(IntegrationTestContainersConfiguration.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public @interface ApiIntegrationTest {
+}

--- a/backend/lined/src/integrationTest/java/io/backend/lined/integration/auth/UserAuthenticationApiIT.java
+++ b/backend/lined/src/integrationTest/java/io/backend/lined/integration/auth/UserAuthenticationApiIT.java
@@ -1,0 +1,89 @@
+package io.backend.lined.integration.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.backend.lined.integration.AbstractApiIntegrationTest;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+
+class UserAuthenticationApiIT extends AbstractApiIntegrationTest {
+
+  @Test
+  void registersUserAndStoresOnlyEncodedPassword() {
+    String label = uniqueLabel("register");
+
+    var response = request(HttpMethod.POST, "/api/users", Map.of(
+        "username", label,
+        "email", label + "@lined.test",
+        "password", "P@ssw0rd!"), null);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().path("email").asText()).isEqualTo(label + "@lined.test");
+    assertThat(response.getBody().has("password")).isFalse();
+    assertThat(jdbcTemplate.queryForObject(
+        "select count(*) from users where lower(email) = lower(?)", Integer.class,
+        label + "@lined.test")).isEqualTo(1);
+    assertThat(jdbcTemplate.queryForObject("select password from users where username = ?", String.class,
+        label)).startsWith("$2");
+  }
+
+  @Test
+  void rejectsCaseInsensitiveDuplicateEmail() {
+    String label = uniqueLabel("duplicate");
+    registerUser(label);
+
+    var response = request(HttpMethod.POST, "/api/users", Map.of(
+        "username", label + "-other",
+        "email", (label + "@LINED.TEST").toUpperCase(),
+        "password", "P@ssw0rd!"), null);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(response.getBody().path("title").asText()).isEqualTo("Conflict");
+    assertThat(jdbcTemplate.queryForObject(
+        "select count(*) from users where lower(email) = lower(?)", Integer.class,
+        label + "@lined.test")).isEqualTo(1);
+  }
+
+  @Test
+  void loginReturnsTokenShapedResponseAndMvpIdentityReadsCurrentUser() {
+    String label = uniqueLabel("login");
+    var user = registerUser(label);
+
+    var login = request(HttpMethod.POST, "/api/auth/login", Map.of(
+        "email", label + "@lined.test",
+        "password", "P@ssw0rd!"), null);
+    var currentUser = request(HttpMethod.GET, "/api/users/me", null, user.path("id").asLong());
+
+    assertThat(login.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(login.getBody().path("accessToken").asText()).isNotBlank();
+    assertThat(login.getBody().path("tokenType").asText()).isEqualTo("Bearer");
+    assertThat(login.getBody().path("userId").asLong()).isEqualTo(user.path("id").asLong());
+    assertThat(currentUser.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(currentUser.getBody().path("id").asLong()).isEqualTo(user.path("id").asLong());
+  }
+
+  @Test
+  void rejectsInvalidPasswordWithoutReturningToken() {
+    String label = uniqueLabel("invalid-password");
+    registerUser(label);
+
+    var response = request(HttpMethod.POST, "/api/auth/login", Map.of(
+        "username", label,
+        "password", "incorrect-password"), null);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(response.getBody().has("accessToken")).isFalse();
+    assertThat(response.getBody().path("detail").asText())
+        .isEqualTo("Invalid email, username, or password");
+  }
+
+  @Test
+  void rejectsCallerScopedRequestWithoutMvpIdentityHeader() {
+    var response = request(HttpMethod.GET, "/api/users/me", null, null);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().path("detail").asText()).contains("X-User-Id");
+  }
+}

--- a/backend/lined/src/integrationTest/java/io/backend/lined/integration/config/IntegrationTestContainersConfiguration.java
+++ b/backend/lined/src/integrationTest/java/io/backend/lined/integration/config/IntegrationTestContainersConfiguration.java
@@ -1,0 +1,20 @@
+package io.backend.lined.integration.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class IntegrationTestContainersConfiguration {
+
+  @Bean
+  @ServiceConnection
+  PostgreSQLContainer<?> postgresContainer() {
+    return new PostgreSQLContainer<>(DockerImageName.parse("postgres:16-alpine"))
+        .withDatabaseName("lined_integration_test")
+        .withUsername("lined_test")
+        .withPassword("lined_test");
+  }
+}

--- a/backend/lined/src/integrationTest/java/io/backend/lined/integration/event/EventApiIT.java
+++ b/backend/lined/src/integrationTest/java/io/backend/lined/integration/event/EventApiIT.java
@@ -1,0 +1,97 @@
+package io.backend.lined.integration.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.backend.lined.integration.AbstractApiIntegrationTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+
+class EventApiIT extends AbstractApiIntegrationTest {
+
+  private static final OffsetDateTime EVENT_START = OffsetDateTime.parse("2026-08-10T18:00:00+03:00");
+  private static final OffsetDateTime EVENT_END = OffsetDateTime.parse("2026-08-10T20:00:00+03:00");
+
+  @Test
+  void createsSharedEventVisibleToBothLobbyMembers() {
+    var owner = registerUser(uniqueLabel("event-owner"));
+    var member = registerUser(uniqueLabel("event-member"));
+    long ownerId = owner.path("id").asLong();
+    long memberId = member.path("id").asLong();
+    var lobby = createLobby(ownerId, "Event Lobby");
+    var invite = invite(ownerId, lobby.path("id").asLong(), memberId);
+    request(HttpMethod.POST, "/api/lobby-invites/" + invite.path("id").asLong() + "/accept",
+        null, memberId);
+
+    var event = createSharedEvent(ownerId, lobby.path("id").asLong(), EVENT_START, EVENT_END);
+    var memberRead = request(HttpMethod.GET,
+        "/api/calendar/events/" + event.path("id").asLong(), null, memberId);
+    var memberList = listEvents(memberId, lobby.path("id").asLong(),
+        EVENT_START.minusHours(1).withOffsetSameInstant(ZoneOffset.UTC),
+        EVENT_END.plusHours(1).withOffsetSameInstant(ZoneOffset.UTC));
+
+    assertThat(memberRead.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(memberRead.getBody().path("title").asText()).isEqualTo("Dinner together");
+    assertThat(memberList.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(memberList.getBody()).hasSize(1);
+    assertThat(memberList.getBody().get(0).path("id").asLong()).isEqualTo(event.path("id").asLong());
+  }
+
+  @Test
+  void rejectsEventCreationByNonMemberWithoutPersistingEvent() {
+    var owner = registerUser(uniqueLabel("event-owner"));
+    var outsider = registerUser(uniqueLabel("event-outsider"));
+    var lobby = createLobby(owner.path("id").asLong(), "Protected Event Lobby");
+
+    var response = request(HttpMethod.POST, "/api/calendar/events", Map.of(
+        "title", "Unauthorized event",
+        "shared", true,
+        "startAt", EVENT_START.toString(),
+        "endAt", EVENT_END.toString(),
+        "timezone", "Europe/Kyiv",
+        "lobbyId", lobby.path("id").asLong(),
+        "notifyMembers", false), outsider.path("id").asLong());
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(jdbcTemplate.queryForObject("select count(*) from events", Integer.class)).isZero();
+  }
+
+  @Test
+  void rejectsEventWhoseEndDoesNotFollowStart() {
+    var owner = registerUser(uniqueLabel("invalid-event-owner"));
+    var lobby = createLobby(owner.path("id").asLong(), "Validation Lobby");
+
+    var response = request(HttpMethod.POST, "/api/calendar/events", Map.of(
+        "title", "Invalid interval",
+        "shared", true,
+        "startAt", EVENT_END.toString(),
+        "endAt", EVENT_START.toString(),
+        "timezone", "Europe/Kyiv",
+        "lobbyId", lobby.path("id").asLong(),
+        "notifyMembers", false), owner.path("id").asLong());
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().path("detail").asText()).contains("end");
+    assertThat(jdbcTemplate.queryForObject("select count(*) from events", Integer.class)).isZero();
+  }
+
+  @Test
+  void preservesEventInstantAcrossOffsetSerialization() {
+    var owner = registerUser(uniqueLabel("timezone-owner"));
+    long ownerId = owner.path("id").asLong();
+    var lobby = createLobby(ownerId, "Timezone Lobby");
+    var created = createSharedEvent(ownerId, lobby.path("id").asLong(), EVENT_START, EVENT_END);
+
+    var response = request(HttpMethod.GET,
+        "/api/calendar/events/" + created.path("id").asLong(), null, ownerId);
+    OffsetDateTime returnedStart = OffsetDateTime.parse(response.getBody().path("startAt").asText());
+    OffsetDateTime returnedEnd = OffsetDateTime.parse(response.getBody().path("endAt").asText());
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(returnedStart.toInstant()).isEqualTo(EVENT_START.toInstant());
+    assertThat(returnedEnd.toInstant()).isEqualTo(EVENT_END.toInstant());
+  }
+}

--- a/backend/lined/src/integrationTest/java/io/backend/lined/integration/infrastructure/ApplicationStartupIT.java
+++ b/backend/lined/src/integrationTest/java/io/backend/lined/integration/infrastructure/ApplicationStartupIT.java
@@ -1,0 +1,18 @@
+package io.backend.lined.integration.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.backend.lined.integration.AbstractApiIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class ApplicationStartupIT extends AbstractApiIntegrationTest {
+
+  @Test
+  void applicationAndPostgreSqlStartSuccessfully() {
+    var response = restTemplate.getForEntity("/actuator/health", String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(jdbcTemplate.queryForObject("select 1", Integer.class)).isEqualTo(1);
+  }
+}

--- a/backend/lined/src/integrationTest/java/io/backend/lined/integration/lobby/LobbyApiIT.java
+++ b/backend/lined/src/integrationTest/java/io/backend/lined/integration/lobby/LobbyApiIT.java
@@ -1,0 +1,84 @@
+package io.backend.lined.integration.lobby;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.backend.lined.integration.AbstractApiIntegrationTest;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+
+class LobbyApiIT extends AbstractApiIntegrationTest {
+
+  @Test
+  void createsLobbyWithOwnerAsItsOnlyInitialMember() {
+    var owner = registerUser(uniqueLabel("lobby-owner"));
+    long ownerId = owner.path("id").asLong();
+
+    var lobby = createLobby(ownerId, "Our Family");
+    var mine = request(HttpMethod.GET, "/api/lobbies/mine", null, ownerId);
+
+    assertThat(lobby.path("ownerId").asLong()).isEqualTo(ownerId);
+    assertThat(lobby.path("memberIds")).hasSize(1);
+    assertThat(lobby.path("memberIds").get(0).asLong()).isEqualTo(ownerId);
+    assertThat(mine.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(mine.getBody()).hasSize(1);
+    assertThat(mine.getBody().get(0).path("id").asLong()).isEqualTo(lobby.path("id").asLong());
+  }
+
+  @Test
+  void invitesAndAddsSecondUserToLobby() {
+    var owner = registerUser(uniqueLabel("invite-owner"));
+    var invitee = registerUser(uniqueLabel("invitee"));
+    long ownerId = owner.path("id").asLong();
+    long inviteeId = invitee.path("id").asLong();
+    var lobby = createLobby(ownerId, "Invite Lobby");
+
+    var invite = invite(ownerId, lobby.path("id").asLong(), inviteeId);
+    var accepted = request(HttpMethod.POST,
+        "/api/lobby-invites/" + invite.path("id").asLong() + "/accept", null, inviteeId);
+    var visibleLobby = request(HttpMethod.GET,
+        "/api/lobbies/" + lobby.path("id").asLong(), null, inviteeId);
+
+    assertThat(accepted.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(accepted.getBody().path("status").asText()).isEqualTo("ACCEPTED");
+    assertThat(visibleLobby.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(visibleLobby.getBody().path("memberIds")).hasSize(2);
+    assertThat(jdbcTemplate.queryForObject("select count(*) from lobby_members where lobby_id = ?",
+        Integer.class, lobby.path("id").asLong())).isEqualTo(2);
+  }
+
+  @Test
+  void rejectsLobbyDetailsForNonMemberWithoutReturningLobbyData() {
+    var owner = registerUser(uniqueLabel("hidden-owner"));
+    var outsider = registerUser(uniqueLabel("hidden-outsider"));
+    var lobby = createLobby(owner.path("id").asLong(), "Hidden Lobby");
+
+    var response = request(HttpMethod.GET, "/api/lobbies/" + lobby.path("id").asLong(), null,
+        outsider.path("id").asLong());
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().has("name")).isFalse();
+    assertThat(response.getBody().path("code").asText()).isEqualTo("common.forbidden");
+  }
+
+  @Test
+  void rejectsOwnerOnlyLobbyUpdateByMember() {
+    var owner = registerUser(uniqueLabel("update-owner"));
+    var member = registerUser(uniqueLabel("update-member"));
+    long ownerId = owner.path("id").asLong();
+    long memberId = member.path("id").asLong();
+    var lobby = createLobby(ownerId, "Original Lobby");
+    var invite = invite(ownerId, lobby.path("id").asLong(), memberId);
+    request(HttpMethod.POST, "/api/lobby-invites/" + invite.path("id").asLong() + "/accept",
+        null, memberId);
+
+    var response = request(HttpMethod.PATCH, "/api/lobbies/" + lobby.path("id").asLong(),
+        Map.of("name", "Changed by member"), memberId, "\"0\"");
+    var ownerRead = request(HttpMethod.GET, "/api/lobbies/" + lobby.path("id").asLong(), null,
+        ownerId);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(ownerRead.getBody().path("name").asText()).isEqualTo("Original Lobby");
+  }
+}

--- a/backend/lined/src/integrationTest/java/io/backend/lined/integration/support/DatabaseCleaner.java
+++ b/backend/lined/src/integrationTest/java/io/backend/lined/integration/support/DatabaseCleaner.java
@@ -1,0 +1,19 @@
+package io.backend.lined.integration.support;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseCleaner {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  public DatabaseCleaner(JdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  /** Clears mutable user-owned data while retaining reference rows seeded by schema.sql. */
+  public void clean() {
+    jdbcTemplate.execute("TRUNCATE TABLE users RESTART IDENTITY CASCADE");
+  }
+}

--- a/backend/lined/src/integrationTest/resources/application-integration-test.yml
+++ b/backend/lined/src/integrationTest/resources/application-integration-test.yml
@@ -1,0 +1,17 @@
+spring:
+  jpa:
+    defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: create-drop
+    open-in-view: false
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
+  sql:
+    init:
+      mode: always
+
+logging:
+  level:
+    org.testcontainers: INFO

--- a/backend/lined/src/main/java/io/backend/lined/lobby/api/LobbyController.java
+++ b/backend/lined/src/main/java/io/backend/lined/lobby/api/LobbyController.java
@@ -86,7 +86,15 @@ public class LobbyController {
   @Operation(summary = "Lobby details", description = "Get lobby by ID.")
   @GetMapping("/{id}")
   public ResponseEntity<LobbyDto> get(
-      @Parameter(description = "Lobby ID", example = "101") @PathVariable Long id) {
+      @Parameter(description = "Lobby ID", example = "101") @PathVariable Long id,
+      @Parameter(description = "Current user id (temporary for MVP)", example = "42")
+      @RequestHeader("X-User-Id") Long currentUserId) {
+    LobbyDto lobby = lobbyService.getById(id, currentUserId);
+    return ResponseEntity.ok().eTag(VersionPrecondition.etag(lobby.version())).body(lobby);
+  }
+
+  @Deprecated
+  public ResponseEntity<LobbyDto> get(Long id) {
     LobbyDto lobby = lobbyService.getById(id);
     return ResponseEntity.ok().eTag(VersionPrecondition.etag(lobby.version())).body(lobby);
   }

--- a/backend/lined/src/main/java/io/backend/lined/lobby/service/LobbyService.java
+++ b/backend/lined/src/main/java/io/backend/lined/lobby/service/LobbyService.java
@@ -11,6 +11,15 @@ public interface LobbyService {
 
   LobbyDto getById(Long id);
 
+  /**
+   * Reads a lobby only when the MVP caller is an owner or member.
+   *
+   * @param id lobby identifier
+   * @param requesterId caller identity from {@code X-User-Id}
+   * @return the accessible lobby
+   */
+  LobbyDto getById(Long id, Long requesterId);
+
   List<LobbyDto> myLobbies(Long userId);
 
   /**

--- a/backend/lined/src/main/java/io/backend/lined/lobby/service/LobbyServiceImpl.java
+++ b/backend/lined/src/main/java/io/backend/lined/lobby/service/LobbyServiceImpl.java
@@ -75,6 +75,13 @@ public class LobbyServiceImpl implements LobbyService {
   }
 
   @Override
+  public LobbyDto getById(Long id, Long requesterId) {
+    var lobby = mustLobby(id);
+    accessPolicy.ensureMember(lobby, requesterId);
+    return mapper.toDto(lobby);
+  }
+
+  @Override
   public List<LobbyDto> myLobbies(Long userId) {
     var list = lobbyRepo.findAllByMemberId(userId);
     return list.stream().map(mapper::toDto).toList();

--- a/backend/lined/src/test/java/io/backend/lined/lobby/service/LobbyServiceImplTest.java
+++ b/backend/lined/src/test/java/io/backend/lined/lobby/service/LobbyServiceImplTest.java
@@ -176,6 +176,26 @@ class LobbyServiceImplTest {
         .hasMessageContaining("999");
   }
 
+  @Test
+  void getById_returnsLobby_whenRequesterIsMember() {
+    lobbyEntity.getMembers().add(member);
+    when(lobbyRepo.findById(101L)).thenReturn(Optional.of(lobbyEntity));
+    when(mapper.toDto(lobbyEntity)).thenReturn(lobbyDto);
+
+    LobbyDto result = lobbyService.getById(101L, 2L);
+
+    assertThat(result).isEqualTo(lobbyDto);
+  }
+
+  @Test
+  void getById_throwsForbidden_whenRequesterIsNotMember() {
+    when(lobbyRepo.findById(101L)).thenReturn(Optional.of(lobbyEntity));
+
+    assertThatThrownBy(() -> lobbyService.getById(101L, 99L))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining("not a member");
+  }
+
   /* =======================
      MY LOBBIES
   ======================= */


### PR DESCRIPTION
## Purpose

Add a dedicated, live PostgreSQL HTTP API integration-test milestone. The suite starts the real
Spring Boot application on a random port and exercises request routing, validation, controllers,
services, persistence, transactions, and RFC 7807 errors through `TestRestTemplate`.

## Type

- [ ] 🧪 Experiment (fitness function research)
- [ ] ✨ Feature (new business logic)
- [x] 🐛 Bug fix
- [x] ♻️ Refactor / neutral change
- [ ] 📝 Documentation only

## Changes

- Adds the isolated `integrationTest` Gradle source set and CI task. `check` remains unit-test
  only, so Docker is never required for ordinary local checks.
- Adds a cached Spring-managed `postgres:16-alpine` Testcontainer, `integration-test` profile,
  random-port composed test annotation, deterministic cleanup, and reusable HTTP fixtures.
- Covers application startup; registration, duplicate email, login, invalid credentials, and
  missing MVP identity; lobby lifecycle/invitation/membership authorization; and shared-event
  visibility, rejection, interval validation, and offset-preserving timestamps.
- Preserves the current MVP identity boundary: login returns the existing token-shaped response,
  while caller-scoped API tests use `X-User-Id`. This PR deliberately does not add a Bearer filter.
- Corrects `GET /api/lobbies/{id}` to require the existing MVP caller header and enforce the
  established owner/member policy, with matching unit and integration coverage.

## Files changed

| File | Change |
|------|--------|
| `build.gradle` | Adds source set, dependencies, and single-worker `integrationTest` task. |
| `src/integrationTest/` | Adds Testcontainers configuration, profile, cleaner, helpers, and 14 HTTP scenarios. |
| `.github/workflows/ci.yml` | Runs API integration tests explicitly after static checks. |
| `LobbyController` / `LobbyService` | Enforces member access for lobby-detail reads. |
| `docs/testing.md`, `docs/api.md` | Documents the dedicated suite and corrected caller contract. |

## How to use and test

```bash
docker info
./gradlew test
./gradlew integrationTest
./gradlew checkstyleIntegrationTest
```

Live PostgreSQL evidence: the four `build/test-results/integrationTest/*.xml` reports contain
14 tests total, with zero failures, errors, and skips.

## Expected result

| Metric | Baseline (main) | Branch | Direction |
|--------|----------------|--------|-----------|
| checkstyle_violations | unknown | 2 pre-existing main-source violations | unchanged |
| spotbugs_total | unknown | 1 pre-existing `NotificationServiceImpl` finding | unchanged |
| line_coverage | not measured | not measured | unknown |
| critical_violations | not measured | not measured | unknown |
| code_smells | not measured | not measured | unknown |
| duplicated_lines_density | not measured | not measured | unknown |
| **F score** | not measured | not measured | unknown |
| **SonarQube QG** | unknown | unknown | unknown |

## Checklist

- [ ] `./gradlew check` passes locally (blocked by two pre-existing `ParameterNumber` violations in `EventCreateDto` and `EventDto`)
- [ ] `./gradlew jacocoTestReport` passes locally (not run)
- [x] `./gradlew test` passes locally
- [x] `./gradlew integrationTest` passes locally with live PostgreSQL
- [x] `./gradlew checkstyleIntegrationTest` passes locally
- [ ] `./gradlew spotbugsMain` passes locally (one pre-existing `DLS_DEAD_LOCAL_STORE` finding in `NotificationServiceImpl`)
- [x] No unintended changes to main business logic
- [x] Branch name matches the requested task
