### PR TITLE
Fix k6 API precondition handling

### DIFF
--- a/backend/lined/docs/load-test-baseline.md
+++ b/backend/lined/docs/load-test-baseline.md
@@ -216,7 +216,7 @@ useful.
 | `WORKLOAD` | `baseline` | `smoke`, `baseline`, `read-heavy`, `write-heavy`, `mixed`, `stress`, or `negative-smoke`. |
 | `RUN_ID` | current timestamp | Prefix used for synthetic users and seeded data. |
 | `USER_COUNT` | `4` | Synthetic users created during setup; minimum `2`. |
-| `SEED_TASK_COUNT` | `12` | Seeded tasks in the bounded task corpus; minimum `2`. |
+| `SEED_TASK_COUNT` | `12` | Minimum seeded tasks in the bounded corpus; the script expands it to at least the active mutation VU capacity so each mutating VU owns a task version. |
 | `SEED_EVENT_COUNT` | `8` | Seeded events in the bounded event corpus; minimum `2`. |
 | `VUS` | `5` | Virtual users for `baseline`, `read-heavy`, `write-heavy`, and `mixed`. |
 | `DURATION` | `2m` | Duration for `baseline`, `read-heavy`, `write-heavy`, and `mixed`. |
@@ -229,6 +229,12 @@ The script rejects malformed numeric values and unknown workload names so a
 mistyped smoke run does not silently become a longer baseline run. The
 `negative-smoke` profile marks expected validation/conflict/not-found responses
 as expected k6 responses so they do not count as `http_req_failed`.
+
+All caller-scoped reads use `X-User-Id`. Task updates and task/event/lobby
+deletes derive quoted `If-Match` values from the response version. Baseline,
+mixed, and stress workloads assign one seeded task per mutating VU and retain
+the returned version after each successful update, avoiding artificial
+optimistic-lock conflicts between VUs.
 
 ## Expected k6 Signals
 

--- a/backend/lined/load-tests/k6/load-test-baseline.js
+++ b/backend/lined/load-tests/k6/load-test-baseline.js
@@ -79,6 +79,7 @@ const ENDPOINTS = {
     lobbyId,
     status: STATUSES.inProgress,
   }),
+  tasksByLobby: (lobbyId) => queryPath('/api/tasks', { lobbyId }),
   user: (userId) => `/api/users/${userId}`,
   userConflict: (userId, requesterId) => queryPath('/api/calendar/user-conflict', {
     end: EVENT_WINDOW.to,
@@ -259,7 +260,7 @@ export const baselineWorkflow = (data) => {
   const user = data.users[exec.vu.idInTest % data.users.length];
   const assignee = data.users[(exec.vu.idInTest + 1) % data.users.length];
   const iterationLabel = `${data.runId}-${exec.vu.idInTest}-${exec.scenario.iterationInTest}`;
-  const task = data.tasks[exec.scenario.iterationInTest % data.tasks.length];
+  const task = taskForCurrentVu(data);
 
   group('users', () => {
     expectStatus(get(ENDPOINTS.user(user.id), 'users', 'get'), MESSAGES.getUser);
@@ -269,20 +270,19 @@ export const baselineWorkflow = (data) => {
     expectStatus(
         getForUser(ENDPOINTS.myLobbies, user.id, 'lobbies', 'mine'),
         MESSAGES.listLobbies);
-    expectStatus(get(ENDPOINTS.lobby(data.lobby.id), 'lobbies', 'get'), MESSAGES.getLobby);
+    expectStatus(
+        getForUser(ENDPOINTS.lobby(data.lobby.id), user.id, 'lobbies', 'get'),
+        MESSAGES.getLobby);
   });
 
   group('tasks', () => {
+    updateTask(task, user.id, `Updated ${iterationLabel}`);
     expectStatus(
-        patchJsonForUser(
-            ENDPOINTS.task(task.id),
-            { status: STATUSES.inProgress, title: `Updated ${iterationLabel}` },
+        getForUser(
+            ENDPOINTS.tasksByAssignee(data.lobby.id, assignee.id),
             user.id,
             'tasks',
-            'update'),
-        MESSAGES.updateTask);
-    expectStatus(
-        get(ENDPOINTS.tasksByAssignee(data.lobby.id, assignee.id), 'tasks', 'list'),
+            'list'),
         MESSAGES.listTasks);
   });
 
@@ -321,12 +321,18 @@ export const readHeavyWorkflow = (data) => {
     expectStatus(
         getForUser(ENDPOINTS.myLobbies, user.id, 'lobbies', 'mine'),
         MESSAGES.listLobbies);
-    expectStatus(get(ENDPOINTS.lobby(data.lobby.id), 'lobbies', 'get'), MESSAGES.getLobby);
+    expectStatus(
+        getForUser(ENDPOINTS.lobby(data.lobby.id), user.id, 'lobbies', 'get'),
+        MESSAGES.getLobby);
   });
 
   group('read-heavy tasks', () => {
     expectStatus(
-        get(ENDPOINTS.tasksByAssigneeAnyStatus(data.lobby.id, assignee.id), 'tasks', 'list'),
+        getForUser(
+            ENDPOINTS.tasksByAssigneeAnyStatus(data.lobby.id, assignee.id),
+            user.id,
+            'tasks',
+            'list'),
         MESSAGES.listTasks);
   });
 
@@ -362,14 +368,7 @@ export const writeHeavyWorkflow = (data) => {
     let task = null;
     try {
       task = createTask(user.id, data.lobby.id, assignee.id, `Write task ${iterationLabel}`);
-      expectStatus(
-          patchJsonForUser(
-              ENDPOINTS.task(task.id),
-              { status: STATUSES.inProgress, title: `Write updated ${iterationLabel}` },
-              user.id,
-              'tasks',
-              'update'),
-          MESSAGES.updateTask);
+      task = updateTask(task, user.id, `Write updated ${iterationLabel}`);
     } finally {
       deleteCreatedTask(task, user.id);
     }
@@ -390,7 +389,7 @@ export const writeHeavyWorkflow = (data) => {
 export const mixedWorkflow = (data) => {
   const user = data.users[exec.vu.idInTest % data.users.length];
   const assignee = data.users[(exec.vu.idInTest + 1) % data.users.length];
-  const task = data.tasks[exec.scenario.iterationInTest % data.tasks.length];
+  const task = taskForCurrentVu(data);
   const iterationLabel = `${data.runId}-${exec.vu.idInTest}-${exec.scenario.iterationInTest}`;
 
   group('mixed reads', () => {
@@ -404,14 +403,7 @@ export const mixedWorkflow = (data) => {
   });
 
   group('mixed updates', () => {
-    expectStatus(
-        patchJsonForUser(
-            ENDPOINTS.task(task.id),
-            { status: STATUSES.inProgress, title: `Mixed updated ${iterationLabel}` },
-            user.id,
-            'tasks',
-            'update'),
-        MESSAGES.updateTask);
+    updateTask(task, user.id, `Mixed updated ${iterationLabel}`);
   });
 
   group('mixed writes', () => {
@@ -421,7 +413,7 @@ export const mixedWorkflow = (data) => {
         assignee.id,
         `Mixed task ${iterationLabel}`);
     expectStatus(
-        delForUser(ENDPOINTS.task(createdTask.id), user.id, 'tasks', 'delete'),
+        delForUser(ENDPOINTS.task(createdTask.id), user.id, 'tasks', 'delete', createdTask.version),
         MESSAGES.deleteTask);
   });
 
@@ -468,17 +460,23 @@ export const teardown = (data) => {
 
   data.events.forEach((event) => {
     expectStatus(
-        delForUser(ENDPOINTS.event(event.id), data.users[0].id, 'calendar', 'delete-event'),
+        delForUser(
+            ENDPOINTS.event(event.id),
+            data.users[0].id,
+            'calendar',
+            'delete-event',
+            event.version),
         MESSAGES.deleteEvent);
   });
   data.tasks.forEach((task) => {
     expectStatus(
-        delForUser(ENDPOINTS.task(task.id), data.users[0].id, 'tasks', 'delete'),
+        deleteSeededTask(task.id, data.users[0].id, data.lobby.id),
         MESSAGES.deleteTask);
   });
-  expectStatus(
-      delForUser(ENDPOINTS.lobby(data.lobby.id), data.users[0].id, 'lobbies', 'delete'),
-      MESSAGES.deleteLobby);
+  const lobby = getResourceForUser(ENDPOINTS.lobby(data.lobby.id), data.users[0].id,
+      'lobbies', 'get');
+  expectStatus(delForUser(ENDPOINTS.lobby(lobby.id), data.users[0].id, 'lobbies', 'delete',
+      lobby.version), MESSAGES.deleteLobby);
   console.warn(
       `Seeded tasks, events, and lobby ${data.lobby.id} were deleted. `
       + `Synthetic users with username prefix `
@@ -534,7 +532,7 @@ const inviteAndAcceptMember = (lobbyId, ownerId, memberId) => {
   expectStatus(acceptRes, MESSAGES.acceptLobbyInvite);
 };
 
-const seedTasks = (ownerId, lobbyId, users) => range(SEED_TASK_COUNT).map((index) => {
+const seedTasks = (ownerId, lobbyId, users) => range(seedTaskCountForWorkload()).map((index) => {
   const assignee = users[(index + 1) % users.length];
   return createTask(ownerId, lobbyId, assignee.id, `Seed task ${RUN_ID}-${index}`);
 });
@@ -549,6 +547,38 @@ const createTask = (currentUserId, lobbyId, assigneeId, title) => {
   const res = postJsonForUser(ENDPOINTS.tasks, payload, currentUserId, 'tasks', 'create');
   expectStatus(res, MESSAGES.createTask);
   return responseJson(res, 'create task');
+};
+
+const updateTask = (task, userId, title) => {
+  const res = patchJsonForUser(
+      ENDPOINTS.task(task.id),
+      { status: STATUSES.inProgress, title },
+      userId,
+      'tasks',
+      'update',
+      task.version);
+  expectStatus(res, MESSAGES.updateTask);
+  const updated = responseJson(res, 'update task');
+  task.version = updated.version;
+  return updated;
+};
+
+const deleteSeededTask = (taskId, userId, lobbyId) => {
+  const response = getForUser(
+      ENDPOINTS.tasksByLobby(lobbyId), userId, 'tasks', 'list-for-delete');
+  expectStatus(response, MESSAGES.listTasks);
+  const task = responseJson(response, 'list tasks for delete')
+      .find((candidate) => candidate.id === taskId);
+  if (!task) {
+    exec.test.abort(`seeded task ${taskId} was not visible for teardown`);
+  }
+  return delForUser(ENDPOINTS.task(taskId), userId, 'tasks', 'delete', task.version);
+};
+
+const getResourceForUser = (path, userId, domain, endpoint) => {
+  const response = getForUser(path, userId, domain, endpoint);
+  expectStatus(response, `${endpoint} succeeds`);
+  return responseJson(response, endpoint);
 };
 
 const seedEvents = (ownerId, lobbyId) => range(SEED_EVENT_COUNT)
@@ -580,7 +610,7 @@ const deleteCreatedTask = (task, userId) => {
     return;
   }
   expectStatus(
-      delForUser(ENDPOINTS.task(task.id), userId, 'tasks', 'delete'),
+      delForUser(ENDPOINTS.task(task.id), userId, 'tasks', 'delete', task.version),
       MESSAGES.deleteTask);
 };
 
@@ -589,7 +619,7 @@ const deleteCreatedEvent = (event, userId) => {
     return;
   }
   expectStatus(
-      delForUser(ENDPOINTS.event(event.id), userId, 'calendar', 'delete-event'),
+      delForUser(ENDPOINTS.event(event.id), userId, 'calendar', 'delete-event', event.version),
       MESSAGES.deleteEvent);
 };
 
@@ -622,21 +652,18 @@ const postJsonForUser = (
     JSON.stringify(payload),
     requestParams(domain, endpoint, userId, expectedStatuses));
 
-const patchJsonForUser = (path, payload, userId, domain, endpoint) => http.patch(
+const patchJsonForUser = (path, payload, userId, domain, endpoint, version) => http.patch(
     url(path),
     JSON.stringify(payload),
-    requestParams(domain, endpoint, userId));
+    requestParams(domain, endpoint, userId, [200], version));
 
-const delForUser = (path, userId, domain, endpoint) => http.del(
+const delForUser = (path, userId, domain, endpoint, version) => http.del(
     url(path),
     null,
-    requestParams(domain, endpoint, userId));
+    requestParams(domain, endpoint, userId, [200], version));
 
-const requestParams = (domain, endpoint, userId = null, expectedStatuses = [200]) => ({
-  headers: userId === null ? JSON_HEADERS : {
-    ...JSON_HEADERS,
-    'X-User-Id': String(userId),
-  },
+const requestParams = (domain, endpoint, userId = null, expectedStatuses = [200], version) => ({
+  headers: requestHeaders(userId, version),
   responseCallback: http.expectedStatuses(...expectedStatuses),
   tags: {
     domain,
@@ -644,6 +671,19 @@ const requestParams = (domain, endpoint, userId = null, expectedStatuses = [200]
     workload: WORKLOAD,
   },
 });
+
+const requestHeaders = (userId, version) => ({
+  ...JSON_HEADERS,
+  ...(userId === null ? {} : { 'X-User-Id': String(userId) }),
+  ...(version === undefined ? {} : { 'If-Match': etagForVersion(version) }),
+});
+
+const etagForVersion = (version) => {
+  if (!Number.isInteger(version) || version < 0) {
+    exec.test.abort(`resource version must be a non-negative integer, got ${version}`);
+  }
+  return `"${version}"`;
+};
 
 const responseJson = (res, label) => {
   if (!res.body) {
@@ -671,5 +711,19 @@ const queryPath = (path, params) => {
 };
 
 const range = (count) => Array.from({ length: count }, (_, index) => index);
+
+const taskForCurrentVu = (data) => data.tasks[(exec.vu.idInTest - 1) % data.tasks.length];
+
+const seedTaskCountForWorkload = () => Math.max(SEED_TASK_COUNT, mutationVuCapacity());
+
+const mutationVuCapacity = () => {
+  if (WORKLOAD === WORKLOADS.stress) {
+    return STRESS_MAX_VUS;
+  }
+  if (WORKLOAD === WORKLOADS.baseline || WORKLOAD === WORKLOADS.mixed) {
+    return BASELINE_VUS;
+  }
+  return 0;
+};
 
 const url = (path) => `${BASE_URL}${path}`;


### PR DESCRIPTION
## Summary

Fixes the k6 baseline workload so it conforms to the backend's current MVP HTTP contract. This is a load-test-only change; it does not alter API authentication, authorization, or persistence semantics.

## Changes

- Sends `X-User-Id` on lobby-detail and task-list reads that require caller identity.
- Sends quoted `If-Match` ETags for every task, event, and lobby mutation/deletion.
- Carries each task's returned version forward after a successful PATCH.
- Reloads seeded task and lobby versions during teardown before deleting them.
- Allocates one seeded task to each mutating VU and expands the seed corpus to the mutation VU capacity, preventing artificial cross-VU optimistic-lock conflicts.
- Documents the identity, version, and ownership behavior for load-test operators.

## How to use and test

```bash
cd backend/lined
k6 inspect load-tests/k6/load-test-baseline.js
node --test load-tests/runtime-scenarios/*.test.mjs
./gradlew test

# With a local backend and PostgreSQL available:
k6 run -e WORKLOAD=smoke -e BASE_URL=http://localhost:18080 \
  load-tests/k6/load-test-baseline.js
```

Verification completed:

- `k6 inspect` passed.
- Runtime-scenario tests: 115 passed, 0 failed, 0 skipped.
- Backend unit tests: passed.
- An isolated Spring Boot + PostgreSQL 16 smoke run passed all 74 checks with 0 failed HTTP requests; observed p95 was 289.83 ms and p99 was 475.13 ms.
- `git diff --check` passed.

## Scope and limitations

The runner deliberately continues to use the MVP `X-User-Id` identity contract. It does not add or test Bearer-token enforcement. The live smoke result is an isolated local API/database proof, not a Kubernetes or CI performance benchmark.

## Quality impact

Fitness metrics: not measured; this change modifies a k6 script and documentation only.
