### PR TITLE
Document implemented Lined backend feature contexts

### DIFF
--- a/backend/lined/docs/CONTEXT.md
+++ b/backend/lined/docs/CONTEXT.md
@@ -8,6 +8,7 @@ documents for their domain.
 |---|---|---|
 | Foundation | Backend-wide architecture, API contract, and testing conventions. | `docs/foundation/` |
 | Governance | Contribution workflow and durable research-knowledge guidance. | `docs/governance/` |
+| Product feature context | Source-grounded guides to implemented backend product features. | `docs/product/features/` |
 | Product billing | Billing design, roadmap, historical checkout proposal, and implementation task specifications. | `docs/product/billing/` |
 | Product feature flags | Capability-management design and related backend tasks. | `docs/product/feature-flags/` |
 | Product privacy | Private events/tasks design and privacy task specifications. | `docs/product/privacy/` |

--- a/backend/lined/docs/README.md
+++ b/backend/lined/docs/README.md
@@ -17,6 +17,7 @@ to choose the domain, then open the document needed for the change.
 
 ## Product domains
 
+- [Implemented backend features](product/features/README.md): source-grounded feature context for the current API.
 - [Billing plan](product/billing/BILLING_TASKS.md) and [billing tasks](product/billing/tasks/)
 - [Feature flags](product/feature-flags/feature-flags.md) and [feature-flag tasks](product/feature-flags/tasks/)
 - [Private events and tasks](product/privacy/private-events-and-tasks-system-design.md) and [privacy tasks](product/privacy/tasks/)

--- a/backend/lined/docs/product/features/README.md
+++ b/backend/lined/docs/product/features/README.md
@@ -1,0 +1,19 @@
+# Implemented Backend Features
+
+These pages describe the cohesive product features currently implemented in
+`src/main/java/io/backend/lined`. They are contextual guides, not a second API
+contract: [the API reference](../../foundation/api.md) and the controllers are
+authoritative for routes and payloads.
+
+- [Authentication and recovery](authentication-and-recovery.md)
+- [Users and accounts](users-and-accounts.md)
+- [Lobbies](lobbies.md)
+- [Lobby invitations](lobby-invitations.md)
+- [Tasks](tasks.md)
+- [Calendar](calendar.md)
+- [Roles](roles.md)
+- [Billing and entitlements](billing-and-entitlements.md)
+- [Notifications and reminders](notifications-and-reminders.md)
+
+Shared `common`, `config`, idempotency, and research packages support these
+features; they are intentionally not presented as product features.

--- a/backend/lined/docs/product/features/authentication-and-recovery.md
+++ b/backend/lined/docs/product/features/authentication-and-recovery.md
@@ -1,0 +1,20 @@
+# Authentication and Recovery
+
+## Purpose and scope
+
+This feature verifies a registered user's password and supports signed-out password recovery. It issues a short-lived, Bearer-shaped login token, but it does **not** yet authenticate ordinary requests: caller-scoped routes still use the transitional `X-User-Id` header.
+
+## Architecture and participating classes
+
+- [`AuthController`](../../../src/main/java/io/backend/lined/auth/api/AuthController.java) is the HTTP boundary for login and the two recovery operations.
+- [`AuthServiceImpl`](../../../src/main/java/io/backend/lined/auth/service/AuthServiceImpl.java) resolves email or username, checks the encoded password, and builds the login response through `AuthTokenService`.
+- [`PasswordResetServiceImpl`](../../../src/main/java/io/backend/lined/auth/service/PasswordResetServiceImpl.java) creates 256-bit opaque tokens, persists only HMAC-SHA256 hashes in [`PasswordResetTokenEntity`](../../../src/main/java/io/backend/lined/auth/domain/PasswordResetTokenEntity.java), and conditionally claims one unexpired token before changing the password.
+- [`SecurityConfig`](../../../src/main/java/io/backend/lined/config/SecurityConfig.java) provides the password encoder; [`UserRepository`](../../../src/main/java/io/backend/lined/user/domain/UserRepository.java) supplies identifier lookup.
+
+## Interactions and data flow
+
+`POST /api/auth/login` maps request DTO → user lookup → password comparison → token-shaped response including user roles. A reset request always returns `202`; for a known account it writes a hash with a 30-minute expiry. Reset redemption atomically marks a token used, updates the encoded password, and invalidates sibling tokens, so concurrent reuse cannot produce two password changes.
+
+## API behavior and references
+
+See the authoritative [authentication API](../../foundation/api.md#authentication), [Spring Security password storage guidance](https://docs.spring.io/spring-security/reference/features/authentication/password-storage.html), and [OWASP Forgot Password Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html). The latter explains the deliberately uniform recovery response; the former explains the `PasswordEncoder` boundary.

--- a/backend/lined/docs/product/features/billing-and-entitlements.md
+++ b/backend/lined/docs/product/features/billing-and-entitlements.md
@@ -1,0 +1,20 @@
+# Billing and Entitlements
+
+## Purpose and scope
+
+Billing provides each user with a personal billing account, an effective plan, and the product limits derived from that plan. It exposes read-only current state at present; catalog, subscription lifecycle, and entitlement enforcement live behind the API rather than as checkout endpoints.
+
+## Architecture and participating classes
+
+- [`BillingController`](../../../src/main/java/io/backend/lined/billing/api/web/BillingController.java) returns the caller's account, effective plan, subscription projection, and limits at `/api/billing/me`.
+- [`BillingAccountService`](../../../src/main/java/io/backend/lined/billing/application/BillingAccountService.java) creates/loads personal accounts; [`EffectivePlanResolver`](../../../src/main/java/io/backend/lined/billing/application/EffectivePlanResolver.java) chooses the active plan.
+- Catalog and lifecycle state are modeled by `PlanCatalogEntity`, `PriceCatalogEntity`, [`SubscriptionEntity`](../../../src/main/java/io/backend/lined/billing/domain/subscription/SubscriptionEntity.java), and [`SubscriptionStateMachine`](../../../src/main/java/io/backend/lined/billing/domain/subscription/SubscriptionStateMachine.java).
+- [`EntitlementService`](../../../src/main/java/io/backend/lined/entitlement/application/EntitlementService.java) and [`LimitEvaluator`](../../../src/main/java/io/backend/lined/entitlement/application/LimitEvaluator.java) translate a plan into enforceable limits.
+
+## Interactions and data flow
+
+Registration provisions a personal billing account. `GET /me` derives the effective plan for the `X-User-Id` account and transforms its entitlements into API limits. Lobby creation, restore, member acceptance, and writable lifecycle call `LimitEvaluator`, so billing affects real coordination capacity without making controllers duplicate pricing rules.
+
+## API behavior and references
+
+The [billing API section](../../foundation/api.md#billing) documents the public response. The domain uses [JPA entity lifecycle](https://docs.spring.io/spring-data/jpa/reference/jpa/entity-persistence.html) for persisted account/catalog/subscription state; see [`BILLING_TASKS.md`](../billing/BILLING_TASKS.md) for repository-specific design and task history.

--- a/backend/lined/docs/product/features/calendar.md
+++ b/backend/lined/docs/product/features/calendar.md
@@ -1,0 +1,20 @@
+# Calendar
+
+## Purpose and scope
+
+The calendar feature manages private and shared lobby events, conflict/free-time queries, reminders, and iCalendar (ICS) interoperability. It owns calendar data and privacy rules; notification delivery is a separate supporting feature.
+
+## Architecture and participating classes
+
+- [`EventController`](../../../src/main/java/io/backend/lined/event/api/EventController.java) exposes event CRUD, conflict, and free-slot routes; [`CalendarIcsController`](../../../src/main/java/io/backend/lined/event/api/CalendarIcsController.java) owns feed-token, export, and import routes.
+- [`EventServiceImpl`](../../../src/main/java/io/backend/lined/event/service/EventServiceImpl.java) applies visibility, lobby access, idempotency, optimistic locking, and reminder update rules.
+- [`EventConflictAnalyzer`](../../../src/main/java/io/backend/lined/event/service/EventConflictAnalyzer.java), [`FreeSlotCalculator`](../../../src/main/java/io/backend/lined/event/service/FreeSlotCalculator.java), and [`EventAccessPolicy`](../../../src/main/java/io/backend/lined/event/service/EventAccessPolicy.java) isolate time-window and privacy decisions.
+- [`CalendarIcsServiceImpl`](../../../src/main/java/io/backend/lined/event/service/CalendarIcsServiceImpl.java), [`CalendarFeedTokenEntity`](../../../src/main/java/io/backend/lined/event/domain/CalendarFeedTokenEntity.java), and event persistence implement import/export.
+
+## Interactions and data flow
+
+An event write resolves requester and lobby, validates private/shared visibility, persists the event, and asks the notification/reminder subsystem to react. Conflict and free-slot queries inspect events without revealing private details to unauthorized members. ICS feed creation issues an opaque path token; token-based export needs no identity header and includes only owner-private plus member-visible shared events. Import accepts raw or multipart RFC 5545 data and upserts caller-owned private events by UID.
+
+## API behavior and references
+
+The [calendar API section](../../foundation/api.md#calendar) is authoritative. The interchange format is [RFC 5545 iCalendar](https://www.rfc-editor.org/rfc/rfc5545); mutable event routes use [RFC 9110 conditional requests](https://www.rfc-editor.org/rfc/rfc9110#section-13.1).

--- a/backend/lined/docs/product/features/lobbies.md
+++ b/backend/lined/docs/product/features/lobbies.md
@@ -1,0 +1,20 @@
+# Lobbies
+
+## Purpose and scope
+
+A lobby is the shared coordination space for a couple, family, friends, or work group. It owns members and is the parent context for tasks, events, invitations, and lobby-level notification preferences. The feature manages lifecycle, ownership, membership removal, writable state, and free-time discovery; invitation lifecycle is separate.
+
+## Architecture and participating classes
+
+- [`LobbyController`](../../../src/main/java/io/backend/lined/lobby/api/LobbyController.java) maps lobby HTTP operations to the service and attaches response ETags.
+- [`LobbyServiceImpl`](../../../src/main/java/io/backend/lined/lobby/service/LobbyServiceImpl.java) creates, lists, restores, updates, deletes, and selects a Free-plan lobby.
+- [`LobbyEntity`](../../../src/main/java/io/backend/lined/lobby/domain/LobbyEntity.java) and [`LobbyRepository`](../../../src/main/java/io/backend/lined/lobby/domain/LobbyRepository.java) model owner, members, lifecycle, and access mode.
+- [`LobbyAccessPolicy`](../../../src/main/java/io/backend/lined/lobby/service/LobbyAccessPolicy.java) enforces owner/member access; [`LobbyWritePolicy`](../../../src/main/java/io/backend/lined/lobby/service/LobbyWritePolicy.java) rejects writes to restricted lobbies.
+
+## Interactions and data flow
+
+Creation makes the owner the first member and checks entitlements through `LimitEvaluator`. Tasks and events require a lobby and reuse its access/write policies; event scheduling supplies free-slot calculation. Billing can make a lobby read-only or archive it, while the owner may select one compliant Free lobby or restore an archived one when capacity allows.
+
+## API behavior and references
+
+Routes and representation fields are defined in the [lobbies API section](../../foundation/api.md#lobbies). See [Spring transaction management](https://docs.spring.io/spring-framework/reference/data-access/transaction.html) for why lifecycle and membership changes occur transactionally, and [RFC 9110 conditional requests](https://www.rfc-editor.org/rfc/rfc9110#section-13.1) for required mutable-resource preconditions.

--- a/backend/lined/docs/product/features/lobby-invitations.md
+++ b/backend/lined/docs/product/features/lobby-invitations.md
@@ -1,0 +1,20 @@
+# Lobby Invitations
+
+## Purpose and scope
+
+Lobby invitations provide the controlled path for adding an existing user to a lobby. Owners create, list, resend, or cancel pending invitations; only the invitee can list, accept, or decline their own invitations.
+
+## Architecture and participating classes
+
+- [`LobbyInviteController`](../../../src/main/java/io/backend/lined/lobby/invite/api/LobbyInviteController.java) owns both nested-lobby and invitee-facing routes.
+- [`LobbyInviteServiceImpl`](../../../src/main/java/io/backend/lined/lobby/invite/service/LobbyInviteServiceImpl.java) implements the `PENDING` → `ACCEPTED`, `DECLINED`, or `CANCELLED` lifecycle.
+- [`LobbyInviteEntity`](../../../src/main/java/io/backend/lined/lobby/invite/domain/LobbyInviteEntity.java), [`LobbyInviteStatus`](../../../src/main/java/io/backend/lined/lobby/invite/domain/LobbyInviteStatus.java), and the repository persist and atomically transition invitations.
+- Lobby access/write policies and `LimitEvaluator` supply ownership, read-only, and membership-limit checks.
+
+## Interactions and data flow
+
+The owner selects exactly one invitee by ID or email. The service prevents inviting a member or duplicating a pending invitation. Acceptance conditionally claims the pending row, adds the invitee to the lobby's members, and treats an already accepted retry as idempotent; a concurrent non-winning transition is reported as a conflict.
+
+## API behavior and references
+
+See the [lobby invitations API section](../../foundation/api.md#lobby-invites). The persistence strategy uses [JPA locking and versioning concepts](https://docs.spring.io/spring-data/jpa/reference/jpa/locking.html) together with a conditional update to make lifecycle transitions safe under concurrent requests.

--- a/backend/lined/docs/product/features/notifications-and-reminders.md
+++ b/backend/lined/docs/product/features/notifications-and-reminders.md
@@ -1,0 +1,20 @@
+# Notifications and Reminders
+
+## Purpose and scope
+
+Notifications give each user an in-app inbox and global/per-lobby delivery preferences. Reminders turn due tasks and upcoming events into notification records. This feature models intended delivery and read state; it does not itself implement a production external email or push provider.
+
+## Architecture and participating classes
+
+- [`NotificationController`](../../../src/main/java/io/backend/lined/notification/api/NotificationController.java) exposes global preferences, the inbox, and mark-read; [`LobbyNotificationPreferenceController`](../../../src/main/java/io/backend/lined/notification/api/LobbyNotificationPreferenceController.java) handles lobby overrides.
+- [`NotificationServiceImpl`](../../../src/main/java/io/backend/lined/notification/service/NotificationServiceImpl.java) resolves preferences, creates records, and enforces recipient ownership.
+- [`ReminderScheduler`](../../../src/main/java/io/backend/lined/notification/service/ReminderScheduler.java) invokes [`ReminderServiceImpl`](../../../src/main/java/io/backend/lined/notification/service/ReminderServiceImpl.java) to claim/record due reminders.
+- `NotificationEntity`, `NotificationDeliveryEntity`, `UserNotificationPreferenceEntity`, and `LobbyNotificationPreferenceEntity` persist inbox, delivery, and preference state.
+
+## Interactions and data flow
+
+Task and event services ask the notification service to create assignee/member notifications when their request flags allow it. The scheduler queries due tasks/events and produces reminders according to configured offsets and user/lobby preference resolution. Reads and preference changes are caller-scoped; preference writes use ETag preconditions so clients do not silently overwrite a newer configuration.
+
+## API behavior and references
+
+See the [notifications API section](../../foundation/api.md#notifications), including scheduled-reminder behavior. [Spring scheduling](https://docs.spring.io/spring-framework/reference/integration/scheduling.html) explains the scheduler mechanism, while [RFC 9110 conditional requests](https://www.rfc-editor.org/rfc/rfc9110#section-13.1) explains preference-update ETags.

--- a/backend/lined/docs/product/features/roles.md
+++ b/backend/lined/docs/product/features/roles.md
@@ -1,0 +1,20 @@
+# Roles
+
+## Purpose and scope
+
+Roles are the reusable role catalog and user-role assignment capability. They project into `UserDto` and login responses, and are initialized during account registration. The current controller exposes role mutation routes without a separate request-authorization layer.
+
+## Architecture and participating classes
+
+- [`RoleController`](../../../src/main/java/io/backend/lined/role/api/RoleController.java) lists names, ensures role records, and replaces/adds/removes a user's role set.
+- [`RoleServiceImpl`](../../../src/main/java/io/backend/lined/role/service/RoleServiceImpl.java) validates and persists assignments.
+- [`RoleResolverImpl`](../../../src/main/java/io/backend/lined/role/service/RoleResolverImpl.java), [`RoleRepository`](../../../src/main/java/io/backend/lined/role/domain/RoleRepository.java), and [`RoleEntity`](../../../src/main/java/io/backend/lined/role/domain/RoleEntity.java) resolve catalog records.
+- [`AccountApplicationServiceImpl`](../../../src/main/java/io/backend/lined/app/AccountApplicationServiceImpl.java) applies the configured default role set during registration.
+
+## Interactions and data flow
+
+Role assignments are stored on the user relationship and returned by the user mapper. Registration invokes role assignment after user creation; login reads the mapped roles into its response. User search can query by role. Roles therefore define account metadata today, not an HTTP authorization decision point.
+
+## API behavior and references
+
+See the [roles API section](../../foundation/api.md#roles). [Spring Security authorization](https://docs.spring.io/spring-security/reference/servlet/authorization/index.html) provides the distinction between storing authorities and enforcing them; this backend currently implements the former at these routes.

--- a/backend/lined/docs/product/features/tasks.md
+++ b/backend/lined/docs/product/features/tasks.md
@@ -1,0 +1,20 @@
+# Tasks
+
+## Purpose and scope
+
+Tasks coordinate work inside a lobby: title, description, assignee, due date, priority, status, and visibility. A task can be shared with lobby members or private to its creator; the feature does not expose another user's private work.
+
+## Architecture and participating classes
+
+- [`TaskController`](../../../src/main/java/io/backend/lined/task/api/TaskController.java) implements create, partial update, visibility-filtered list, personal list, and delete operations.
+- [`TaskServiceImpl`](../../../src/main/java/io/backend/lined/task/service/TaskServiceImpl.java) applies privacy, assignment, authorization, idempotency, and version rules.
+- [`TaskEntity`](../../../src/main/java/io/backend/lined/task/domain/TaskEntity.java), repository, `TaskStatus`, `TaskPriority`, and `TaskVisibility` define persisted state and queries.
+- [`TaskAccessPolicy`](../../../src/main/java/io/backend/lined/task/service/TaskAccessPolicy.java), lobby write policy, and [`NotificationService`](../../../src/main/java/io/backend/lined/notification/service/NotificationService.java) provide cross-feature access, restriction, and optional assignee notification behavior.
+
+## Interactions and data flow
+
+Create and update resolve the requester and lobby, enforce private-task self-assignment, then persist and optionally notify the assignee. Listing passes requester identity into repository/service visibility filters. Writes require `If-Match`; create accepts an optional `Idempotency-Key` so an identical retry can replay the original result instead of creating another task.
+
+## API behavior and references
+
+The [tasks API section](../../foundation/api.md#tasks) is the route and DTO contract. See [RFC 9110 conditional requests](https://www.rfc-editor.org/rfc/rfc9110#section-13.1) and the repository's [`IdempotencyService`](../../../src/main/java/io/backend/lined/common/idempotency/IdempotencyService.java) for the two retry-safety mechanisms.

--- a/backend/lined/docs/product/features/users-and-accounts.md
+++ b/backend/lined/docs/product/features/users-and-accounts.md
@@ -1,0 +1,20 @@
+# Users and Accounts
+
+## Purpose and scope
+
+Users are the account and profile records behind every lobby, task, event, role assignment, preference, and billing account. The feature covers registration, profile lookup/update, search, and self-service deletion; authentication and role administration are documented separately.
+
+## Architecture and participating classes
+
+- [`UserController`](../../../src/main/java/io/backend/lined/user/api/UserController.java) exposes `/api/users` and returns versioned `UserDto` representations.
+- [`UserServiceImpl`](../../../src/main/java/io/backend/lined/user/service/UserServiceImpl.java), [`UserRepository`](../../../src/main/java/io/backend/lined/user/domain/UserRepository.java), and [`UserEntity`](../../../src/main/java/io/backend/lined/user/domain/UserEntity.java) implement profile persistence and search.
+- [`AccountApplicationServiceImpl`](../../../src/main/java/io/backend/lined/app/AccountApplicationServiceImpl.java) orchestrates registration: it creates the user, gives default roles, creates a personal billing account, then returns the enriched profile.
+- [`VersionPrecondition`](../../../src/main/java/io/backend/lined/common/VersionPrecondition.java) converts `If-Match` into optimistic-concurrency checks.
+
+## Interactions and data flow
+
+Registration flows controller → account application service → user service → role and billing services in one transaction. Updates and deletion require the ETag version; deletion also verifies that `X-User-Id` matches the path user and that the user owns no lobby. Search is read-only and can filter by role through the role relationship.
+
+## API behavior and references
+
+The [users API section](../../foundation/api.md#users) is authoritative for payloads and statuses. See [Spring Data JPA repositories](https://docs.spring.io/spring-data/jpa/reference/jpa.html) for the repository model and [HTTP conditional requests (RFC 9110)](https://www.rfc-editor.org/rfc/rfc9110#section-13.1) for the ETag/`If-Match` mechanism.


### PR DESCRIPTION
## Purpose

Add a contextual, source-grounded Markdown guide for every cohesive backend product feature currently implemented by the controller and service inventory.

## Type

- [ ] 🧪 Experiment (fitness function research)
- [ ] ✨ Feature (new business logic)
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor / neutral change
- [x] 📝 Documentation only

## Changes

- Add nine feature guides: authentication and recovery, users and accounts, lobbies, lobby invitations, tasks, calendar (including ICS), roles, billing and entitlements, and notifications and reminders.
- Document each feature's scope, architecture, class responsibilities, cross-feature interactions, API/data flow, and authoritative repository/external references.
- Add the implemented-feature index and route it through the backend documentation index and context map.
- Keep supporting infrastructure and research packages out of the product-feature inventory.

## Files changed

| File | Change |
|------|--------|
| `docs/product/features/README.md` | Feature inventory and navigation |
| `docs/product/features/*.md` | One contextual guide per implemented product feature |
| `docs/README.md` | Link to feature documentation |
| `docs/CONTEXT.md` | Canonical documentation location |

## Expected result

Runtime behavior and quality metrics are unchanged: this PR adds Markdown only.

| Metric | Baseline (main) | Branch | Direction |
|--------|----------------|--------|-----------|
| checkstyle_violations | not measured | unchanged | neutral |
| spotbugs_total | not measured | unchanged | neutral |
| line_coverage | not measured | unchanged | neutral |
| critical_violations | not measured | unchanged | neutral |
| code_smells | not measured | unchanged | neutral |
| duplicated_lines_density | not measured | unchanged | neutral |
| **F score** | not measured | unchanged | neutral |
| **SonarQube QG** | not measured | unchanged | neutral |

## How to use and test

```bash
git checkout codex/docs-backend-feature-context
git diff --check origin/main...HEAD
ruby -e 'Dir["docs/product/features/*.md"].each { |file| File.read(file).scan(/\]\((?!https?:)([^)#]+)/).flatten.each { |link| abort("missing #{file}: #{link}") unless File.exist?(File.expand_path(link, File.dirname(file))) } }'
```

Open `docs/product/features/README.md`, then follow its links to a feature guide and the linked controller/service/API reference. External reference URLs were checked with `curl --head`.

## Verification status

- Passed: `git diff --check origin/main...HEAD`
- Passed: all local feature-document links resolve
- Passed: all external feature-document links resolve with `curl --head`
- Not run: `./gradlew check` and `./gradlew jacocoTestReport` (documentation-only change; no application behavior or test code changed)

## Checklist

- [ ] ./gradlew check passes locally
- [ ] ./gradlew jacocoTestReport passes locally
- [x] No unintended changes to main business logic
- [x] Branch name is descriptive and documentation-scoped
